### PR TITLE
fix: ifame内で起動できない問題への対処

### DIFF
--- a/server/config/app.ts
+++ b/server/config/app.ts
@@ -50,7 +50,11 @@ async function app(fastify: FastifyInstance, options: Options) {
     fastify.register(session, {
       secret: sessionSecret,
       store: sessionStore,
-      cookie: { secure: "auto" },
+      cookie: {
+        secure: "auto",
+        // NOTE: SameSite=Lax では iframe に埋め込み時 Cookie が送信されないため。
+        sameSite: "none",
+      },
     }),
     fastify.register(auth),
     fastify.register(formbody),

--- a/server/config/app.ts
+++ b/server/config/app.ts
@@ -51,6 +51,8 @@ async function app(fastify: FastifyInstance, options: Options) {
       secret: sessionSecret,
       store: sessionStore,
       cookie: {
+        // NOTE: secure: true では HTTP をサポートできないため。
+        //       HTTPS のサポートのみであれば取り除いて。
         secure: "auto",
         // NOTE: SameSite=Lax では iframe に埋め込み時 Cookie が送信されないため。
         sameSite: "none",


### PR DESCRIPTION
Set-CookieのデフォルトがSameSite=Laxに変更され、SameSite=Lax では iframe に埋め込み時 Cookie が送信されないためSameSite=Noneを指定

確認したこと: SameSite=None が加わっていること。

$ diff -u <(curl -si https://chibi-ch-i-lo.ties-makimura.vercel.app/api/v2/session) <(curl -si https://chibi-ch-i-lo-git-fix-lanch-in-iframe.ties-makimura.vercel.app/api/v2/session)

```diff
--- /dev/fd/63	2021-02-05 19:41:30.622416392 +0900
+++ /dev/fd/62	2021-02-05 19:41:30.626416414 +0900
@@ -14,13 +14,13 @@
 content-length: 2
 x-frame-options: SAMEORIGIN
 x-content-type-options: nosniff
-set-cookie: sessionId=DAbZzypueLT8hcXTp27sgVOBxg_-g1ZL.xlZ8AmAQm17CZrr1%2FMXiK%2FPGgDt9nOztAnW2lssW1rY; Path=/; HttpOnly; Secure
+set-cookie: sessionId=xvZkZ_ozxZN09igowMH7tB1QFgmHpE6Q.X1TvKsyJuaxMZHnDLUGedoSz56y%2BB2c4gWJhLN8zwfg; Path=/; HttpOnly; Secure; SameSite=None
 access-control-allow-credentials: true
 referrer-policy: no-referrer
-date: Fri, 05 Feb 2021 10:41:31 GMT
+date: Fri, 05 Feb 2021 10:41:33 GMT
 x-vercel-cache: MISS
 age: 0
 server: Vercel
-x-vercel-id: hnd1::iad1::ddlwl-1612521691100-58fa47abefa2
+x-vercel-id: hnd1::iad1::8bj8f-1612521691074-97817d729ece
 
 {}
```