### PR TITLE
マイブックとブック編集にトピック編集の動線を追加

### DIFF
--- a/components/molecules/BookChildrenTree.stories.tsx
+++ b/components/molecules/BookChildrenTree.stories.tsx
@@ -25,7 +25,11 @@ export const Editable = () => (
     defaultCollapseIcon={<ExpandMoreIcon />}
     defaultExpandIcon={<ChevronRightIcon />}
   >
-    <BookChildrenTree {...props} onItemEditClick={console.log} />
+    <BookChildrenTree
+      {...props}
+      onItemEditClick={console.log}
+      isTopicEditable={() => true}
+    />
   </TreeView>
 );
 

--- a/components/organisms/BookAccordion.stories.tsx
+++ b/components/organisms/BookAccordion.stories.tsx
@@ -5,12 +5,23 @@ import { book } from "samples";
 
 const props = { book, onEditClick: console.log, onTopicClick: console.log };
 
-export const Default = () => {
-  return (
-    <div>
-      {[...Array(10)].map((_value, index) => (
-        <BookAccordion key={index} {...props} />
-      ))}
-    </div>
-  );
-};
+export const Default = () => (
+  <div>
+    {[...Array(10)].map((_value, index) => (
+      <BookAccordion key={index} {...props} />
+    ))}
+  </div>
+);
+
+export const Editable = () => (
+  <div>
+    {[...Array(10)].map((_value, index) => (
+      <BookAccordion
+        key={index}
+        {...props}
+        onTopicEditClick={console.log}
+        isTopicEditable={() => true}
+      />
+    ))}
+  </div>
+);

--- a/components/organisms/BookAccordion.tsx
+++ b/components/organisms/BookAccordion.tsx
@@ -48,10 +48,18 @@ type Props = {
   book: BookSchema;
   onEditClick(book: BookSchema): void;
   onTopicClick(topic: TopicSchema): void;
+  onTopicEditClick?(topic: TopicSchema): void;
+  isTopicEditable?(topic: TopicSchema): boolean | undefined;
 };
 
 export default function BookAccordion(props: Props) {
-  const { book, onEditClick, onTopicClick } = props;
+  const {
+    book,
+    onEditClick,
+    onTopicClick,
+    onTopicEditClick,
+    isTopicEditable,
+  } = props;
   const classes = useStyles();
   const accordionClasses = useAccordionStyle();
   const accordionSummaryClasses = useAccordionSummaryStyle();
@@ -64,8 +72,10 @@ export default function BookAccordion(props: Props) {
   const handleClose = () => {
     setOpen(false);
   };
-  const handleItemClick = ([sectionIndex, topicIndex]: ItemIndex) =>
-    onTopicClick(book.sections[sectionIndex].topics[topicIndex]);
+  const handleItem = (handler?: (topic: TopicSchema) => void) => ([
+    sectionIndex,
+    topicIndex,
+  ]: ItemIndex) => handler?.(book.sections[sectionIndex].topics[topicIndex]);
   const handleEditClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onEditClick(book);
@@ -111,7 +121,9 @@ export default function BookAccordion(props: Props) {
         >
           <BookChildrenTree
             sections={book.sections}
-            onItemClick={handleItemClick}
+            onItemClick={handleItem(onTopicClick)}
+            onItemEditClick={handleItem(onTopicEditClick)}
+            isTopicEditable={isTopicEditable}
           />
         </TreeView>
       </AccordionDetails>

--- a/components/organisms/BookEditChildren.stories.tsx
+++ b/components/organisms/BookEditChildren.stories.tsx
@@ -4,7 +4,17 @@ import BookEditChildren from "./BookEditChildren";
 import { sections } from "samples";
 
 const handleTopicClick = console.log;
+const handleTopicEditClick = console.log;
 
 export const Default = () => (
   <BookEditChildren sections={sections} onTopicClick={handleTopicClick} />
+);
+
+export const Editable = () => (
+  <BookEditChildren
+    sections={sections}
+    onTopicClick={handleTopicClick}
+    onTopicEditClick={handleTopicEditClick}
+    isTopicEditable={() => true}
+  />
 );

--- a/components/organisms/BookEditChildren.tsx
+++ b/components/organisms/BookEditChildren.tsx
@@ -38,14 +38,24 @@ type Props = {
   onSectionNewClick?(): void;
   onSortableChange?(): void;
   onTopicClick(topic: TopicSchema): void;
+  onTopicEditClick?(topic: TopicSchema): void;
+  isTopicEditable?(topic: TopicSchema): boolean | undefined;
 };
 
 export default function BookEditChildren(props: Props) {
-  const { sections, className, onTopicClick } = props;
+  const {
+    sections,
+    className,
+    onTopicClick,
+    onTopicEditClick,
+    isTopicEditable,
+  } = props;
   const cardClasses = useCardStyles();
   const classes = useStyles();
-  const handleItemClick = ([sectionIndex, topicIndex]: ItemIndex) =>
-    onTopicClick(sections[sectionIndex].topics[topicIndex]);
+  const handleItem = (handler?: (topic: TopicSchema) => void) => ([
+    sectionIndex,
+    topicIndex,
+  ]: ItemIndex) => handler?.(sections[sectionIndex].topics[topicIndex]);
   return (
     <Card classes={cardClasses} className={className}>
       <div className={classes.items}>
@@ -81,7 +91,12 @@ export default function BookEditChildren(props: Props) {
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
       >
-        <BookChildrenTree sections={sections} onItemClick={handleItemClick} />
+        <BookChildrenTree
+          sections={sections}
+          onItemClick={handleItem(onTopicClick)}
+          onItemEditClick={handleItem(onTopicEditClick)}
+          isTopicEditable={isTopicEditable}
+        />
       </TreeView>
     </Card>
   );

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -9,13 +9,16 @@ const handleAddSection = console.log;
 const handleTopicImportClick = () => console.log("onTopicImportClick");
 const handleTopicNewClick = () => console.log("onTopicNewClick");
 const handleBookImportClick = () => console.log("onBookImportClick");
+const handleTopicEditClick = console.log;
 const handlers = {
   onSubmit: handleSubmit,
   onDelete: handleDelete,
   onAddSection: handleAddSection,
   onTopicImportClick: handleTopicImportClick,
   onTopicNewClick: handleTopicNewClick,
+  onTopicEditClick: handleTopicEditClick,
   onBookImportClick: handleBookImportClick,
+  isTopicEditable: () => true,
 };
 
 export const Default = () => <BookEdit book={book} {...handlers} />;

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -48,7 +48,9 @@ type Props = {
   onAddSection(props: SectionProps): void;
   onTopicImportClick(): void;
   onTopicNewClick(): void;
+  onTopicEditClick?(topic: TopicSchema): void;
   onBookImportClick(): void;
+  isTopicEditable?(topic: TopicSchema): boolean | undefined;
 };
 
 export default function BookEdit(props: Props) {
@@ -59,7 +61,9 @@ export default function BookEdit(props: Props) {
     onAddSection,
     onTopicImportClick,
     onTopicNewClick,
+    onTopicEditClick,
     onBookImportClick,
+    isTopicEditable,
   } = props;
   const classes = useStyles();
   const containerClasses = useContainerStyles();
@@ -102,10 +106,12 @@ export default function BookEdit(props: Props) {
         className={classes.children}
         sections={book?.sections ?? []}
         onTopicClick={handleTopicClick}
+        onTopicEditClick={onTopicEditClick}
         onTopicImportClick={onTopicImportClick}
         onTopicNewClick={onTopicNewClick}
         onBookImportClick={onBookImportClick}
         onSectionNewClick={handleSectionNewClick}
+        isTopicEditable={isTopicEditable}
       />
       <BookForm className={classes.form} book={book} onSubmit={onSubmit} />
       <Button size="small" color="primary" onClick={handleDeleteButtonClick}>

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -8,6 +8,7 @@ import BookAccordion from "$organisms/BookAccordion";
 import SortSelect from "$atoms/SortSelect";
 import SearchTextField from "$atoms/SearchTextField";
 import type { BookSchema } from "$server/models/book";
+import type { TopicSchema } from "$server/models/topic";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 import useContainerStyles from "styles/container";
 
@@ -43,7 +44,7 @@ type Props = {
   onBookNewClick(): void;
   onBookLinkClick(): void;
   onTopicEditClick?(topic: TopicSchema): void;
-  isTopicEditable?(): boolean | undefined;
+  isTopicEditable?(topic: TopicSchema): boolean | undefined;
 };
 
 export default function Books(props: Props) {

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -42,6 +42,8 @@ type Props = {
   onBookEditClick(book: BookSchema): void;
   onBookNewClick(): void;
   onBookLinkClick(): void;
+  onTopicEditClick?(topic: TopicSchema): void;
+  isTopicEditable?(): boolean | undefined;
 };
 
 export default function Books(props: Props) {
@@ -52,6 +54,8 @@ export default function Books(props: Props) {
     onBookEditClick,
     onBookNewClick,
     onBookLinkClick,
+    onTopicEditClick,
+    isTopicEditable,
   } = props;
   const handleBookEditClick = (book: BookSchema) => () => onBookEditClick(book);
   const handleTopicClick = (book: BookSchema) => () => onBookClick(book);
@@ -91,6 +95,8 @@ export default function Books(props: Props) {
             book={book}
             onEditClick={handleBookEditClick(book)}
             onTopicClick={handleTopicClick(book)}
+            onTopicEditClick={onTopicEditClick}
+            isTopicEditable={isTopicEditable}
           />
         ))}
       </div>

--- a/pages/book/edit/topic/edit.tsx
+++ b/pages/book/edit/topic/edit.tsx
@@ -1,0 +1,3 @@
+import Edit, { Query as EditQuery } from "$pages/topics/edit";
+export type Query = EditQuery;
+export default Edit;

--- a/pages/book/edit/topic/index.tsx
+++ b/pages/book/edit/topic/index.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import type { Query as BookEditQuery } from "$pages/book/edit";
+import Placeholder from "$templates/Placeholder";
+import { pagesPath } from "$utils/$path";
+
+function Router() {
+  const router = useRouter();
+  useEffect(() => {
+    const bookId = Number(router.query.bookId);
+    const { context }: Pick<BookEditQuery, "context"> = router.query;
+    const query = { bookId, ...(context && { context }) };
+    router.replace(pagesPath.book.edit.$url({ query }));
+  }, [router]);
+  return <Placeholder />;
+}
+
+export default Router;

--- a/pages/books/index.tsx
+++ b/pages/books/index.tsx
@@ -5,6 +5,7 @@ import { useSession } from "$utils/session";
 import { useUserBooks } from "$utils/userBooks";
 import Books from "$templates/Books";
 import { pagesPath } from "$utils/$path";
+import { TopicSchema } from "$server/models/topic";
 
 function UserBooks(
   props: Omit<Parameters<typeof Books>[0], "books"> & {
@@ -37,6 +38,17 @@ function Index() {
     },
     onBookLinkClick() {
       return router.push(pagesPath.link.$url());
+    },
+    onTopicEditClick({ id }: Pick<TopicSchema, "id">) {
+      return router.push(
+        pagesPath.books.topic.edit.$url({
+          query: { topicId: id },
+        })
+      );
+    },
+    isTopicEditable(topic: TopicSchema) {
+      // NOTE: 自身以外の作成したトピックに関しては編集不可
+      return session?.data?.user && topic.creator.id === session?.data?.user.id;
     },
   };
 

--- a/pages/books/topic/edit.tsx
+++ b/pages/books/topic/edit.tsx
@@ -1,0 +1,3 @@
+import Edit, { Query as EditQuery } from "$pages/topics/edit";
+export type Query = EditQuery;
+export default Edit;

--- a/pages/books/topic/index.tsx
+++ b/pages/books/topic/index.tsx
@@ -1,16 +1,12 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
-import type { Query as BookEditQuery } from "$pages/book/edit";
 import Placeholder from "$templates/Placeholder";
 import { pagesPath } from "$utils/$path";
 
 function Router() {
   const router = useRouter();
   useEffect(() => {
-    const bookId = Number(router.query.bookId);
-    const { context }: Pick<BookEditQuery, "context"> = router.query;
-    const query = { bookId, ...(context && { context }) };
-    router.replace(pagesPath.books.$url({ query }));
+    router.replace(pagesPath.books.$url());
   }, [router]);
   return <Placeholder />;
 }

--- a/pages/books/topic/index.tsx
+++ b/pages/books/topic/index.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import type { Query as BookEditQuery } from "$pages/book/edit";
+import Placeholder from "$templates/Placeholder";
+import { pagesPath } from "$utils/$path";
+
+function Router() {
+  const router = useRouter();
+  useEffect(() => {
+    const bookId = Number(router.query.bookId);
+    const { context }: Pick<BookEditQuery, "context"> = router.query;
+    const query = { bookId, ...(context && { context }) };
+    router.replace(pagesPath.books.$url({ query }));
+  }, [router]);
+  return <Placeholder />;
+}
+
+export default Router;


### PR DESCRIPTION
マイブックとブック編集からそれぞれトピック編集に遷移して、編集後に元の画面に遷移するようにしました

![image](https://user-images.githubusercontent.com/9744580/106112101-31958700-6190-11eb-8fdf-f141ace47705.png)

![image](https://user-images.githubusercontent.com/9744580/106112138-3b1eef00-6190-11eb-95e3-8b572c5969f4.png)
