### PR TITLE
fix: セクションが空になるケースへの対処/ブックから参照されている場合、そのブックから取り除く

### DIFF
--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -913,7 +913,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * トピックを削除します。 教員または管理者でなければなりません。 教員の場合は自身の作成したトピックでなければなりません。
+     * トピックを削除します。 ブックから参照されている場合、そのブックから取り除きます。 教員または管理者でなければなりません。 教員の場合は自身の作成したトピックでなければなりません。
      * トピックの削除
      */
     async apiV2TopicTopicIdDeleteRaw(requestParameters: ApiV2TopicTopicIdDeleteRequest): Promise<runtime.ApiResponse<void>> {
@@ -936,7 +936,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * トピックを削除します。 教員または管理者でなければなりません。 教員の場合は自身の作成したトピックでなければなりません。
+     * トピックを削除します。 ブックから参照されている場合、そのブックから取り除きます。 教員または管理者でなければなりません。 教員の場合は自身の作成したトピックでなければなりません。
      * トピックの削除
      */
     async apiV2TopicTopicIdDelete(requestParameters: ApiV2TopicTopicIdDeleteRequest): Promise<void> {

--- a/server/services/topic/destroy.ts
+++ b/server/services/topic/destroy.ts
@@ -12,6 +12,7 @@ export const destroySchema: FastifySchema = {
   summary: "トピックの削除",
   description: outdent`
     トピックを削除します。
+    ブックから参照されている場合、そのブックから取り除きます。
     教員または管理者でなければなりません。
     教員の場合は自身の作成したトピックでなければなりません。`,
   params: topicParamsSchema,

--- a/server/utils/topic/destroyTopic.ts
+++ b/server/utils/topic/destroyTopic.ts
@@ -4,6 +4,12 @@ import prisma from "$server/utils/prisma";
 async function destroyTopic(id: Topic["id"]) {
   try {
     await prisma.$transaction([
+      prisma.topicSection.deleteMany({
+        where: { topicId: id },
+      }),
+      prisma.section.deleteMany({
+        where: { topicSections: { every: { topicId: id } } },
+      }),
       prisma.activityTimeRange.deleteMany({
         where: { activity: { topicId: id } },
       }),


### PR DESCRIPTION
fix #229
確認したこと:
ブックにトピックをインポート、そのトピックを削除し、セクションの残骸が残らず、番号が1から振られていること
