### PR TITLE
feat: add test action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,7 @@ jobs:
         run: |
           git -c "user.name=bot" -c "user.email=bot@example" commit -a -m "bot: format"
           git push origin HEAD
+      - name: test
+        run: yarn test
       - name: build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "videojs-youtube": "^2.6.1"
   },
   "scripts": {
+    "test": "yarn workspaces run test",
     "build": "yarn --cwd server build:prisma && next build && next export -o v1",
     "build:openapi": "openapi-generator-cli generate -i http://localhost:8080/api/v2/swagger/json -g typescript-fetch -o openapi",
     "format": "prettier --write .",


### PR DESCRIPTION
サーバー側には jest を導入済み。yarn --cwd server test でいくつかテストケースが実証される。
クライアント側には未導入。﻿
yarn test するとひとまず chibichilo-server の yarn test だけが実行される
本PRではGitHub Actionsのなかで継続的に yarn test を実行するようにしました。