### PR TITLE
refactor: export default とファイル名の一致を検証

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ parserOptions:
 plugins:
   - react
   - "@typescript-eslint"
+  - filenames
 settings:
   react:
     version: detect
@@ -23,6 +24,7 @@ rules:
     - "error"
     - varsIgnorePattern: "^_"
   react/react-in-jsx-scope: "off"
+  filenames/match-exported: error
 overrides:
   - files:
       - next.config.js
@@ -32,3 +34,9 @@ overrides:
       - samples/**
     rules:
       no-irregular-whitespace: "off"
+  - files: pages/**
+    rules:
+      filenames/match-exported: "off"
+  - files: [types/**, server/types/**]
+    rules:
+      filenames/match-exported: [error, camel]

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -40,7 +40,7 @@ type Props = {
   onEnded?: () => void;
 };
 
-export default function TopicPlaer(props: Props) {
+export default function TopicViewerContent(props: Props) {
   const classes = useStyles();
   const { topic, onEnded } = props;
   return (

--- a/components/organisms/BookNotFoundProblem.tsx
+++ b/components/organisms/BookNotFoundProblem.tsx
@@ -2,7 +2,7 @@ import Link from "@material-ui/core/Link";
 import { useLmsUrl } from "$store/session";
 import Problem from "./Problem";
 
-export default function TopicNotFoundProblem() {
+export default function BookNotFoundProblem() {
   const url = useLmsUrl();
 
   return (

--- a/components/organisms/TopicNotFoundProblem.tsx
+++ b/components/organisms/TopicNotFoundProblem.tsx
@@ -2,7 +2,7 @@ import Link from "@material-ui/core/Link";
 import { useLmsUrl } from "$store/session";
 import Problem from "./Problem";
 
-export default function BookNotFoundProblem() {
+export default function TopicNotFoundProblem() {
   const url = useLmsUrl();
 
   return (

--- a/components/organisms/TopicViewer.tsx
+++ b/components/organisms/TopicViewer.tsx
@@ -9,7 +9,7 @@ type Props = {
   onEnded?: () => void;
 };
 
-export default function TopicPlaer(props: Props) {
+export default function TopicViewer(props: Props) {
   const cardClasses = useCardStyles();
   const { className, topic, onEnded } = props;
   return (

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^2.16.1",
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^7.0.0",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/store/playerTracker.ts
+++ b/store/playerTracker.ts
@@ -2,7 +2,7 @@ import { atom, useAtom } from "jotai";
 import { useAtomValue, useUpdateAtom } from "jotai/utils";
 import type { VideoJsPlayer } from "video.js";
 import type VimeoPlayer from "@vimeo/player";
-import PlayerTracker from "$utils/eventLogger/playerTracker";
+import { PlayerTracker } from "$utils/eventLogger/playerTracker";
 
 const playerTrackerAtom = atom<PlayerTracker | undefined>(undefined);
 const playerTrackingAtom = atom<

--- a/utils/activity.ts
+++ b/utils/activity.ts
@@ -4,7 +4,7 @@ import usePrevious from "@rooks/use-previous";
 import type { TopicSchema } from "$server/models/topic";
 import { useBookAtom } from "$store/book";
 import { usePlayerTrackerAtom } from "$store/playerTracker";
-import type PlayerTracker from "./eventLogger/playerTracker";
+import type { PlayerTracker } from "./eventLogger/playerTracker";
 import { api } from "./api";
 import { NEXT_PUBLIC_ACTIVITY_SEND_INTERVAL } from "./env";
 

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -1,6 +1,6 @@
 import type { EventType } from "$server/models/event";
 import { api } from "$utils/api";
-import PlayerTracker, { PlayerEvent, PlayerEvents } from "./playerTracker";
+import { PlayerEvent, PlayerEvents, PlayerTracker } from "./playerTracker";
 import { load } from "./loggerSessionPersister";
 
 /** v1のときのトラッキング用コードの移植 */

--- a/utils/eventLogger/playerTracker.ts
+++ b/utils/eventLogger/playerTracker.ts
@@ -43,7 +43,7 @@ const nullEvent = {
 } as const;
 
 /** プレイヤーのトラッキング用 */
-class PlayerTracker extends (EventEmitter as {
+export class PlayerTracker extends (EventEmitter as {
   new (): StrictEventEmitter<EventEmitter, PlayerEvents & CustomEvents>;
 }) {
   readonly player: VideoJsPlayer | VimeoPlayer;
@@ -132,8 +132,6 @@ class PlayerTracker extends (EventEmitter as {
     );
   }
 }
-
-export default PlayerTracker;
 
 function videoJsStats(player: VideoJsPlayer): PlayerEvent {
   // @ts-expect-error: @types/video.js@^7.3.11 Unsupported

--- a/yarn.lock
+++ b/yarn.lock
@@ -5996,6 +5996,16 @@ eslint-config-prettier@^7.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.0.0.tgz#c1ae4106f74e6c0357f44adb076771d032ac0e97"
   integrity sha512-8Y8lGLVPPZdaNA7JXqnvETVC7IiVRgAP6afQu9gOQRn90YY3otMNh+x7Vr2vMePQntF+5erdSUBqSzCmU/AxaQ==
 
+eslint-plugin-filenames@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
+  integrity sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==
+  dependencies:
+    lodash.camelcase "4.3.0"
+    lodash.kebabcase "4.1.1"
+    lodash.snakecase "4.1.1"
+    lodash.upperfirst "4.3.1"
+
 eslint-plugin-jsx-a11y@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd"
@@ -9073,6 +9083,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.camelcase@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -9093,10 +9108,20 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
+lodash.kebabcase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.snakecase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -9112,6 +9137,11 @@ lodash.union@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
+
+lodash.upperfirst@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
 lodash@4.17.20, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"


### PR DESCRIPTION
つい気になったのでfilenames/match-exportedを追加

- `pages/**` default export を使うのは Next.js の仕様で明らか
なので無視
- `types/**`, `server/types/**` camelCase のまま保持
- いくつかリネーム﻿
