### PR TITLE
fix: path.basename is not a function

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,20 +1,18 @@
-const path = require("path");
-const glob = require("glob");
+const { basename, resolve } = require("path");
+const { sync: glob } = require("glob");
 
 module.exports = {
   webpackFinal: async (config) => {
-    glob
-      .sync(`../*/`, { cwd: __dirname })
-      .map((path) => path.basename(path))
+    glob(`../*/`, { cwd: __dirname })
+      .map((path) => basename(path))
       .forEach((dir) => {
-        config.resolve.alias[dir] = path.resolve(__dirname, "..", dir);
-        config.resolve.alias[`$${dir}`] = path.resolve(__dirname, "..", dir);
+        config.resolve.alias[dir] = resolve(__dirname, "..", dir);
+        config.resolve.alias[`$${dir}`] = resolve(__dirname, "..", dir);
       });
-    glob
-      .sync(`../components/*/`, { cwd: __dirname })
-      .map((path) => path.basename(path))
+    glob(`../components/*/`, { cwd: __dirname })
+      .map((path) => basename(path))
       .forEach((dir) => {
-        config.resolve.alias[`$${dir}`] = path.resolve(
+        config.resolve.alias[`$${dir}`] = resolve(
           __dirname,
           "..",
           "components",


### PR DESCRIPTION
yarn storybookを実行した際に以下のエラーが出たので、それを解消するPRです

```
$ yarn storybook
yarn run v1.22.5
$ start-storybook
info @storybook/react v6.1.1
info 
info => Loading presets
info => Loading presets
info => Loading custom babel config as JS
info => Loading custom babel config
info => Loading custom babel config as JS
info => Loading custom babel config
info => Loading 1 config file in "./.storybook"
info => Adding stories defined in ".storybook/main.js"
info => Using cached manager
ERR! TypeError: path.basename is not a function
ERR!     at /var/home/kimiaki/Workspace/github.com/npocccties/ChibiCHiLO/.storybook/main.js:8:27
ERR!     at Array.map (<anonymous>)
```