### PR TITLE
fix: ゼロ件のとき読み込み中になり続ける問題の解決

### DIFF
--- a/utils/books.ts
+++ b/utils/books.ts
@@ -53,11 +53,8 @@ export function useBooks(
   isBookEditable: (book: Pick<BookSchema, "author">) => boolean,
   isTopicEditable: (topic: Pick<TopicSchema, "creator">) => boolean
 ) {
-  const { data, size, setSize } = useSWRInfinite<BookSchema[]>(
-    makeKey("updated"),
-    fetchBooks
-  );
+  const res = useSWRInfinite<BookSchema[]>(makeKey("updated"), fetchBooks);
   const books =
-    data?.flat().flatMap(filter(isBookEditable, isTopicEditable)) ?? [];
-  return { books, ...useInfiniteProps(data, size, setSize) };
+    res.data?.flat().flatMap(filter(isBookEditable, isTopicEditable)) ?? [];
+  return { books, ...useInfiniteProps(res) };
 }

--- a/utils/topics.ts
+++ b/utils/topics.ts
@@ -45,10 +45,10 @@ const filter = (
 export function useTopics(
   isTopicEditable: (topic: Pick<TopicSchema, "creator">) => boolean
 ) {
-  const { data, size, setSize } = useSWRInfinite<TopicSchema[]>(
+  const res = useSWRInfinite<TopicSchema[]>(
     makeKey("updated", 20),
     fetchTopics
   );
-  const topics = data?.flat().flatMap(filter(isTopicEditable)) ?? [];
-  return { topics, ...useInfiniteProps(data, size, setSize) };
+  const topics = res.data?.flat().flatMap(filter(isTopicEditable)) ?? [];
+  return { topics, ...useInfiniteProps(res) };
 }

--- a/utils/useInfiniteProps.ts
+++ b/utils/useInfiniteProps.ts
@@ -1,13 +1,15 @@
 import { useCallback } from "react";
+import { SWRInfiniteResponseInterface } from "swr";
 
-function useInfiniteProps<Data>(
-  data: Data[][] | undefined,
-  size: number,
-  setSize: (size: number | ((size: number) => number)) => Promise<unknown>
-) {
+function useInfiniteProps<Data>({
+  data,
+  size,
+  setSize,
+  isValidating,
+}: SWRInfiniteResponseInterface<Data[]>) {
   const [prev] = data?.slice(-1) ?? [];
   const hasNextPage = prev === undefined || prev.length > 0;
-  const loading = data?.length !== size;
+  const loading = isValidating && data?.length !== size;
   const onLoadMore = useCallback(() => setSize((n) => n + 1), [setSize]);
   return { loading, hasNextPage, onLoadMore };
 }

--- a/utils/userBooks.ts
+++ b/utils/userBooks.ts
@@ -26,10 +26,10 @@ async function fetchUserBooks(
 }
 
 export function useUserBooks(userId: UserSchema["id"]) {
-  const { data, size, setSize } = useSWRInfinite<BookSchema[]>(
+  const res = useSWRInfinite<BookSchema[]>(
     makeKey(userId, "updated"),
     fetchUserBooks
   );
-  const books = data?.flatMap((books) => books) ?? [];
-  return { books, ...useInfiniteProps(data, size, setSize) };
+  const books = res.data?.flatMap((books) => books) ?? [];
+  return { books, ...useInfiniteProps(res) };
 }

--- a/utils/userTopics.ts
+++ b/utils/userTopics.ts
@@ -36,10 +36,10 @@ async function fetchUserTopics(
 }
 
 export function useUserTopics(userId: UserSchema["id"]) {
-  const { data, size, setSize } = useSWRInfinite<TopicSchema[]>(
+  const res = useSWRInfinite<TopicSchema[]>(
     makeKey(userId, "updated", 20),
     fetchUserTopics
   );
-  const topics = data?.flatMap((topics) => topics) ?? [];
-  return { topics, ...useInfiniteProps(data, size, setSize) };
+  const topics = res.data?.flatMap((topics) => topics) ?? [];
+  return { topics, ...useInfiniteProps(res) };
 }


### PR DESCRIPTION
それぞれ一覧画面で読み込み中が意図せず発生するケースへの対処です