### PR TITLE
ブックの作成/更新/削除/トピックの詳細の取得/更新/削除クライアントAPI

### DIFF
--- a/server/models/book/section.ts
+++ b/server/models/book/section.ts
@@ -3,7 +3,8 @@ import jsonSchema from "$server/prisma/json-schema.json";
 import { TopicSchema, topicSchema } from "$server/models/topic";
 
 export type SectionProps = {
-  name?: Section["name"];
+  // NOTE: Section<"name"> を使うと openapi-generator によって生成される型と整合せず
+  name?: string;
   topicIds: Array<Topic["id"]>;
 };
 

--- a/server/utils/book/destroyBook.ts
+++ b/server/utils/book/destroyBook.ts
@@ -5,7 +5,10 @@ import cleanupSections from "./cleanupSections";
 async function destroyBook(id: Book["id"]) {
   try {
     await cleanupSections(id);
-    await prisma.book.delete({ where: { id } });
+    await prisma.$transaction([
+      prisma.ltiResourceLink.deleteMany({ where: { bookId: id } }),
+      prisma.book.deleteMany({ where: { id } }),
+    ]);
   } catch {
     return;
   }

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -6,13 +6,13 @@ import { changeBookAtom } from "$store/book";
 
 const key = "/api/v2/book/{book_id}";
 
-async function fetchBook(_: typeof key, bookId: BookSchema["id"]) {
-  const res = await api.apiV2BookBookIdGet({ bookId });
+async function fetchBook(_: typeof key, id: BookSchema["id"]) {
+  const res = await api.apiV2BookBookIdGet({ bookId: id });
   return res as BookSchema;
 }
 
-export function useBook(bookId: BookSchema["id"]) {
-  const { data } = useSWR<BookSchema>([key, bookId], fetchBook);
+export function useBook(id: BookSchema["id"]) {
+  const { data } = useSWR<BookSchema>([key, id], fetchBook);
   const changeBook = useAtom(changeBookAtom)[1];
   if (data) changeBook(data);
   return data;

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -1,7 +1,7 @@
 import { useAtom } from "jotai";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import { api } from "./api";
-import { BookSchema } from "$server/models/book";
+import { BookProps, BookSchema } from "$server/models/book";
 import { changeBookAtom } from "$store/book";
 
 const key = "/api/v2/book/{book_id}";
@@ -16,4 +16,23 @@ export function useBook(id: BookSchema["id"]) {
   const changeBook = useAtom(changeBookAtom)[1];
   if (data) changeBook(data);
   return data;
+}
+
+export async function createBook(body: BookProps): Promise<BookSchema> {
+  const res = await api.apiV2BookPost({ body });
+  await mutate([key, res.id], res);
+  return res as BookSchema;
+}
+
+export async function updateBook({
+  id,
+  ...body
+}: BookProps & { id: BookSchema["id"] }): Promise<BookSchema> {
+  const res = await api.apiV2BookBookIdPut({ bookId: id, body });
+  await mutate([key, res.id], res);
+  return res as BookSchema;
+}
+
+export async function destroyBook(id: BookSchema["id"]) {
+  await api.apiV2BookBookIdDelete({ bookId: id });
 }

--- a/utils/ltiResourceLink.ts
+++ b/utils/ltiResourceLink.ts
@@ -33,5 +33,4 @@ export async function destroyLtiResourceLink(id: LtiResourceLinkSchema["id"]) {
   await api.apiV2LtiResourceLinkLtiResourceLinkIdDelete({
     ltiResourceLinkId: id,
   });
-  await mutate([key, id], undefined);
 }

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -4,12 +4,12 @@ import { TopicSchema } from "$server/models/topic";
 
 const key = "/api/v2/topic/{topic_id}";
 
-async function fetchTopic(_: typeof key, topicId: TopicSchema["id"]) {
-  const res = await api.apiV2TopicTopicIdGet({ topicId });
+async function fetchTopic(_: typeof key, id: TopicSchema["id"]) {
+  const res = await api.apiV2TopicTopicIdGet({ topicId: id });
   return res as TopicSchema;
 }
 
-export function useTopic(topicId: TopicSchema["id"]) {
-  const { data } = useSWR<TopicSchema>([key, topicId], fetchTopic);
+export function useTopic(id: TopicSchema["id"]) {
+  const { data } = useSWR<TopicSchema>([key, id], fetchTopic);
   return data;
 }

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -1,6 +1,6 @@
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import { api } from "./api";
-import { TopicSchema } from "$server/models/topic";
+import { TopicProps, TopicSchema } from "$server/models/topic";
 
 const key = "/api/v2/topic/{topic_id}";
 
@@ -12,4 +12,23 @@ async function fetchTopic(_: typeof key, id: TopicSchema["id"]) {
 export function useTopic(id: TopicSchema["id"]) {
   const { data } = useSWR<TopicSchema>([key, id], fetchTopic);
   return data;
+}
+
+export async function createTopic(body: TopicProps): Promise<TopicSchema> {
+  const res = await api.apiV2TopicPost({ body });
+  await mutate([key, res.id], res);
+  return res as TopicSchema;
+}
+
+export async function updateTopic({
+  id,
+  ...body
+}: TopicProps & { id: TopicSchema["id"] }): Promise<TopicSchema> {
+  const res = await api.apiV2TopicTopicIdPut({ topicId: id, body });
+  await mutate([key, res.id], res);
+  return res as TopicSchema;
+}
+
+export async function destroyTopic(id: TopicSchema["id"]) {
+  await api.apiV2TopicTopicIdDelete({ topicId: id });
 }

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+import { api } from "./api";
+import { TopicSchema } from "$server/models/topic";
+
+const key = "/api/v2/topic/{topic_id}";
+
+async function fetchTopic(_: typeof key, topicId: TopicSchema["id"]) {
+  const res = await api.apiV2TopicTopicIdGet({ topicId });
+  return res as TopicSchema;
+}
+
+export function useTopic(topicId: TopicSchema["id"]) {
+  const { data } = useSWR<TopicSchema>([key, topicId], fetchTopic);
+  return data;
+}


### PR DESCRIPTION
#96, #110 関連
クライアントのためのAPIの提供

- feat: useTopic hook
- feat: {create,update,destroy}Book
- feat: {create,update,destroy}Topic
- fix: 関連するltiResourceLinkが存在する時bookが削除されない問題を修正
