### PR TITLE
fix: ブック削除後のLTIリソースリンクとの不整合の修正

### DIFF
--- a/server/services/book/destroy.ts
+++ b/server/services/book/destroy.ts
@@ -40,5 +40,9 @@ export async function destroy({
 
   await destroyBook(params.book_id);
 
+  if (session.ltiResourceLink?.bookId === params.book_id) {
+    session.ltiResourceLink = null;
+  }
+
   return { status: 204 };
 }

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -6,6 +6,7 @@ import type { BookProps, BookSchema } from "$server/models/book";
 import type { TopicSchema } from "$server/models/topic";
 import type { SectionSchema } from "$server/models/book/section";
 import { createTopic } from "./topic";
+import { revalidateSession } from "./session";
 
 const key = "/api/v2/book/{book_id}";
 
@@ -77,6 +78,7 @@ export async function updateBook({
 
 export async function destroyBook(id: BookSchema["id"]) {
   await api.apiV2BookBookIdDelete({ bookId: id });
+  await revalidateSession();
 }
 
 export function revalidateBook(


### PR DESCRIPTION
LTIリソースとしてリンクされているブックを削除後、「LTIリンク」ボタンを押すと、「ブックがありません」エラー画面が表示される不具合があったのでその問題を解決