### PR TITLE
トピック作成・編集画面実装

### DIFF
--- a/components/organisms/BookChildren.tsx
+++ b/components/organisms/BookChildren.tsx
@@ -8,56 +8,71 @@ import Collapse from "@material-ui/core/Collapse";
 import { ExpandLess, ExpandMore, EditOutlined } from "@material-ui/icons";
 import { SectionSchema } from "$server/models/book/section";
 
+type ItemIndex = [number, number];
+
 type Props = {
   className?: string;
   sections: SectionSchema[];
-  onItemClick(event: MouseEvent<HTMLElement>, index: [number, number]): void;
+  onItemClick(event: MouseEvent<HTMLElement>, index: ItemIndex): void;
+  onItemEditClick?(event: MouseEvent<HTMLElement>, index: ItemIndex): void;
 };
 
 export default function BookChildren(props: Props) {
-  const { className, sections, onItemClick } = props;
+  const { className, sections, onItemClick, onItemEditClick } = props;
   const [open, setOpen] = useState<boolean[]>(sections.map(() => true));
   const handleItemClick = (event: MouseEvent<HTMLElement>) => {
     const { section, topic } = event.currentTarget.dataset;
-    onItemClick(event, [section, topic].map(Number) as [number, number]);
+    onItemClick(event, [section, topic].map(Number) as ItemIndex);
   };
-  const handleSectionClick = (sectionIndex: number) => {
+  const handleSectionClick = (sectionItemIndex: number) => {
     setOpen((open) => {
       const newOpen = open.slice();
-      newOpen[sectionIndex] = !newOpen[sectionIndex];
+      newOpen[sectionItemIndex] = !newOpen[sectionItemIndex];
       return newOpen;
     });
   };
-  const handleEditClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleItemEditClick = (...index: ItemIndex) => (
+    event: MouseEvent<HTMLButtonElement>
+  ) => {
     event.stopPropagation();
+    onItemEditClick?.(event, index);
   };
   return (
     <List disablePadding className={className}>
-      {sections.map((section, sectionIndex) => (
+      {sections.map((section, sectionItemIndex) => (
         <Fragment key={section.id}>
           {(section.name && (
             <>
-              <ListItem button onClick={() => handleSectionClick(sectionIndex)}>
+              <ListItem
+                button
+                onClick={() => handleSectionClick(sectionItemIndex)}
+              >
                 <ListItemText>
-                  {sectionIndex + 1} {section.name}
+                  {sectionItemIndex + 1} {section.name}
                 </ListItemText>
-                {open[sectionIndex] ? <ExpandLess /> : <ExpandMore />}
+                {open[sectionItemIndex] ? <ExpandLess /> : <ExpandMore />}
               </ListItem>
-              <Collapse in={open[sectionIndex]}>
-                {section.topics.map((topic, topicIndex) => (
+              <Collapse in={open[sectionItemIndex]}>
+                {section.topics.map((topic, topicItemIndex) => (
                   <ListItem
                     key={topic.id}
                     button
-                    data-section={sectionIndex}
-                    data-topic={topicIndex}
+                    data-section={sectionItemIndex}
+                    data-topic={topicItemIndex}
                     onClick={handleItemClick}
                   >
                     <ListItemText>
-                      {sectionIndex + 1}
-                      {section.name && `.${topicIndex + 1}`} {topic.name}
+                      {sectionItemIndex + 1}
+                      {section.name && `.${topicItemIndex + 1}`} {topic.name}
                     </ListItemText>
                     <ListItemSecondaryAction>
-                      <IconButton color="primary" onClick={handleEditClick}>
+                      <IconButton
+                        color="primary"
+                        onClick={handleItemEditClick(
+                          sectionItemIndex,
+                          topicItemIndex
+                        )}
+                      >
                         <EditOutlined />
                       </IconButton>
                     </ListItemSecondaryAction>
@@ -67,20 +82,26 @@ export default function BookChildren(props: Props) {
             </>
           )) || (
             <>
-              {section.topics.map((topic, topicIndex) => (
+              {section.topics.map((topic, topicItemIndex) => (
                 <ListItem
                   key={topic.id}
                   button
-                  data-section={sectionIndex}
-                  data-topic={topicIndex}
+                  data-section={sectionItemIndex}
+                  data-topic={topicItemIndex}
                   onClick={handleItemClick}
                 >
                   <ListItemText>
-                    {sectionIndex + 1}
-                    {section.name && `.${topicIndex + 1}`} {topic.name}
+                    {sectionItemIndex + 1}
+                    {section.name && `.${topicItemIndex + 1}`} {topic.name}
                   </ListItemText>
                   <ListItemSecondaryAction>
-                    <IconButton color="primary" onClick={handleEditClick}>
+                    <IconButton
+                      color="primary"
+                      onClick={handleItemEditClick(
+                        sectionItemIndex,
+                        topicItemIndex
+                      )}
+                    >
                       <EditOutlined />
                     </IconButton>
                   </ListItemSecondaryAction>

--- a/components/organisms/SubtitleUploadDialog.tsx
+++ b/components/organisms/SubtitleUploadDialog.tsx
@@ -37,7 +37,9 @@ export default function SubtitleUploadDialog(props: Props) {
     language: Object.getOwnPropertyNames(languages)[0],
     content: "",
   };
-  const { handleSubmit, register, control } = useForm<VideoTrackProps>({
+  const { handleSubmit, register, control } = useForm<
+    VideoTrackProps & { contentFile?: FileList }
+  >({
     defaultValues,
   });
   return (
@@ -47,15 +49,16 @@ export default function SubtitleUploadDialog(props: Props) {
       PaperProps={{
         classes: cardClasses,
         component: "form",
-        onSubmit: handleSubmit((values) => {
-          onSubmit({ ...defaultValues, ...values });
+        onSubmit: handleSubmit(({ contentFile, ...values }) => {
+          const content = contentFile?.[0] ?? defaultValues.content;
+          onSubmit({ ...defaultValues, ...values, content });
         }),
       }}
     >
       <DialogTitle>字幕のアップロード</DialogTitle>
       <DialogContent className={classes.margin}>
         <TextField
-          name="content"
+          name="contentFile"
           label="字幕ファイル"
           type="file"
           inputRef={register}

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -82,132 +82,135 @@ export default function TopicForm(props: Props) {
     defaultValues,
   });
   return (
-    <Card
-      classes={cardClasses}
-      className={`${classes.margin} ${className}`}
-      component="form"
-      onSubmit={handleSubmit((values) => {
-        onSubmit({ ...defaultValues, ...values });
-      })}
-    >
-      <TextField
-        name="name"
-        inputRef={register}
-        label={
-          <>
-            タイトル
-            <Typography
-              className={classes.labelDescription}
-              variant="caption"
-              component="span"
-            >
-              学習者が学習範囲を簡潔に理解できるタイトルを設定できます
-            </Typography>
-          </>
-        }
-        defaultValue={topic?.name}
-        required
-        fullWidth
-      />
-      <div>
-        <InputLabel classes={inputLabelClasses} htmlFor="shared">
-          他の編集者に共有
-        </InputLabel>
-        <Checkbox
-          id="shared"
-          name="shared"
+    <>
+      <Card
+        classes={cardClasses}
+        className={`${classes.margin} ${className}`}
+        component="form"
+        onSubmit={handleSubmit((values) => {
+          onSubmit({ ...defaultValues, ...values });
+        })}
+      >
+        <TextField
+          name="name"
           inputRef={register}
-          defaultChecked={defaultValues.shared}
-          color="primary"
+          label={
+            <>
+              タイトル
+              <Typography
+                className={classes.labelDescription}
+                variant="caption"
+                component="span"
+              >
+                学習者が学習範囲を簡潔に理解できるタイトルを設定できます
+              </Typography>
+            </>
+          }
+          defaultValue={topic?.name}
+          required
+          fullWidth
         />
-      </div>
-      <TextField
-        name="resource.url"
-        label={
-          <>
-            動画のURL
-            <Typography
-              className={classes.labelDescription}
-              variant="caption"
-              component="span"
-            >
-              YouTube, Vimeo, Wowzaに対応しています
-            </Typography>
-          </>
-        }
-        type="url"
-        defaultValue={topic?.resource.url}
-        inputProps={{
-          ref: register({
-            setValueAs: (value) => parse(value)?.url ?? value,
-          }),
-        }}
-        required
-        fullWidth
-      />
-      {topic && "tracks" in topic.resource && <Video {...topic.resource} />}
-      <Controller
-        name="language"
-        control={control}
-        defaultValue={defaultValues.language}
-        render={(props) => (
-          <TextField label="教材の主要な言語" select inputProps={props}>
-            {Object.entries(languages).map(([value, label]) => (
-              <MenuItem key={value} value={value}>
-                {label}
-              </MenuItem>
-            ))}
-          </TextField>
-        )}
-      />
-      <TextField
-        name="timeRequired"
-        label="学習時間 (秒)"
-        type="number"
-        inputProps={{
-          ref: register({
-            setValueAs: (value) => (value === "" ? null : +value),
-            min: 0,
-          }),
-          min: 0,
-        }}
-      />
-      <div>
-        <InputLabel classes={inputLabelClasses}>字幕</InputLabel>
-        <div className={classes.subtitles}>
-          {topic &&
-            "tracks" in topic.resource &&
-            topic.resource.tracks.map((track) => (
-              <SubtitleChip
-                key={track.id}
-                videoTrack={track}
-                onDelete={onSubtitleDelete}
-              />
-            ))}
+        <div>
+          <InputLabel classes={inputLabelClasses} htmlFor="shared">
+            他の編集者に共有
+          </InputLabel>
+          <Checkbox
+            id="shared"
+            name="shared"
+            inputRef={register}
+            defaultChecked={defaultValues.shared}
+            color="primary"
+          />
         </div>
-        <Button
-          variant="outlined"
-          color="primary"
-          onClick={handleClickSubtitle}
-        >
-          字幕を追加
-        </Button>
-        <SubtitleUploadDialog
-          open={open}
-          onClose={handleClose}
-          onSubmit={handleSubmitSubtitle}
+        <TextField
+          name="resource.url"
+          label={
+            <>
+              動画のURL
+              <Typography
+                className={classes.labelDescription}
+                variant="caption"
+                component="span"
+              >
+                YouTube, Vimeo, Wowzaに対応しています
+              </Typography>
+            </>
+          }
+          type="url"
+          defaultValue={topic?.resource.url}
+          inputProps={{
+            ref: register({
+              setValueAs: (value) => parse(value)?.url ?? value,
+            }),
+          }}
+          required
+          fullWidth
         />
-      </div>
-      <TextField
-        label="解説"
-        fullWidth
-        multiline
-        name="description"
-        inputRef={register}
+        {topic && "tracks" in topic.resource && <Video {...topic.resource} />}
+        <Controller
+          name="language"
+          control={control}
+          defaultValue={defaultValues.language}
+          render={(props) => (
+            <TextField label="教材の主要な言語" select inputProps={props}>
+              {Object.entries(languages).map(([value, label]) => (
+                <MenuItem key={value} value={value}>
+                  {label}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+        <TextField
+          name="timeRequired"
+          label="学習時間 (秒)"
+          type="number"
+          inputProps={{
+            ref: register({
+              setValueAs: (value) => (value === "" ? null : +value),
+              min: 0,
+            }),
+            min: 0,
+          }}
+        />
+        <div>
+          <InputLabel classes={inputLabelClasses}>字幕</InputLabel>
+          <div className={classes.subtitles}>
+            {topic &&
+              "tracks" in topic.resource &&
+              topic.resource.tracks.map((track) => (
+                <SubtitleChip
+                  key={track.id}
+                  videoTrack={track}
+                  onDelete={onSubtitleDelete}
+                />
+              ))}
+          </div>
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={handleClickSubtitle}
+          >
+            字幕を追加
+          </Button>
+        </div>
+        <TextField
+          label="解説"
+          fullWidth
+          multiline
+          name="description"
+          inputRef={register}
+        />
+        <Button variant="contained" color="primary" type="submit">
+          {submitLabel}
+        </Button>
+      </Card>
+
+      <SubtitleUploadDialog
+        open={open}
+        onClose={handleClose}
+        onSubmit={handleSubmitSubtitle}
       />
-      <Button variant="contained" color="primary" type="submit">
-        {submitLabel}
-      </Button>
-    </Card>
+    </>
   );
 }

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -69,6 +69,7 @@ export default function TopicForm(props: Props) {
   };
   const handleSubmitSubtitle = (videoTrack: VideoTrackProps) => {
     onSubtitleSubmit(videoTrack);
+    setOpen(false);
   };
   const defaultValues = {
     name: topic?.name,

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -17,6 +17,7 @@ import gray from "theme/colors/gray";
 import { TopicProps, TopicSchema } from "$server/models/topic";
 import { VideoTrackProps, VideoTrackSchema } from "$server/models/videoTrack";
 import languages from "$utils/languages";
+import { parse } from "$utils/videoResource";
 
 const useStyles = makeStyles((theme) => ({
   margin: {
@@ -121,7 +122,7 @@ export default function TopicForm(props: Props) {
         />
       </div>
       <TextField
-        id="contentURL"
+        name="resource.url"
         label={
           <>
             動画のURL
@@ -134,7 +135,13 @@ export default function TopicForm(props: Props) {
             </Typography>
           </>
         }
+        type="url"
         defaultValue={topic?.resource.url}
+        inputProps={{
+          ref: register({
+            setValueAs: (value) => parse(value)?.url ?? value,
+          }),
+        }}
         required
         fullWidth
       />

--- a/components/templates/Book.stories.tsx
+++ b/components/templates/Book.stories.tsx
@@ -4,7 +4,11 @@ import { useNextItemIndexAtom } from "$store/book";
 import Book from "./Book";
 import { book } from "samples";
 
-const props = { book, onBookEditClick: console.log };
+const props = {
+  book,
+  onBookEditClick: console.log,
+  onTopicEditClick: console.log,
+};
 
 // TODO: Please use <Provider> の問題の回避。なぜか回避できる。
 function wrap(WrappedComponent: React.FC) {

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -11,7 +11,8 @@ import LinkIcon from "@material-ui/icons/Link";
 import BookChildren from "$organisms/BookChildren";
 import BookItemDialog from "$organisms/BookItemDialog";
 import TopicViewer from "$organisms/TopicViewer";
-import { BookSchema } from "$server/models/book";
+import type { BookSchema } from "$server/models/book";
+import type { TopicSchema } from "$server/models/topic";
 import useContainerStyles from "styles/container";
 
 const useStyles = makeStyles((theme) => ({
@@ -51,12 +52,15 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+type ItemIndex = [number, number];
+
 type Props = {
   book: BookSchema | null;
-  index: [number, number];
+  index: ItemIndex;
   onBookEditClick(book: BookSchema): void;
+  onTopicEditClick?(topic: TopicSchema): void;
   onTopicEnded(): void;
-  onItemClick(index: [number, number]): void;
+  onItemClick(index: ItemIndex): void;
 };
 
 export default function Book(props: Props) {
@@ -64,6 +68,7 @@ export default function Book(props: Props) {
     book,
     index: [sectionIndex, topicIndex],
     onBookEditClick,
+    onTopicEditClick,
     onTopicEnded,
     onItemClick,
   } = props;
@@ -80,9 +85,17 @@ export default function Book(props: Props) {
     setOpen(false);
   };
   const handleEditClick = () => book && onBookEditClick(book);
-  const handleItemClick = (_: never, index: [number, number]) => {
+  const handleItemClick = (_: never, index: ItemIndex) => {
     onItemClick(index);
   };
+  function handleItemEditClick(
+    _: never,
+    [sectionIndex, topicIndex]: ItemIndex
+  ) {
+    const topic = book?.sections[sectionIndex]?.topics[topicIndex];
+    if (topic) onTopicEditClick?.(topic);
+  }
+
   return (
     <Container
       classes={containerClasses}
@@ -118,6 +131,7 @@ export default function Book(props: Props) {
           className={classes.bookChildren}
           sections={book?.sections ?? []}
           onItemClick={handleItemClick}
+          onItemEditClick={handleItemEditClick}
         />
       </div>
       {book && <BookItemDialog open={open} onClose={handleClose} book={book} />}

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -5,10 +5,12 @@ import { book } from "samples";
 
 const handleSubmit = console.log;
 const handleDelete = console.log;
+const handleAddSection = console.log;
 const handleTopicNewClick = () => console.log("onTopicNewClick");
 const handlers = {
   onSubmit: handleSubmit,
   onDelete: handleDelete,
+  onAddSection: handleAddSection,
   onTopicNewClick: handleTopicNewClick,
 };
 

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -1,45 +1,15 @@
 export default { title: "templates/BookEdit" };
 
-import { useState } from "react";
 import BookEdit from "./BookEdit";
-import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
 import { book } from "samples";
-import { TopicSchema } from "$server/models/topic";
 
-const handleTopicClick = console.log;
 const handleSubmit = console.log;
 const handleDelete = console.log;
 
-export const Default = () => {
-  const [open, setOpen] = useState(false);
-  const [topic, setTopic] = useState<TopicSchema | null>(null);
-  const handleTopicClick = (topic: TopicSchema) => {
-    setTopic(topic);
-    setOpen(true);
-  };
-  const handleClose = () => {
-    setOpen(false);
-  };
-  return (
-    <>
-      <BookEdit
-        book={book}
-        onSubmit={handleSubmit}
-        onTopicClick={handleTopicClick}
-        onDelete={handleDelete}
-      />
-      {topic && (
-        <TopicPreviewDialog open={open} onClose={handleClose} topic={topic} />
-      )}
-    </>
-  );
-};
+export const Default = () => (
+  <BookEdit book={book} onSubmit={handleSubmit} onDelete={handleDelete} />
+);
 
 export const Empty = () => (
-  <BookEdit
-    book={null}
-    onSubmit={handleSubmit}
-    onTopicClick={handleTopicClick}
-    onDelete={handleDelete}
-  />
+  <BookEdit book={null} onSubmit={handleSubmit} onDelete={handleDelete} />
 );

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -5,11 +5,13 @@ import { book } from "samples";
 
 const handleSubmit = console.log;
 const handleDelete = console.log;
+const handleTopicNewClick = () => console.log("onTopicNewClick");
+const handlers = {
+  onSubmit: handleSubmit,
+  onDelete: handleDelete,
+  onTopicNewClick: handleTopicNewClick,
+};
 
-export const Default = () => (
-  <BookEdit book={book} onSubmit={handleSubmit} onDelete={handleDelete} />
-);
+export const Default = () => <BookEdit book={book} {...handlers} />;
 
-export const Empty = () => (
-  <BookEdit book={null} onSubmit={handleSubmit} onDelete={handleDelete} />
-);
+export const Empty = () => <BookEdit book={null} {...handlers} />;

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Typography from "@material-ui/core/Typography";
 import Container from "@material-ui/core/Container";
 import Button from "@material-ui/core/Button";
@@ -5,6 +6,7 @@ import { DeleteOutlined } from "@material-ui/icons";
 import { makeStyles } from "@material-ui/core/styles";
 import BookEditChildren from "$organisms/BookEditChildren";
 import BookForm from "$organisms/BookForm";
+import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
 import RequiredDot from "$atoms/RequiredDot";
 import useContainerStyles from "styles/container";
 import { BookProps, BookSchema } from "$server/models/book";
@@ -41,16 +43,17 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   book: BookSchema | null;
   onSubmit(book: BookProps): void;
-  onTopicClick(topic: TopicSchema): void;
   onDelete(book: BookSchema): void;
 };
 
 export default function BookEdit(props: Props) {
-  const { book, onSubmit, onTopicClick, onDelete } = props;
+  const { book, onSubmit, onDelete } = props;
   const classes = useStyles();
   const containerClasses = useContainerStyles();
   const confirm = useConfirm();
-  const handleTopicClick = (topic: TopicSchema) => onTopicClick(topic);
+  const [previewTopic, setPreviewTopic] = useState<TopicSchema | null>(null);
+  const handlePreviewTopicClose = () => setPreviewTopic(null);
+  const handleTopicClick = (topic: TopicSchema) => setPreviewTopic(topic);
   const handleDeleteButtonClick = async () => {
     if (!book) return;
     await confirm({
@@ -84,6 +87,13 @@ export default function BookEdit(props: Props) {
         <DeleteOutlined />
         ブックを削除
       </Button>
+      {previewTopic && (
+        <TopicPreviewDialog
+          open
+          onClose={handlePreviewTopicClose}
+          topic={previewTopic}
+        />
+      )}
     </Container>
   );
 }

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -10,6 +10,7 @@ import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
 import RequiredDot from "$atoms/RequiredDot";
 import useContainerStyles from "styles/container";
 import { BookProps, BookSchema } from "$server/models/book";
+import { SectionProps } from "$server/models/book/section";
 import { TopicSchema } from "$server/models/topic";
 import { useConfirm } from "material-ui-confirm";
 
@@ -44,11 +45,12 @@ type Props = {
   book: BookSchema | null;
   onSubmit(book: BookProps): void;
   onDelete(book: BookSchema): void;
+  onAddSection(props: SectionProps): void;
   onTopicNewClick(): void;
 };
 
 export default function BookEdit(props: Props) {
-  const { book, onSubmit, onDelete, onTopicNewClick } = props;
+  const { book, onSubmit, onDelete, onAddSection, onTopicNewClick } = props;
   const classes = useStyles();
   const containerClasses = useContainerStyles();
   const confirm = useConfirm();
@@ -63,6 +65,11 @@ export default function BookEdit(props: Props) {
       confirmationText: "OK",
     });
     onDelete(book);
+  };
+  const handleSectionNewClick = () => {
+    // TODO: window.prompt は非推奨な API なのでやめたい
+    const name = window.prompt("新しいセクション名を入力してください。");
+    if (name) onAddSection({ name, topics: [] });
   };
 
   return (
@@ -83,6 +90,7 @@ export default function BookEdit(props: Props) {
         sections={book?.sections ?? []}
         onTopicClick={handleTopicClick}
         onTopicNewClick={onTopicNewClick}
+        onSectionNewClick={handleSectionNewClick}
       />
       <BookForm className={classes.form} book={book} onSubmit={onSubmit} />
       <Button size="small" color="primary" onClick={handleDeleteButtonClick}>

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -44,10 +44,11 @@ type Props = {
   book: BookSchema | null;
   onSubmit(book: BookProps): void;
   onDelete(book: BookSchema): void;
+  onTopicNewClick(): void;
 };
 
 export default function BookEdit(props: Props) {
-  const { book, onSubmit, onDelete } = props;
+  const { book, onSubmit, onDelete, onTopicNewClick } = props;
   const classes = useStyles();
   const containerClasses = useContainerStyles();
   const confirm = useConfirm();
@@ -81,6 +82,7 @@ export default function BookEdit(props: Props) {
         className={classes.children}
         sections={book?.sections ?? []}
         onTopicClick={handleTopicClick}
+        onTopicNewClick={onTopicNewClick}
       />
       <BookForm className={classes.form} book={book} onSubmit={onSubmit} />
       <Button size="small" color="primary" onClick={handleDeleteButtonClick}>

--- a/components/templates/TopicEdit.stories.tsx
+++ b/components/templates/TopicEdit.stories.tsx
@@ -12,4 +12,4 @@ const props = {
 
 export const Default = () => <TopicEdit {...props} />;
 
-export const Empty = () => <TopicEdit {...{ ...props, topic: null }} />;
+export const Empty = () => <TopicEdit {...props} topic={null} />;

--- a/components/templates/TopicEdit.stories.tsx
+++ b/components/templates/TopicEdit.stories.tsx
@@ -6,6 +6,7 @@ import { topic } from "samples";
 const props = {
   topic,
   onSubmit: console.log,
+  onDelete: console.log,
   onSubtitleDelete: console.log,
   onSubtitleSubmit: console.log,
 };

--- a/components/templates/TopicEdit.tsx
+++ b/components/templates/TopicEdit.tsx
@@ -8,6 +8,7 @@ import RequiredDot from "$atoms/RequiredDot";
 import useContainerStyles from "styles/container";
 import { TopicProps, TopicSchema } from "$server/models/topic";
 import { VideoTrackProps, VideoTrackSchema } from "$server/models/videoTrack";
+import { useConfirm } from "material-ui-confirm";
 
 const useStyles = makeStyles((theme) => ({
   header: {
@@ -36,14 +37,31 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   topic: TopicSchema | null;
   onSubmit(topic: TopicProps): void;
+  onDelete(topic: TopicSchema): void;
   onSubtitleDelete(videoTrack: VideoTrackSchema): void;
   onSubtitleSubmit(videoTrack: VideoTrackProps): void;
 };
 
 export default function TopicEdit(props: Props) {
-  const { topic, onSubmit, onSubtitleDelete, onSubtitleSubmit } = props;
+  const {
+    topic,
+    onSubmit,
+    onDelete,
+    onSubtitleDelete,
+    onSubtitleSubmit,
+  } = props;
   const classes = useStyles();
   const containerClasses = useContainerStyles();
+  const confirm = useConfirm();
+  const handleDeleteButtonClick = async () => {
+    if (!topic) return;
+    await confirm({
+      title: `トピック「${topic.name}」を削除します。よろしいですか？`,
+      cancellationText: "キャンセル",
+      confirmationText: "OK",
+    });
+    onDelete(topic);
+  };
 
   return (
     <Container
@@ -65,7 +83,7 @@ export default function TopicEdit(props: Props) {
         onSubtitleDelete={onSubtitleDelete}
         onSubtitleSubmit={onSubtitleSubmit}
       />
-      <Button size="small" color="primary">
+      <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
         <DeleteOutlined />
         トピックを削除
       </Button>

--- a/components/templates/TopicNew.stories.tsx
+++ b/components/templates/TopicNew.stories.tsx
@@ -1,15 +1,11 @@
 export default { title: "templates/TopicNew" };
 
 import TopicNew from "./TopicNew";
-import { topic } from "samples";
 
 const props = {
-  topic,
   onSubmit: console.log,
   onSubtitleDelete: console.log,
   onSubtitleSubmit: console.log,
 };
 
 export const Default = () => <TopicNew {...props} />;
-
-export const Empty = () => <TopicNew {...{ ...props, topic: null }} />;

--- a/components/templates/TopicNew.tsx
+++ b/components/templates/TopicNew.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import TopicForm from "$organisms/TopicForm";
 import RequiredDot from "$atoms/RequiredDot";
 import useContainerStyles from "styles/container";
-import { TopicProps } from "$server/models/topic";
+import { TopicProps, TopicSchema } from "$server/models/topic";
 import { VideoTrackProps, VideoTrackSchema } from "$server/models/videoTrack";
 
 const useStyles = makeStyles((theme) => ({

--- a/components/templates/TopicNew.tsx
+++ b/components/templates/TopicNew.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import TopicForm from "$organisms/TopicForm";
 import RequiredDot from "$atoms/RequiredDot";
 import useContainerStyles from "styles/container";
-import { TopicProps, TopicSchema } from "$server/models/topic";
+import { TopicProps } from "$server/models/topic";
 import { VideoTrackProps, VideoTrackSchema } from "$server/models/videoTrack";
 
 const useStyles = makeStyles((theme) => ({

--- a/components/templates/TopicNew.tsx
+++ b/components/templates/TopicNew.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import TopicForm from "$organisms/TopicForm";
 import RequiredDot from "$atoms/RequiredDot";
 import useContainerStyles from "styles/container";
-import { TopicProps, TopicSchema } from "$server/models/topic";
+import { TopicProps } from "$server/models/topic";
 import { VideoTrackProps, VideoTrackSchema } from "$server/models/videoTrack";
 
 const useStyles = makeStyles((theme) => ({
@@ -29,14 +29,13 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type Props = {
-  topic: TopicSchema | null;
   onSubmit(topic: TopicProps): void;
   onSubtitleDelete(videoTrack: VideoTrackSchema): void;
   onSubtitleSubmit(videoTrack: VideoTrackProps): void;
 };
 
 export default function TopicNew(props: Props) {
-  const { topic, onSubmit, onSubtitleDelete, onSubtitleSubmit } = props;
+  const { onSubmit, onSubtitleDelete, onSubtitleSubmit } = props;
   const classes = useStyles();
   const containerClasses = useContainerStyles();
 
@@ -54,7 +53,7 @@ export default function TopicNew(props: Props) {
         </Typography>
       </Typography>
       <TopicForm
-        topic={topic}
+        topic={null}
         submitLabel="作成"
         onSubmit={onSubmit}
         onSubtitleDelete={onSubtitleDelete}

--- a/openapi/models/InlineResponse2001Sections.ts
+++ b/openapi/models/InlineResponse2001Sections.ts
@@ -34,6 +34,12 @@ export interface InlineResponse2001Sections {
     id?: number;
     /**
      * 
+     * @type {string}
+     * @memberof InlineResponse2001Sections
+     */
+    name?: string;
+    /**
+     * 
      * @type {Array<InlineResponse2001Topics>}
      * @memberof InlineResponse2001Sections
      */
@@ -51,6 +57,7 @@ export function InlineResponse2001SectionsFromJSONTyped(json: any, ignoreDiscrim
     return {
         
         'id': !exists(json, 'id') ? undefined : json['id'],
+        'name': !exists(json, 'name') ? undefined : json['name'],
         'topics': !exists(json, 'topics') ? undefined : ((json['topics'] as Array<any>).map(InlineResponse2001TopicsFromJSON)),
     };
 }
@@ -65,6 +72,7 @@ export function InlineResponse2001SectionsToJSON(value?: InlineResponse2001Secti
     return {
         
         'id': value.id,
+        'name': value.name,
         'topics': value.topics === undefined ? undefined : ((value.topics as Array<any>).map(InlineResponse2001TopicsToJSON)),
     };
 }

--- a/pages/book.tsx
+++ b/pages/book.tsx
@@ -7,11 +7,11 @@ import Unknown from "$templates/Unknown";
 import { useBook } from "$utils/book";
 
 export type Query = {
-  id?: string;
+  bookId?: string;
 };
 
-function Show(props: Pick<BookSchema, "id">) {
-  const book = useBook(props.id);
+function Show(props: { bookId: BookSchema["id"] }) {
+  const book = useBook(props.bookId);
   const [index, nextItemIndex] = useNextItemIndexAtom();
   const handleTopicEnded = () => nextItemIndex();
   const handleItemClick = nextItemIndex;
@@ -36,16 +36,16 @@ function Show(props: Pick<BookSchema, "id">) {
 function Router() {
   const router = useRouter();
   const query: Query = router.query;
-  const id = Number(query.id);
+  const bookId = Number(query.bookId);
 
-  if (!Number.isFinite(id))
+  if (!Number.isFinite(bookId))
     return (
       <Unknown header="ブックがありません">
         ブックが見つかりませんでした
       </Unknown>
     );
 
-  return <Show id={id} />;
+  return <Show bookId={bookId} />;
 }
 
 export default Router;

--- a/pages/book.tsx
+++ b/pages/book.tsx
@@ -10,7 +10,9 @@ export type Query = {
   bookId?: string;
 };
 
-function Show(props: { bookId: BookSchema["id"] }) {
+export type ShowProps = { bookId: BookSchema["id"] };
+
+function Show(props: ShowProps) {
   const book = useBook(props.bookId);
   const [index, nextItemIndex] = useNextItemIndexAtom();
   const handleTopicEnded = () => nextItemIndex();

--- a/pages/book.tsx
+++ b/pages/book.tsx
@@ -5,6 +5,7 @@ import Book from "$templates/Book";
 import Placeholder from "$templates/Placeholder";
 import Unknown from "$templates/Unknown";
 import { useBook } from "$utils/book";
+import { TopicSchema } from "$server/models/topic";
 
 export type Query = {
   bookId?: string;
@@ -21,6 +22,15 @@ function Show(props: ShowProps) {
   const handleBookEditClick = () => {
     router.push({ pathname: "/book/edit", query: props });
   };
+  const handleTopicEditClick = ({ id }: Pick<TopicSchema, "id">) => {
+    router.push({
+      pathname: "/book/topic/edit",
+      query: {
+        bookId: props.bookId,
+        topicId: id,
+      },
+    });
+  };
 
   if (!book) return <Placeholder />;
 
@@ -29,6 +39,7 @@ function Show(props: ShowProps) {
       book={book}
       index={index}
       onBookEditClick={handleBookEditClick}
+      onTopicEditClick={handleTopicEditClick}
       onTopicEnded={handleTopicEnded}
       onItemClick={handleItemClick}
     />

--- a/pages/book/edit.tsx
+++ b/pages/book/edit.tsx
@@ -6,22 +6,22 @@ import Unknown from "$templates/Unknown";
 import { destroyBook, updateBook, useBook } from "$utils/book";
 
 export type Query = {
-  id?: string;
+  bookId?: string;
   prev?: "/books";
 };
 
-export type EditProps = Pick<BookSchema, "id"> & Pick<Query, "prev">;
+export type EditProps = { bookId: BookSchema["id"] } & Pick<Query, "prev">;
 
-function Edit({ id, prev }: EditProps) {
-  const book = useBook(id);
+function Edit({ bookId, prev }: EditProps) {
+  const book = useBook(bookId);
   const router = useRouter();
   async function handleSubmit(props: BookProps) {
-    await updateBook({ id, ...props });
+    await updateBook({ id: bookId, ...props });
     switch (prev) {
       case "/books":
         return router.push(prev);
       default:
-        return router.push({ pathname: "/book", query: { id } });
+        return router.push({ pathname: "/book", query: { bookId } });
     }
   }
   async function handleDelete({ id }: Pick<BookSchema, "id">) {
@@ -34,7 +34,7 @@ function Edit({ id, prev }: EditProps) {
     onTopicNewClick: () =>
       router.push({
         pathname: "/book/topic/new",
-        query: { id, prev },
+        query: { bookId, prev },
       }),
   };
   if (!book) return <Placeholder />;
@@ -45,16 +45,16 @@ function Edit({ id, prev }: EditProps) {
 function Router() {
   const router = useRouter();
   const query: Query = router.query;
-  const id = Number(query.id);
+  const bookId = Number(query.bookId);
 
-  if (!Number.isFinite(id))
+  if (!Number.isFinite(bookId))
     return (
       <Unknown header="ブックがありません">
         ブックが見つかりませんでした
       </Unknown>
     );
 
-  return <Edit id={id} prev={query.prev} />;
+  return <Edit bookId={bookId} prev={query.prev} />;
 }
 
 export default Router;

--- a/pages/book/edit.tsx
+++ b/pages/book/edit.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
-import { BookProps, BookSchema } from "$server/models/book";
+import type { BookProps, BookSchema } from "$server/models/book";
+import type { SectionProps } from "$server/models/book/section";
 import BookEdit from "$templates/BookEdit";
 import Placeholder from "$templates/Placeholder";
 import Unknown from "$templates/Unknown";
@@ -28,9 +29,18 @@ function Edit({ bookId, prev }: EditProps) {
     await destroyBook(id);
     return router.push("/books");
   }
+  async function handleAddSection(section: SectionProps) {
+    if (!book) return;
+    await updateBook({
+      ...book,
+      ltiResourceLinks: undefined,
+      sections: [...book?.sections, section],
+    });
+  }
   const handlers = {
     onSubmit: handleSubmit,
     onDelete: handleDelete,
+    onAddSection: handleAddSection,
     onTopicNewClick: () =>
       router.push({
         pathname: "/book/topic/new",

--- a/pages/book/edit.tsx
+++ b/pages/book/edit.tsx
@@ -34,7 +34,7 @@ function Edit({ bookId, prev }: EditProps) {
     onTopicNewClick: () =>
       router.push({
         pathname: "/book/topic/new",
-        query: { bookId, prev },
+        query: { bookId, ...(prev && { prev }) },
       }),
   };
   if (!book) return <Placeholder />;

--- a/pages/book/edit.tsx
+++ b/pages/book/edit.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
 import { useRouter } from "next/router";
 import { BookProps, BookSchema } from "$server/models/book";
-import { TopicSchema } from "$server/models/topic";
-import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
 import BookEdit from "$templates/BookEdit";
 import Placeholder from "$templates/Placeholder";
 import Unknown from "$templates/Unknown";
@@ -16,8 +13,6 @@ export type Query = {
 function Edit({ id, prev }: Pick<BookSchema, "id"> & Pick<Query, "prev">) {
   const book = useBook(id);
   const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const [topic, setTopic] = useState<TopicSchema | null>(null);
   async function handleSubmit(props: BookProps) {
     await updateBook({ id, ...props });
     switch (prev) {
@@ -27,13 +22,6 @@ function Edit({ id, prev }: Pick<BookSchema, "id"> & Pick<Query, "prev">) {
         return router.push({ pathname: "/book", query: { id } });
     }
   }
-  function handleTopicClick(topic: TopicSchema) {
-    setTopic(topic);
-    setOpen(true);
-  }
-  const handleClose = () => {
-    setOpen(false);
-  };
   async function handleDelete({ id }: Pick<BookSchema, "id">) {
     await destroyBook(id);
     return router.push("/books");
@@ -42,17 +30,7 @@ function Edit({ id, prev }: Pick<BookSchema, "id"> & Pick<Query, "prev">) {
   if (!book) return <Placeholder />;
 
   return (
-    <>
-      <BookEdit
-        book={book}
-        onSubmit={handleSubmit}
-        onTopicClick={handleTopicClick}
-        onDelete={handleDelete}
-      />
-      {topic && (
-        <TopicPreviewDialog open={open} onClose={handleClose} topic={topic} />
-      )}
-    </>
+    <BookEdit book={book} onSubmit={handleSubmit} onDelete={handleDelete} />
   );
 }
 

--- a/pages/book/edit.tsx
+++ b/pages/book/edit.tsx
@@ -10,7 +10,9 @@ export type Query = {
   prev?: "/books";
 };
 
-function Edit({ id, prev }: Pick<BookSchema, "id"> & Pick<Query, "prev">) {
+export type EditProps = Pick<BookSchema, "id"> & Pick<Query, "prev">;
+
+function Edit({ id, prev }: EditProps) {
   const book = useBook(id);
   const router = useRouter();
   async function handleSubmit(props: BookProps) {
@@ -26,12 +28,18 @@ function Edit({ id, prev }: Pick<BookSchema, "id"> & Pick<Query, "prev">) {
     await destroyBook(id);
     return router.push("/books");
   }
-
+  const handlers = {
+    onSubmit: handleSubmit,
+    onDelete: handleDelete,
+    onTopicNewClick: () =>
+      router.push({
+        pathname: "/book/topic/new",
+        query: { id, prev },
+      }),
+  };
   if (!book) return <Placeholder />;
 
-  return (
-    <BookEdit book={book} onSubmit={handleSubmit} onDelete={handleDelete} />
-  );
+  return <BookEdit book={book} {...handlers} />;
 }
 
 function Router() {

--- a/pages/book/new.tsx
+++ b/pages/book/new.tsx
@@ -9,7 +9,7 @@ function New() {
     const { id } = await createBook(book);
     await router.replace({
       pathname: "/book/edit",
-      query: { id },
+      query: { bookId: id },
     });
   };
 

--- a/pages/book/topic/edit.tsx
+++ b/pages/book/topic/edit.tsx
@@ -1,0 +1,56 @@
+import { useRouter } from "next/router";
+import type { TopicProps, TopicSchema } from "$server/models/topic";
+import type {
+  Query as BookQuery,
+  ShowProps as BookShowProps,
+} from "../../book";
+import Placeholder from "$templates/Placeholder";
+import TopicEdit from "$templates/TopicEdit";
+import { updateTopic, useTopic } from "$utils/topic";
+
+type Query = BookQuery & {
+  topicId?: string;
+};
+
+type EditProps = BookShowProps & {
+  topicId: TopicSchema["id"];
+};
+
+function Edit({ topicId, bookId }: EditProps) {
+  const topic = useTopic(topicId);
+  const router = useRouter();
+  async function handleSubmit(props: TopicProps) {
+    await updateTopic({ id: topicId, ...props });
+    return router.push({ pathname: "/book", query: { bookId } });
+  }
+  function handleSubtitleSubmit() {
+    // TODO: 未実装
+  }
+  async function handleSubtitleDelete() {
+    // TODO: 未実装
+  }
+
+  if (!topic) return <Placeholder />;
+
+  return (
+    <TopicEdit
+      topic={topic}
+      onSubmit={handleSubmit}
+      onSubtitleSubmit={handleSubtitleSubmit}
+      onSubtitleDelete={handleSubtitleDelete}
+    />
+  );
+}
+
+function Router() {
+  const router = useRouter();
+  const query: Query = router.query;
+  const props = {
+    bookId: Number(query.bookId),
+    topicId: Number(query.topicId),
+  };
+
+  return <Edit {...props} />;
+}
+
+export default Router;

--- a/pages/book/topic/new.tsx
+++ b/pages/book/topic/new.tsx
@@ -10,8 +10,8 @@ import type {
   EditProps as BookEditProps,
 } from "../edit";
 
-function New(query: BookEditProps) {
-  const book = useBook(query.bookId);
+function New({ bookId, prev }: BookEditProps) {
+  const book = useBook(bookId);
   const router = useRouter();
   async function handleSubmit(props: TopicProps) {
     if (!book) return;
@@ -22,7 +22,10 @@ function New(query: BookEditProps) {
       ltiResourceLinks: undefined,
       sections: [...book.sections, { name: null, topics: [{ id }] }],
     });
-    return router.push({ pathname: "/book/edit", query });
+    return router.push({
+      pathname: "/book/edit",
+      query: { bookId, ...(prev && { prev }) },
+    });
   }
   function handleSubtitleSubmit() {
     // TODO: 未実装

--- a/pages/book/topic/new.tsx
+++ b/pages/book/topic/new.tsx
@@ -22,9 +22,14 @@ function New({ bookId, prev }: BookEditProps) {
       ltiResourceLinks: undefined,
       sections: [...book.sections, { name: null, topics: [{ id }] }],
     });
+    const bookEditQuery = { bookId, ...(prev && { prev }) };
+    await router.replace({
+      pathname: "/book/topic/edit",
+      query: { ...bookEditQuery, topicId: id },
+    });
     return router.push({
       pathname: "/book/edit",
-      query: { bookId, ...(prev && { prev }) },
+      query: bookEditQuery,
     });
   }
   function handleSubtitleSubmit() {

--- a/pages/book/topic/new.tsx
+++ b/pages/book/topic/new.tsx
@@ -11,7 +11,7 @@ import type {
 } from "../edit";
 
 function New(query: BookEditProps) {
-  const book = useBook(query.id);
+  const book = useBook(query.bookId);
   const router = useRouter();
   async function handleSubmit(props: TopicProps) {
     if (!book) return;
@@ -45,16 +45,16 @@ function New(query: BookEditProps) {
 function Router() {
   const router = useRouter();
   const query: BookEditQuery = router.query;
-  const id = Number(query.id);
+  const bookId = Number(query.bookId);
 
-  if (!Number.isFinite(id))
+  if (!Number.isFinite(bookId))
     return (
       <Unknown header="ブックがありません">
         ブックが見つかりませんでした
       </Unknown>
     );
 
-  return <New id={id} prev={query.prev} />;
+  return <New bookId={bookId} prev={query.prev} />;
 }
 
 export default Router;

--- a/pages/book/topic/new.tsx
+++ b/pages/book/topic/new.tsx
@@ -1,0 +1,60 @@
+import { useRouter } from "next/router";
+import type { TopicProps } from "$server/models/topic";
+import TopicNew from "$templates/TopicNew";
+import Placeholder from "$templates/Placeholder";
+import Unknown from "$templates/Unknown";
+import { updateBook, useBook } from "$utils/book";
+import { createTopic } from "$utils/topic";
+import type {
+  Query as BookEditQuery,
+  EditProps as BookEditProps,
+} from "../edit";
+
+function New(query: BookEditProps) {
+  const book = useBook(query.id);
+  const router = useRouter();
+  async function handleSubmit(props: TopicProps) {
+    if (!book) return;
+
+    const { id } = await createTopic(props);
+    await updateBook({
+      ...book,
+      ltiResourceLinks: undefined,
+      sections: [...book.sections, { name: null, topics: [{ id }] }],
+    });
+    return router.push({ pathname: "/book/edit", query });
+  }
+  function handleSubtitleSubmit() {
+    // TODO: 未実装
+  }
+  async function handleSubtitleDelete() {
+    // TODO: 未実装
+  }
+
+  if (!book) return <Placeholder />;
+
+  return (
+    <TopicNew
+      onSubmit={handleSubmit}
+      onSubtitleSubmit={handleSubtitleSubmit}
+      onSubtitleDelete={handleSubtitleDelete}
+    />
+  );
+}
+
+function Router() {
+  const router = useRouter();
+  const query: BookEditQuery = router.query;
+  const id = Number(query.id);
+
+  if (!Number.isFinite(id))
+    return (
+      <Unknown header="ブックがありません">
+        ブックが見つかりませんでした
+      </Unknown>
+    );
+
+  return <New id={id} prev={query.prev} />;
+}
+
+export default Router;

--- a/pages/books.tsx
+++ b/pages/books.tsx
@@ -22,7 +22,7 @@ function Index() {
     pathname: `/book${"" | "/edit"}`,
     query?: BookQuery | BookEditQuery
   ) => ({ id }: Pick<Book, "id">) => {
-    router.push({ pathname, query: { ...query, id } });
+    router.push({ pathname, query: { ...query, bookId: id } });
   };
   const handlers = {
     onBookClick: handleBookClick("/book"),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ function Replace(props: { href: string | UrlObject }) {
 function ReplaceToBook(props: { ltiResourceLink: LtiResourceLinkSchema }) {
   const url = {
     pathname: "/book",
-    query: { id: props.ltiResourceLink.bookId },
+    query: { bookId: props.ltiResourceLink.bookId },
   };
 
   return <Replace href={url} />;

--- a/server/models/book/section.ts
+++ b/server/models/book/section.ts
@@ -8,13 +8,12 @@ export type SectionProps = {
 };
 
 const { id: topicId } = jsonSchema.definitions.Topic.properties;
+const nameSchema = { type: "string", nullable: true };
+
 export const sectionPropsSchema = {
   type: "object",
   properties: {
-    name: {
-      type: "string",
-      nullable: true,
-    },
+    name: nameSchema,
     topics: {
       type: "array",
       items: { type: "object", properties: { id: topicId } },
@@ -26,12 +25,12 @@ export type SectionSchema = Pick<Section, "id" | "name"> & {
   topics: TopicSchema[];
 };
 
-const { id, name } = jsonSchema.definitions.Section.properties;
+const { id } = jsonSchema.definitions.Section.properties;
 export const sectionSchema = {
   type: "object",
   properties: {
     id,
-    name,
+    name: nameSchema,
     topics: {
       type: "array",
       items: topicSchema,

--- a/server/models/videoTrack.ts
+++ b/server/models/videoTrack.ts
@@ -3,8 +3,10 @@ import jsonSchema from "$server/prisma/json-schema.json";
 
 export type VideoTrackProps = Pick<
   Prisma.TrackCreateWithoutVideoInput,
-  "language" | "content"
->;
+  "language"
+> & {
+  content: Track["content"] | Blob;
+};
 
 export type VideoTrackSchema = Pick<Track, "id" | "kind" | "language"> & {
   url: string;

--- a/server/services/videoTrack/show.ts
+++ b/server/services/videoTrack/show.ts
@@ -4,7 +4,6 @@ import {
   videoTrackParamsSchema,
 } from "$server/validators/videoTrackParams";
 import findVideoTrack from "$server/utils/videoTrack/findVideoTrack";
-import { Session } from "$utils/session";
 
 export const showSchema: FastifySchema = {
   description: "字幕の取得",
@@ -13,22 +12,11 @@ export const showSchema: FastifySchema = {
   produces: ["text/vtt"],
   response: {
     200: {},
-    400: {},
     404: {},
   },
 };
 
-export async function show({
-  session,
-  params,
-}: {
-  session: Session;
-  params: VideoTrackParams;
-}) {
-  console.log(session);
-  console.log(params);
-  if (!session.user) return { status: 400 };
-
+export async function show({ params }: { params: VideoTrackParams }) {
   const videoTrack = await findVideoTrack(
     params.resource_id,
     params.video_track_id

--- a/server/utils/book/destroyBook.ts
+++ b/server/utils/book/destroyBook.ts
@@ -1,22 +1,33 @@
 import { Book } from "@prisma/client";
 import prisma from "$server/utils/prisma";
+import destroyTopic from "$server/utils/topic/destroyTopic";
 import cleanupSections from "./cleanupSections";
 
 async function destroyBook(id: Book["id"]) {
-  try {
-    const sectionIds = (
-      await prisma.section.findMany({
-        where: { bookId: id },
-        select: { id: true },
-      })
-    ).map(({ id }) => id);
+  const sectionIds = (
+    await prisma.section.findMany({
+      where: { bookId: id },
+      select: { id: true },
+    })
+  ).map(({ id }) => id);
 
+  const topicIds = (
+    await prisma.topicSection.findMany({
+      where: { sectionId: { in: sectionIds } },
+      select: { topicId: true },
+    })
+  ).map(({ topicId }) => topicId);
+
+  try {
     await prisma.$transaction([
       ...cleanupSections(sectionIds),
       prisma.ltiResourceLink.deleteMany({ where: { bookId: id } }),
       prisma.book.deleteMany({ where: { id } }),
     ]);
-  } catch {
+
+    await Promise.all(topicIds.map(destroyTopic));
+  } catch (error) {
+    console.error(error.stack);
     return;
   }
 }

--- a/server/utils/topic/destroyTopic.ts
+++ b/server/utils/topic/destroyTopic.ts
@@ -11,11 +11,11 @@ async function destroyTopic(id: Topic["id"]) {
   if (!topic) return;
 
   try {
-    await destroyResource(topic.resourceId);
     await prisma.$transaction([
       prisma.activity.deleteMany({ where: { topicId: id } }),
       prisma.topic.deleteMany({ where: { id } }),
     ]);
+    await destroyResource(topic.resourceId);
   } catch {
     return;
   }

--- a/server/utils/videoTrack/createVideoTrack.ts
+++ b/server/utils/videoTrack/createVideoTrack.ts
@@ -5,7 +5,7 @@ import prisma from "$server/utils/prisma";
 async function createVideoTrack(
   createRequestUrl: string,
   resourceId: Resource["id"],
-  videoTrack: VideoTrackProps
+  { content, ...props }: VideoTrackProps
 ): Promise<undefined | VideoTrackSchema> {
   const resource = await prisma.resource.findUnique({
     where: { id: resourceId },
@@ -15,9 +15,13 @@ async function createVideoTrack(
   if (!resource) return;
   if (resource.videoId == null) return;
 
+  const contentText =
+    typeof content === "string" ? content : await content.text();
+
   const created = await prisma.track.create({
     data: {
-      ...videoTrack,
+      ...props,
+      content: contentText,
       video: { connect: { id: resource.videoId } },
     },
     select: { id: true, kind: true, language: true },

--- a/store/book.ts
+++ b/store/book.ts
@@ -10,7 +10,7 @@ const itemIndexAtom = atom<ItemIndex>([0, 0]);
 const updateBookAtom = atom<BookSchema | undefined, BookSchema>(
   (get) => get(bookAtom),
   (get, set, book) => {
-    if (get(bookAtom) !== book) set(bookAtom, book);
+    set(bookAtom, book);
     if (get(itemIndexAtom).some((i) => i !== 0)) set(itemIndexAtom, [0, 0]);
   }
 );

--- a/store/topic.ts
+++ b/store/topic.ts
@@ -1,0 +1,19 @@
+import { atom, useAtom } from "jotai";
+import type { VideoTrackProps } from "$server/models/videoTrack";
+
+const additionalVideoTracksAtom = atom<VideoTrackProps[]>([]);
+
+const addVideoTrackAtom = atom<VideoTrackProps[], VideoTrackProps>(
+  (get) => get(additionalVideoTracksAtom),
+  (get, set, videoTrack) => {
+    set(additionalVideoTracksAtom, [
+      ...get(additionalVideoTracksAtom),
+      videoTrack,
+    ]);
+  }
+);
+
+export function useAddVideoTrackAtom() {
+  useAtom(additionalVideoTracksAtom);
+  return useAtom(addVideoTrackAtom);
+}

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -1,6 +1,6 @@
 import useSWR, { mutate } from "swr";
+import type { TopicProps, TopicSchema } from "$server/models/topic";
 import { api } from "./api";
-import { TopicProps, TopicSchema } from "$server/models/topic";
 
 const key = "/api/v2/topic/{topic_id}";
 
@@ -31,4 +31,8 @@ export async function updateTopic({
 
 export async function destroyTopic(id: TopicSchema["id"]) {
   await api.apiV2TopicTopicIdDelete({ topicId: id });
+}
+
+export function revalidateTopic(id: TopicSchema["id"]): Promise<TopicSchema> {
+  return mutate([key, id]);
 }

--- a/utils/videoResource.ts
+++ b/utils/videoResource.ts
@@ -1,0 +1,1 @@
+export { parse } from "$server/utils/videoResource";

--- a/utils/videoTrack.ts
+++ b/utils/videoTrack.ts
@@ -4,8 +4,7 @@ import { api } from "./api";
 
 export async function uploadVideoTrack(
   resourceId: Resource["id"],
-  props: Omit<VideoTrackProps, "content">,
-  content: Blob | string
+  { content, ...props }: VideoTrackProps
 ) {
   const contentText =
     typeof content === "string" ? content : await content.text();


### PR DESCRIPTION
close #99, close #98 

- feat: support resource.url in TopicForm
- refactor: TopicPreviewDialogをBookEditに隠蔽
- feat: トピック作成機能 - fix: SubtitleUploadDialog submitイベントに反応させないように再構成 - feat: onTopicNewClickの注入 - refactor: TopicNew: 作成時デフォルトは空 - feat: create pages/book/topic/new
- refactor: query.bookIdと明示
- feat: create pages/book/topic/edit.tsx
- feat: onItemEditClick/onTopicEditClick注入
- fix: トピック削除できない問題への対処 リソースの削除の可否によらずトピックを取り除けるようにした
- fix: ブック削除してもトピックが残り続ける問題への対処 参照無ければ消す
- feat: トピック削除機能
- fix: query.prev が空なら含めない
- feat: トピック作成後ブラウザバックすると作成したトピックの編集画面
- feat: セクション追加機能
- fix: セクション名が得られない問題の修正 - chore: yarn build:openapi
- refactor 冗長な条件分岐の削除
- refactor: VideoTrackProps["content"]はBlobも許容しておく 大きいサイズだとメモリリークの恐れがあるため将来的にはBlobにしたい
- fix: CORSで保護されているのでセッションにアクセスしない/console.logを取り除く
- feat: 字幕アップロード機能 (トピック編集/作成画面)
