### PR TITLE
fix: ltiResourceLink更新後sessionに反映されない

### DIFF
--- a/server/services/ltiResourceLink.ts
+++ b/server/services/ltiResourceLink.ts
@@ -1,3 +1,4 @@
+import type { FastifyRequest } from "fastify";
 import { outdent } from "outdent";
 import Method from "$server/types/method";
 import {
@@ -57,11 +58,16 @@ export const method: Method = {
 
 export const preHandler = authInstructorHandler;
 
-export async function show({ params }: { params: LtiResourceLinkParams }) {
+export async function show({
+  params,
+  session,
+}: FastifyRequest<{ Params: LtiResourceLinkParams }>) {
   const link = await findLtiResourceLink({
     consumerId: params.lti_consumer_id,
     id: params.lti_resource_link_id,
   });
+
+  session.ltiResourceLink = link;
 
   return {
     status: link == null ? 404 : 200,
@@ -72,15 +78,18 @@ export async function show({ params }: { params: LtiResourceLinkParams }) {
 export async function update({
   body,
   params,
-}: {
-  body: Props;
-  params: LtiResourceLinkParams;
-}) {
+  session,
+}: FastifyRequest<{
+  Body: Props;
+  Params: LtiResourceLinkParams;
+}>) {
   const link = await upsertLtiResourceLink({
     ...body,
     consumerId: params.lti_consumer_id,
     id: params.lti_resource_link_id,
   });
+
+  session.ltiResourceLink = link;
 
   return {
     status: link == null ? 400 : 201,
@@ -88,11 +97,16 @@ export async function update({
   };
 }
 
-export async function destroy({ params }: { params: LtiResourceLinkParams }) {
+export async function destroy({
+  params,
+  session,
+}: FastifyRequest<{ Params: LtiResourceLinkParams }>) {
   await destroyLtiResourceLink({
     consumerId: params.lti_consumer_id,
     id: params.lti_resource_link_id,
   });
+
+  session.ltiResourceLink = null;
 
   return {
     status: 204,

--- a/utils/ltiResourceLink.ts
+++ b/utils/ltiResourceLink.ts
@@ -1,6 +1,7 @@
 import useSWR, { mutate } from "swr";
 import { api } from "./api";
 import { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
+import { revalidateSession } from "./session";
 
 const key =
   "/api/v2/lti/{lti_consumer_id}/resource_link/{lti_resource_link_id}";
@@ -14,6 +15,7 @@ async function fetchLtiResourceLink(
     ltiConsumerId: consumerId,
     ltiResourceLinkId: id,
   });
+  await revalidateSession();
   return res as LtiResourceLinkSchema;
 }
 
@@ -37,7 +39,8 @@ export async function updateLtiResourceLink({
     ltiResourceLinkId: id,
     body,
   });
-  await mutate([key, id], res);
+  await mutate([key, consumerId, id], res);
+  await revalidateSession();
 }
 
 export async function destroyLtiResourceLink({
@@ -48,4 +51,5 @@ export async function destroyLtiResourceLink({
     ltiConsumerId: consumerId,
     ltiResourceLinkId: id,
   });
+  await revalidateSession();
 }

--- a/utils/session.ts
+++ b/utils/session.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import type { TopicSchema } from "$server/models/topic";
 import type { BookSchema } from "$server/models/book";
 import { Session, isAdministrator, isInstructor } from "$server/utils/session";
@@ -10,8 +10,10 @@ import bookCreateBy from "./bookCreateBy";
 
 export * from "$server/utils/session";
 
+const key = "/api/v2/session";
+
 export function useSessionInit() {
-  const { data, error } = useSWR<Session>("/api/v2/session", async () => {
+  const { data, error } = useSWR<Session>(key, async () => {
     const res = await api.apiV2SessionGetRaw();
     return res.raw.json();
   });
@@ -38,4 +40,8 @@ export function useSessionInit() {
   }, [sessionWithState, updateSession]);
 
   return sessionWithState;
+}
+
+export function revalidateSession(): Promise<Session> {
+  return mutate(key);
 }


### PR DESCRIPTION
updateLtiResourceLink実行後にsessionに反映されていない問題の修正。
一応useLtiResourceLink()を使うと回避できるが使われておらずsessionを中心にしているためsessionに反映。