### PR TITLE
ブック連携時のブックの複製をする際にブック内のトピックも複製

### DIFF
--- a/pages/book/import/index.tsx
+++ b/pages/book/import/index.tsx
@@ -8,25 +8,16 @@ import { useBooks } from "$utils/books";
 import type { BookSchema } from "$server/models/book";
 import type { SectionSchema } from "$server/models/book/section";
 import type { TopicSchema } from "$server/models/topic";
-import type { UserSchema } from "$server/models/user";
 import type { Query as BookEditQuery } from "../edit";
-import bookCreateBy from "$utils/bookCreateBy";
-import topicCreateBy from "$utils/topicCreateBy";
-import { createTopic } from "$utils/topic";
+import { connectOrCreateTopic } from "$utils/topic";
 import { pagesPath } from "$utils/$path";
 
 export type Query = BookEditQuery;
 
-const sharedOrCreatedBy = (author?: Pick<UserSchema, "id">) => (
-  book: BookSchema
-) => {
-  return book.shared || bookCreateBy(book, author);
-};
-
 function Import({ bookId, context }: Query) {
   const { data: session } = useSession();
   const book = useBook(bookId);
-  const books = useBooks();
+  const books = useBooks(session?.user);
   const router = useRouter();
   const bookEditQuery = { bookId, ...(context && { context }) };
   async function handleSubmit({
@@ -40,9 +31,8 @@ function Import({ bookId, context }: Query) {
 
     const connectOrCreateTopics = topics.map(async (topic) => {
       if (!session?.user) return Promise.reject();
-      if (topicCreateBy(topic, session.user)) return Promise.resolve(topic.id);
       // NOTE: 自身以外の作成したトピックに関しては影響を及ぼすのを避ける目的で複製
-      return createTopic(topic).then(({ id }) => id);
+      return connectOrCreateTopic(session.user, topic).then(({ id }) => id);
     });
     const ids = await Promise.all(connectOrCreateTopics);
     await updateBook({
@@ -83,12 +73,7 @@ function Import({ bookId, context }: Query) {
   if (!book) return <Placeholder />;
   if (!books) return <Placeholder />;
 
-  return (
-    <BookImport
-      books={books.filter(sharedOrCreatedBy(session?.user))}
-      {...handlers}
-    />
-  );
+  return <BookImport books={books} {...handlers} />;
 }
 
 function Router() {

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -3,8 +3,11 @@ import useSWR, { mutate } from "swr";
 import { useUpdateBookAtom } from "$store/book";
 import { api } from "./api";
 import type { BookProps, BookSchema } from "$server/models/book";
+import type { SectionSchema } from "$server/models/book/section";
 import type { UserSchema } from "$server/models/user";
 import bookCreateBy from "./bookCreateBy";
+import { createTopic } from "./topic";
+import topicCreateBy from "./topicCreateBy";
 
 const key = "/api/v2/book/{book_id}";
 
@@ -29,13 +32,35 @@ export async function createBook(body: BookProps): Promise<BookSchema> {
   return res as BookSchema;
 }
 
+const sectionInput = (creator: Pick<UserSchema, "id">) => async (
+  section: SectionSchema
+) => {
+  const topics = await Promise.all(
+    section.topics.map(async (topic) => {
+      if (topicCreateBy(topic, creator)) return topic;
+      return createTopic(topic);
+    })
+  );
+  return { ...section, topics };
+};
+
+async function connectOrCreateSections(
+  user: Pick<UserSchema, "id">,
+  sections: SectionSchema[]
+) {
+  return Promise.all(sections.map(sectionInput(user)));
+}
+
 export async function connectOrCreateBook(
   user: Pick<UserSchema, "id">,
   book: BookSchema
 ) {
   if (bookCreateBy(book, user)) return book;
   const { ltiResourceLinks: _, ...bookProps } = book;
-  return createBook(bookProps);
+  // NOTE: 自身以外の作成したトピックの含まれるセクションに関しては、
+  //       影響を及ぼすのを避ける目的でトピックを複製して更新
+  const sections = await connectOrCreateSections(user, bookProps.sections);
+  return createBook({ ...bookProps, sections });
 }
 
 export async function updateBook({

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -2,7 +2,9 @@ import { useEffect } from "react";
 import useSWR, { mutate } from "swr";
 import { useUpdateBookAtom } from "$store/book";
 import { api } from "./api";
-import { BookProps, BookSchema } from "$server/models/book";
+import type { BookProps, BookSchema } from "$server/models/book";
+import type { UserSchema } from "$server/models/user";
+import bookCreateBy from "./bookCreateBy";
 
 const key = "/api/v2/book/{book_id}";
 
@@ -25,6 +27,15 @@ export async function createBook(body: BookProps): Promise<BookSchema> {
   const res = await api.apiV2BookPost({ body });
   await mutate([key, res.id], res);
   return res as BookSchema;
+}
+
+export async function connectOrCreateBook(
+  user: Pick<UserSchema, "id">,
+  book: BookSchema
+) {
+  if (bookCreateBy(book, user)) return book;
+  const { ltiResourceLinks: _, ...bookProps } = book;
+  return createBook(bookProps);
 }
 
 export async function updateBook({

--- a/utils/books.ts
+++ b/utils/books.ts
@@ -1,7 +1,9 @@
 import useSWR from "swr";
 import type { BookSchema } from "$server/models/book";
+import type { UserSchema } from "$server/models/user";
 import { api } from "./api";
 import { revalidateBook } from "./book";
+import bookCreateBy from "./bookCreateBy";
 
 const key = "/api/v2/books";
 
@@ -12,7 +14,13 @@ async function fetchBooks(_: typeof key, page = 0): Promise<BookSchema[]> {
   return books;
 }
 
-export function useBooks() {
+const sharedOrCreatedBy = (author?: Pick<UserSchema, "id">) => (
+  book: BookSchema
+) => {
+  return book.shared || bookCreateBy(book, author);
+};
+
+export function useBooks(author: Pick<UserSchema, "id"> | undefined) {
   const { data } = useSWR<BookSchema[]>(key, fetchBooks);
-  return data;
+  return data?.filter(sharedOrCreatedBy(author));
 }

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -1,6 +1,8 @@
 import useSWR, { mutate } from "swr";
 import type { TopicProps, TopicSchema } from "$server/models/topic";
+import type { UserSchema } from "$server/models/user";
 import { api } from "./api";
+import topicCreateBy from "./topicCreateBy";
 
 const key = "/api/v2/topic/{topic_id}";
 
@@ -20,6 +22,14 @@ export async function createTopic(body: TopicProps): Promise<TopicSchema> {
   })) as TopicSchema;
   await revalidateTopic(res.id, res);
   return res;
+}
+
+export async function connectOrCreateTopic(
+  user: Pick<UserSchema, "id">,
+  topic: TopicSchema
+) {
+  if (topicCreateBy(topic, user)) return topic;
+  return createTopic(topic);
 }
 
 export async function updateTopic({

--- a/utils/topics.ts
+++ b/utils/topics.ts
@@ -1,7 +1,9 @@
 import useSWR from "swr";
 import type { TopicSchema } from "$server/models/topic";
+import type { UserSchema } from "$server/models/user";
 import { api } from "./api";
 import { revalidateTopic } from "./topic";
+import topicCreateBy from "./topicCreateBy";
 
 const key = "/api/v2/topics";
 
@@ -12,7 +14,11 @@ async function fetchTopics(_: typeof key, page = 0): Promise<TopicSchema[]> {
   return topics;
 }
 
-export function useTopics() {
+const sharedOrCreatedBy = (creator?: Pick<UserSchema, "id">) => (
+  topic: TopicSchema
+) => topic.shared || topicCreateBy(topic, creator);
+
+export function useTopics(creator: Pick<UserSchema, "id"> | undefined) {
   const { data } = useSWR<TopicSchema[]>(key, fetchTopics);
-  return data;
+  return data?.filter(sharedOrCreatedBy(creator));
 }


### PR DESCRIPTION
close #190

リンク時のデフォルトの振る舞いを自身以外の作成したトピックへの影響を及ぼすのを避けるためにトピックの参照→トピックの複製に修正しました。

- refactor: $utils/topic,bookへ整理 - sharedOrCreatedBy - connectOrCreateBook - connectOrCreateTopic
- fix: 自身以外の作成した共有されていないトピックは含めない
- fix: 自身以外の作成者のトピックの複製

なおリンク OR 複製 等の選択は本PRでは対応しません。