### PR TITLE
create docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports: ["8081:8080"]
     environment:
       MOODLE_USERNAME: user
-      MOODLE_PASSWORD: passowrd
+      MOODLE_PASSWORD: password
       ALLOW_EMPTY_PASSWORD: "yes"
       MOODLE_DATABASE_USER: root
     depends_on: [mariadb]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+# NOTE: DON'T USE IT IN PRODUCTION. 本番環境で使用しないで。
+version: "3"
+services:
+  mariadb:
+    image: "mariadb:10"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: bitnami_moodle
+  moodle:
+    image: "bitnami/moodle:3"
+    ports: ["8081:8080"]
+    environment:
+      MOODLE_USERNAME: user
+      MOODLE_PASSWORD: passowrd
+      ALLOW_EMPTY_PASSWORD: "yes"
+      MOODLE_DATABASE_USER: root
+    depends_on: [mariadb]
+  db:
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports: ["5432:5432"]
+  app:
+    image: node:lts-alpine
+    environment:
+      NEXT_PUBLIC_API_BASE_PATH: "http://localhost:8080"
+      NEXT_PUBLIC_LMS_URL: "http://localhost:8081"
+      NEXT_PUBLIC_BASE_PATH: ""
+      PORT: "8080"
+      BASE_PATH: /api/v2
+      FRONTEND_ORIGIN: "http://localhost:3000"
+      FRONTEND_PATH: /
+      SESSION_SECRET: super_secret_characters_for_session
+      OAUTH_CONSUMER_KEY: test
+      OAUTH_CONSUMER_SECRET: test
+      DATABASE_URL: postgresql://postgres:password@db/postgres
+    command: "sh -c 'cd /app && yarn && yarn --cwd server build && yarn dev'"
+    volumes: ["./:/app"]
+    ports:
+      - "3000:3000"
+      - "5555:5555"
+      - "8080:8080"
+    depends_on: [moodle, db]

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "material-ui-popup-state": "^1.6.1",
     "material-ui-snackbar-provider": "^1.4.0",
     "next": "^9.5.3",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.1.1",
     "react": "^16.13.1",
     "react-beautiful-dnd": "^13.0.0",
@@ -51,6 +52,9 @@
   },
   "scripts": {
     "test": "yarn workspaces run test",
+    "dev": "run-p dev:*",
+    "dev:app": "next",
+    "dev:server": "yarn --cwd server dev",
     "build": "yarn --cwd server build:prisma && next build && next export -o v1",
     "build:openapi": "openapi-generator-cli generate -i http://localhost:8080/api/v2/swagger/json -g typescript-fetch -o openapi",
     "format": "prettier --write .",

--- a/server/main.ts
+++ b/server/main.ts
@@ -12,4 +12,4 @@ fastify({ logger: isDev })
     sessionSecret: SESSION_SECRET,
     sessionStore: sessionStore as Options["sessionStore"],
   })
-  .listen(PORT);
+  .listen(PORT, "::");


### PR DESCRIPTION
開発用にローカルからLMSを起動したりDB構築したりするのが不便だったのでdocker-composeにまとめてます。
```
docker-compose up
```
したあと、構築できたら http://localhost:8081 にアクセスして Moodle にログインしてLTI v1.1 ツールに http://localhost:8080/api/v2/lti/launch を指定、key: test, secret: test を指定して、コースを作る、外部ツールとして追加したツールを追加して、試せるハズ。
