### PR TITLE
fix: 以前のフォームの状態を保持し続けている問題の修正/コードの整理 - store/book.ts, store/videoTrack.ts: アンマウント後リセット

### DIFF
--- a/pages/topics/new.tsx
+++ b/pages/topics/new.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useRouter } from "next/router";
 import type { TopicProps, TopicSchema } from "$server/models/topic";
 import type {
@@ -25,13 +24,9 @@ type NewProps = {
 function New({ edit, back, onSubmit }: NewProps) {
   const {
     videoTracksProps,
-    resetVideoTrackProps,
     addVideoTrack,
     deleteVideoTrack,
   } = useVideoTrackAtom();
-  useEffect(() => {
-    resetVideoTrackProps();
-  }, [resetVideoTrackProps]);
   async function handleSubmit(props: TopicProps) {
     const topic = await createTopic(props);
     const {

--- a/store/book.ts
+++ b/store/book.ts
@@ -1,5 +1,6 @@
-import { atom } from "jotai";
-import { useAtomValue, useUpdateAtom } from "jotai/utils";
+import { useEffect } from "react";
+import { atom, useAtom } from "jotai";
+import { RESET, atomWithReset, useUpdateAtom } from "jotai/utils";
 import type { BookSchema } from "$server/models/book";
 import type { TopicSchema } from "$server/models/topic";
 
@@ -9,7 +10,7 @@ type BookState = {
   itemExists(itemIndex: ItemIndex): TopicSchema | undefined;
 };
 
-const bookAtom = atom<BookState>({
+const bookAtom = atomWithReset<BookState>({
   book: undefined,
   itemIndex: [0, 0],
   itemExists: () => undefined,
@@ -66,9 +67,15 @@ const nextItemIndexAtom = atom(
 );
 
 export function useBookAtom() {
-  const state = useAtomValue(bookAtom);
+  const [state, reset] = useAtom(bookAtom);
   const updateBook = useUpdateAtom(updateBookAtom);
   const updateItemIndex = useUpdateAtom(updateItemIndexAtom);
   const nextItemIndex = useUpdateAtom(nextItemIndexAtom);
+  useEffect(
+    () => () => {
+      reset(RESET);
+    },
+    [reset]
+  );
   return { ...state, updateBook, updateItemIndex, nextItemIndex };
 }

--- a/store/videoTrack.ts
+++ b/store/videoTrack.ts
@@ -1,10 +1,6 @@
-import { atom } from "jotai";
-import {
-  atomWithReset,
-  useResetAtom,
-  useAtomValue,
-  useUpdateAtom,
-} from "jotai/utils";
+import { useEffect } from "react";
+import { atom, useAtom } from "jotai";
+import { RESET, atomWithReset, useAtomValue, useUpdateAtom } from "jotai/utils";
 import type {
   VideoTrackProps,
   VideoTrackSchema,
@@ -66,15 +62,19 @@ const deleteVideoTrackAtom = atom<null, VideoTrackSchema["id"]>(
 );
 
 export function useVideoTrackAtom() {
-  const videoTracksProps = useAtomValue(videoTracksPropsAtom);
-  const resetVideoTrackProps = useResetAtom(videoTracksPropsAtom);
+  const [videoTracksProps, reset] = useAtom(videoTracksPropsAtom);
   const videoTracks = useAtomValue(videoTracksAtom);
   const setVideoTracks = useUpdateAtom(videoTracksSchemaAtom);
   const addVideoTrack = useUpdateAtom(addVideoTrackAtom);
   const deleteVideoTrack = useUpdateAtom(deleteVideoTrackAtom);
+  useEffect(
+    () => () => {
+      reset(RESET);
+    },
+    [reset]
+  );
   return {
     videoTracksProps,
-    resetVideoTrackProps,
     videoTracks,
     setVideoTracks,
     addVideoTrack,


### PR DESCRIPTION
もともとPR #223 にて含めていたが #223 の内容とは直接関係ないのでcherry-pick

マウント以外の理由でリセットしなければならないユースケースの優先度は低いと考え useVideoTrackAtom 内に隠蔽、加えてアンマウント後のタイミングに変更してみましたが、問題あるかどうか確認ください bow > @knokmki612

