### PR TITLE
refactor: no use spread literal to topic book props

### DIFF
--- a/components/organisms/BookAccordion.stories.tsx
+++ b/components/organisms/BookAccordion.stories.tsx
@@ -3,7 +3,7 @@ export default { title: "organisms/BookAccordion" };
 import BookAccordion from "./BookAccordion";
 import { book } from "samples";
 
-const props = book;
+const props = { book };
 
 const handleTopicClick = console.log;
 

--- a/components/organisms/BookAccordion.tsx
+++ b/components/organisms/BookAccordion.tsx
@@ -36,20 +36,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type Props = Book & {
+type Props = {
+  book: Book;
   onTopicClick(topic: Topic): void;
 };
 
 export default function BookAccordion(props: Props) {
-  const {
-    name,
-    author,
-    createdAt,
-    updatedAt,
-    sections,
-    ltiResourceLinks,
-    onTopicClick,
-  } = props;
+  const { book, onTopicClick } = props;
   const classes = useStyles();
   const accordionClasses = useAccordionStyle();
   const accordionSummaryClasses = useAccordionSummaryStyle();
@@ -57,7 +50,7 @@ export default function BookAccordion(props: Props) {
   const handleItemClick = (
     _: never,
     [sectionIndex, topicIndex]: [number, number]
-  ) => onTopicClick(sections[sectionIndex].topics[topicIndex]);
+  ) => onTopicClick(book.sections[sectionIndex].topics[topicIndex]);
   const handleInfoClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
   };
@@ -74,7 +67,7 @@ export default function BookAccordion(props: Props) {
         IconButtonProps={{ edge: "start" }}
         expandIcon={<ExpandMoreIcon />}
       >
-        <Typography variant="h6">{name}</Typography>
+        <Typography variant="h6">{book.name}</Typography>
         <IconButton onClick={handleInfoClick}>
           <InfoOutlinedIcon />
         </IconButton>
@@ -84,7 +77,7 @@ export default function BookAccordion(props: Props) {
       </AccordionSummary>
       <AccordionDetails classes={accordionDetailClasses}>
         <div className={classes.chips}>
-          {ltiResourceLinks.map((ltiResourceLink) => (
+          {book.ltiResourceLinks.map((ltiResourceLink) => (
             <CourseChip
               key={ltiResourceLink.contextId}
               ltiResourceLink={ltiResourceLink}
@@ -93,13 +86,13 @@ export default function BookAccordion(props: Props) {
           ))}
         </div>
         <div className={classes.items}>
-          <Item itemKey="作成日" value={format(createdAt, "yyyy.MM.dd")} />
-          <Item itemKey="更新日" value={format(updatedAt, "yyyy.MM.dd")} />
-          <Item itemKey="著者" value={author.name} />
+          <Item itemKey="作成日" value={format(book.createdAt, "yyyy.MM.dd")} />
+          <Item itemKey="更新日" value={format(book.updatedAt, "yyyy.MM.dd")} />
+          <Item itemKey="著者" value={book.author.name} />
         </div>
         <Divider />
         <BookAccordionChildren
-          sections={sections}
+          sections={book.sections}
           onItemClick={handleItemClick}
         />
       </AccordionDetails>

--- a/components/organisms/BookPreview.stories.tsx
+++ b/components/organisms/BookPreview.stories.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const props = book;
+const props = { book };
 
 export const Default = () => {
   const classes = useStyles();

--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -52,21 +52,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type Props = Book;
+type Props = { book: Book };
 
 export default function BookPreview(props: Props) {
   const cardClasses = useCardStyle();
   const classes = useStyles();
-  const {
-    name,
-    author,
-    createdAt,
-    updatedAt,
-    sections,
-    ltiResourceLinks,
-  } = props;
+  const { book } = props;
   const [checkBox, setCheckBox] = useState(false);
-  const [topic] = useState<Topic>(sections[0].topics[0]);
+  const [topic] = useState<Topic>(book.sections[0].topics[0]);
   const handleCheckBoxClick = () => {
     setCheckBox(!checkBox);
   };
@@ -84,13 +77,13 @@ export default function BookPreview(props: Props) {
           >
             {checkBox ? <CheckBoxOutlinedIcon /> : <CheckBoxOutlineBlonkIcon />}
           </IconButton>
-          {name}
+          {book.name}
           <IconButton color="primary">
             <EditOutlinedIcon />
           </IconButton>
         </Typography>
         <div className={classes.chips}>
-          {ltiResourceLinks.map((ltiResourceLink) => (
+          {book.ltiResourceLinks.map((ltiResourceLink) => (
             <CourseChip
               key={ltiResourceLink.contextId}
               ltiResourceLink={ltiResourceLink}
@@ -98,11 +91,11 @@ export default function BookPreview(props: Props) {
           ))}
         </div>
         <div className={classes.items}>
-          <Item itemKey="作成日" value={format(createdAt, "yyyy.MM.dd")} />
-          <Item itemKey="更新日" value={format(updatedAt, "yyyy.MM.dd")} />
-          <Item itemKey="著者" value={author.name} />
+          <Item itemKey="作成日" value={format(book.createdAt, "yyyy.MM.dd")} />
+          <Item itemKey="更新日" value={format(book.updatedAt, "yyyy.MM.dd")} />
+          <Item itemKey="著者" value={book.author.name} />
         </div>
-        {sections.map((section, sectionIndex) => (
+        {book.sections.map((section, sectionIndex) => (
           <Fragment key={section.id}>
             {section.name && (
               <p>

--- a/components/organisms/TopicViewer.stories.tsx
+++ b/components/organisms/TopicViewer.stories.tsx
@@ -1,8 +1,8 @@
 export default { title: "organisms/TopicViewer" };
 
-import TopicPlayer from "./TopicViewer";
+import TopicViewer from "./TopicViewer";
 import { topic } from "samples";
 
-const props = topic;
+const props = { topic };
 
-export const Default = () => <TopicPlayer {...props} />;
+export const Default = () => <TopicViewer {...props} />;

--- a/components/organisms/TopicViewer.tsx
+++ b/components/organisms/TopicViewer.tsx
@@ -35,37 +35,31 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type Props = Topic & { onEnded?: () => void };
+type Props = {
+  topic: Topic;
+  onEnded?: () => void;
+};
 
 export default function TopicPlaer(props: Props) {
   const classes = useStyles();
   const cardClasses = useCardStyles();
-  const {
-    name,
-    resource,
-    timeRequired,
-    createdAt,
-    updatedAt,
-    creator,
-    description,
-    onEnded,
-  } = props;
+  const { topic, onEnded } = props;
   return (
     <Card classes={cardClasses}>
       <Video
         className={classes.video}
         providerUrl="https://www.youtube.com/" // TODO: resource が video ならば video.providerUrl を使いたい
-        url={resource.url}
+        url={topic.resource.url}
         subtitles={[]}
         onEnded={onEnded}
         autoplay
       />
       <Typography className={classes.title} variant="h5">
-        {name}
+        {topic.name}
       </Typography>
       <div className={classes.items}>
         <Typography className={classes.title} variant="h6">
-          学習時間 {formatInterval(0, timeRequired * 1000) || "10秒未満"}
+          学習時間 {formatInterval(0, topic.timeRequired * 1000) || "10秒未満"}
         </Typography>
         <Typography className={classes.title} variant="h6">
           日本語
@@ -75,11 +69,11 @@ export default function TopicPlaer(props: Props) {
         </Typography>
       </div>
       <div className={classes.items}>
-        <Item itemKey="作成日" value={format(createdAt, "yyyy.MM.dd")} />
-        <Item itemKey="更新日" value={format(updatedAt, "yyyy.MM.dd")} />
-        <Item itemKey="著者" value={creator.name} />
+        <Item itemKey="作成日" value={format(topic.createdAt, "yyyy.MM.dd")} />
+        <Item itemKey="更新日" value={format(topic.updatedAt, "yyyy.MM.dd")} />
+        <Item itemKey="著者" value={topic.creator.name} />
       </div>
-      <p className={classes.description}>{description}</p>
+      <p className={classes.description}>{topic.description}</p>
     </Card>
   );
 }

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -65,7 +65,7 @@ export default function Book(props: Props) {
           LTIリンクの再連携
         </Button>
       </Typography>
-      {topic && <TopicViewer {...topic} onEnded={onTopicEnded} />}
+      {topic && <TopicViewer topic={topic} onEnded={onTopicEnded} />}
       <BookChildren
         sections={book?.sections ?? []}
         onItemClick={handleItemClick}

--- a/components/templates/BookImport.tsx
+++ b/components/templates/BookImport.tsx
@@ -71,7 +71,7 @@ export default function BookImport(props: Props) {
       </div>
       <div className={classes.books}>
         {books.map((book) => (
-          <BookPreview key={book.id} {...book} />
+          <BookPreview key={book.id} book={book} />
         ))}
       </div>
     </Container>

--- a/components/templates/BookLink.tsx
+++ b/components/templates/BookLink.tsx
@@ -79,7 +79,7 @@ export default function BookLink(props: Props) {
       </div>
       <div className={classes.books}>
         {books.map((book) => (
-          <BookPreview key={book.id} {...book} />
+          <BookPreview key={book.id} book={book} />
         ))}
       </div>
     </Container>

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -69,7 +69,7 @@ export default function Books(props: Props) {
         {books.map((book) => (
           <BookAccordion
             key={book.id}
-            {...book}
+            book={book}
             onTopicClick={handleTopicClick(book)}
           />
         ))}


### PR DESCRIPTION
https://github.com/npocccties/ChibiCHiLO/pull/119/files#r546573061 で書いたように、topicとbookを
スプレッド構文でわたすのではなく、そのままtopic propとbook propでわたすように変更しました