### PR TITLE
feat: use Slide with AppBar & ActionHeader

### DIFF
--- a/components/organisms/ActionHeader.tsx
+++ b/components/organisms/ActionHeader.tsx
@@ -16,6 +16,9 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       marginRight: theme.spacing(1),
     },
+    "& > p": {
+      paddingTop: theme.spacing(1),
+    },
   },
   action: {
     display: "flex",

--- a/components/organisms/ActionHeader.tsx
+++ b/components/organisms/ActionHeader.tsx
@@ -3,19 +3,17 @@ import clsx from "clsx";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Typography";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import { useTheme, makeStyles } from "@material-ui/core/styles";
 import { gray } from "theme/colors";
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    zIndex: 1,
-    position: "sticky",
-    backgroundColor: gray[50],
     paddingTop: theme.spacing(5),
     paddingBottom: theme.spacing(2),
   },
   title: {
-    marginBottom: theme.spacing(4),
+    marginBottom: 0,
     "& > *": {
       marginRight: theme.spacing(1),
     },
@@ -24,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
     flexWrap: "wrap",
-    marginBottom: theme.spacing(-2),
+    paddingTop: theme.spacing(2),
     "& > *": {
       marginRight: theme.spacing(2),
       marginBottom: theme.spacing(2),
@@ -32,6 +30,22 @@ const useStyles = makeStyles((theme) => ({
   },
   container: {
     padding: 0,
+  },
+  sticky: {
+    zIndex: 1,
+    position: "sticky",
+    backgroundColor: gray[50],
+    transition: theme.transitions.create("top", {
+      duration: theme.transitions.duration.enteringScreen,
+      easing: theme.transitions.easing.easeOut,
+    }),
+  },
+  scroll: {
+    top: 0,
+    transition: theme.transitions.create("top", {
+      duration: theme.transitions.duration.leavingScreen,
+      easing: theme.transitions.easing.sharp,
+    }),
   },
   desktop: {
     top: 65,
@@ -51,19 +65,35 @@ export default function ActionHeader(props: Props) {
   const classes = useStyles();
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.up("sm"));
+  const trigger = useScrollTrigger();
   return (
-    <div
-      className={clsx(classes.root, matches ? classes.desktop : classes.mobile)}
-    >
-      <Container
-        className={clsx({ [classes.container]: !maxWidth })}
-        maxWidth={maxWidth}
-      >
-        <Typography className={classes.title} variant="h4" gutterBottom>
-          {title}
-        </Typography>
-        {action && <div className={classes.action}>{action}</div>}
-      </Container>
-    </div>
+    <>
+      <div className={classes.root}>
+        <Container
+          className={clsx({ [classes.container]: !maxWidth })}
+          maxWidth={maxWidth}
+        >
+          <Typography className={classes.title} variant="h4" gutterBottom>
+            {title}
+          </Typography>
+        </Container>
+      </div>
+      {action && (
+        <Container
+          className={clsx(
+            { [classes.container]: !maxWidth },
+            classes.sticky,
+            trigger
+              ? classes.scroll
+              : matches
+              ? classes.desktop
+              : classes.mobile
+          )}
+          maxWidth={maxWidth}
+        >
+          <div className={classes.action}>{action}</div>
+        </Container>
+      )}
+    </>
   );
 }

--- a/components/organisms/ActionHeader.tsx
+++ b/components/organisms/ActionHeader.tsx
@@ -13,7 +13,6 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: theme.spacing(2),
   },
   title: {
-    marginBottom: 0,
     "& > *": {
       marginRight: theme.spacing(1),
     },
@@ -73,7 +72,7 @@ export default function ActionHeader(props: Props) {
           className={clsx({ [classes.container]: !maxWidth })}
           maxWidth={maxWidth}
         >
-          <Typography className={classes.title} variant="h4" gutterBottom>
+          <Typography className={classes.title} variant="h4">
             {title}
           </Typography>
         </Container>

--- a/components/organisms/AppBar.tsx
+++ b/components/organisms/AppBar.tsx
@@ -1,4 +1,4 @@
-import { useState, ComponentProps } from "react";
+import { useState, forwardRef, ComponentProps, Ref } from "react";
 import MuiAppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Button from "@material-ui/core/Button";
@@ -67,7 +67,7 @@ const role = (session: SessionSchema) => {
   return "学生";
 };
 
-export default function AppBar(props: Props) {
+function AppBar(props: Props, ref: Ref<unknown>) {
   const {
     session,
     onBooksClick,
@@ -86,7 +86,7 @@ export default function AppBar(props: Props) {
     setOpen(false);
   };
   return (
-    <MuiAppBar classes={appBarClasses} color="default" {...others}>
+    <MuiAppBar classes={appBarClasses} color="default" {...others} ref={ref}>
       <Toolbar color="inherit" disableGutters>
         <div className={classes.inner}>
           <LogoIcon className={clsx(classes.margin, classes.logo)} />
@@ -141,3 +141,5 @@ export default function AppBar(props: Props) {
     </MuiAppBar>
   );
 }
+
+export default forwardRef(AppBar);

--- a/components/templates/BookImport.stories.tsx
+++ b/components/templates/BookImport.stories.tsx
@@ -1,6 +1,8 @@
 export default { title: "templates/BookImport" };
 
 import BookImport from "./BookImport";
+import Slide from "@material-ui/core/Slide";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import AppBar from "$organisms/AppBar";
 import { books, session } from "samples";
 
@@ -18,16 +20,25 @@ const handlers = {
   onCancel: () => console.log("Cancel"),
 };
 
+function SlideAppBar() {
+  const trigger = useScrollTrigger();
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      <AppBar position="sticky" session={session} {...appBarHandlers} />
+    </Slide>
+  );
+}
+
 export const Default = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <BookImport books={books} {...handlers} />
   </>
 );
 
 export const Empty = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <BookImport books={[]} {...handlers} />
   </>
 );

--- a/components/templates/BookLink.stories.tsx
+++ b/components/templates/BookLink.stories.tsx
@@ -1,6 +1,8 @@
 export default { title: "templates/BookLink" };
 
 import BookLink from "./BookLink";
+import Slide from "@material-ui/core/Slide";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import AppBar from "$organisms/AppBar";
 import { books, session } from "samples";
 
@@ -25,16 +27,25 @@ const defaultProps = {
   onBookNewClick: console.log,
 };
 
+function SlideAppBar() {
+  const trigger = useScrollTrigger();
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      <AppBar position="sticky" session={session} {...appBarHandlers} />
+    </Slide>
+  );
+}
+
 export const Default = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <BookLink {...defaultProps} />
   </>
 );
 
 export const Empty = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <BookLink {...defaultProps} books={[]} />
   </>
 );

--- a/components/templates/Books.stories.tsx
+++ b/components/templates/Books.stories.tsx
@@ -1,6 +1,8 @@
 export default { title: "templates/Books" };
 
 import Books from "./Books";
+import Slide from "@material-ui/core/Slide";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import AppBar from "$organisms/AppBar";
 import { books, session } from "samples";
 
@@ -21,16 +23,25 @@ const handlers = {
   },
 };
 
+function SlideAppBar() {
+  const trigger = useScrollTrigger();
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      <AppBar position="sticky" session={session} {...appBarHandlers} />
+    </Slide>
+  );
+}
+
 export const Default = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <Books books={books} {...handlers} />
   </>
 );
 
 export const Empty = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <Books books={[]} {...handlers} />
   </>
 );

--- a/components/templates/TopicImport.stories.tsx
+++ b/components/templates/TopicImport.stories.tsx
@@ -1,6 +1,8 @@
 export default { title: "templates/TopicImport" };
 
 import TopicImport from "./TopicImport";
+import Slide from "@material-ui/core/Slide";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import AppBar from "$organisms/AppBar";
 import { topic, session } from "samples";
 
@@ -19,23 +21,32 @@ const handlers = {
   isTopicEditable: () => true,
 };
 
+function SlideAppBar() {
+  const trigger = useScrollTrigger();
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      <AppBar position="sticky" session={session} {...appBarHandlers} />
+    </Slide>
+  );
+}
+
 export const Default = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <TopicImport topics={topics} {...handlers} />
   </>
 );
 
 export const Empty = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <TopicImport topics={[]} {...handlers} />
   </>
 );
 
 export const Others = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <TopicImport topics={topics} {...handlers} isTopicEditable={() => false} />
   </>
 );

--- a/components/templates/Topics.stories.tsx
+++ b/components/templates/Topics.stories.tsx
@@ -1,6 +1,8 @@
 export default { title: "templates/Topics" };
 
 import Topics from "./Topics";
+import Slide from "@material-ui/core/Slide";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import AppBar from "$organisms/AppBar";
 import { topic, session } from "samples";
 
@@ -17,16 +19,25 @@ const handlers = {
   onTopicNewClick: console.log,
 };
 
+function SlideAppBar() {
+  const trigger = useScrollTrigger();
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      <AppBar position="sticky" session={session} {...appBarHandlers} />
+    </Slide>
+  );
+}
+
 export const Default = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <Topics topics={topics} {...handlers} />
   </>
 );
 
 export const Empty = () => (
   <>
-    <AppBar position="sticky" session={session} {...appBarHandlers} />
+    <SlideAppBar />
     <Topics topics={[]} {...handlers} />
   </>
 );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,8 @@ import type { AppProps } from "next/app";
 import Head from "next/head";
 import MuiThemeProvider from "@material-ui/styles/ThemeProvider";
 import CssBaseline from "@material-ui/core/CssBaseline";
+import Slide from "@material-ui/core/Slide";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import { ConfirmProvider } from "material-ui-confirm";
 import theme from "$theme";
 import Placeholder from "$templates/Placeholder";
@@ -20,6 +22,7 @@ import "$styles/video-js.css";
 function Content({ children }: { children: ReactNode }) {
   const router = useRouter();
   const { session, isInstructor, error } = useSessionInit();
+  const trigger = useScrollTrigger();
 
   if (error) {
     return (
@@ -37,13 +40,15 @@ function Content({ children }: { children: ReactNode }) {
   return (
     <>
       {isInstructor && (
-        <AppBar
-          position="sticky"
-          session={session}
-          onBooksClick={handleBooksClick}
-          onTopicsClick={handleTopicsClick}
-          onBookLinkClick={handleBookLinkClick}
-        />
+        <Slide appear={false} direction="down" in={!trigger}>
+          <AppBar
+            position="sticky"
+            session={session}
+            onBooksClick={handleBooksClick}
+            onTopicsClick={handleTopicsClick}
+            onBookLinkClick={handleBookLinkClick}
+          />
+        </Slide>
       )}
       {children}
     </>


### PR DESCRIPTION
#238 の改善です

以下のスクリーンショットのように、

100px程度スクロールした段階で

- 上部AppBarが非表示になる
- ActionHeaderはタイトルは張り付かず、ソートと検索のみ固定表示になる

ように変更しました

![image](https://user-images.githubusercontent.com/9744580/109121312-7231f180-778a-11eb-9f68-5e3677997811.png)

