### PR TITLE
feat: forward, backイベントのサポート

### DIFF
--- a/components/organisms/Video/VideoJs.tsx
+++ b/components/organisms/Video/VideoJs.tsx
@@ -38,9 +38,11 @@ export function VideoJs(props: VideoJsProps) {
       forward: 15,
       back: 15,
     });
-    tracking(player);
-    volumePersister(player);
-    if (props.onEnded) player.on("ended", props.onEnded);
+    player.ready(() => {
+      tracking(player);
+      volumePersister(player);
+      if (props.onEnded) player.on("ended", props.onEnded);
+    });
     return () => {
       // TODO: played() に失敗するので dispose() せず一時停止して保持
       //       メモリリークにつながるので避けたほうが望ましい

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -2,6 +2,8 @@ import { IsOptional, IsString } from "class-validator";
 import { validationMetadatasToSchemas } from "class-validator-jsonschema";
 
 export type EventType =
+  | "forward"
+  | "back"
   | "changepage"
   | "timeupdate"
   | "seeking"

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -66,7 +66,14 @@ function logger(tracker: PlayerTracker) {
     send("trackchange", event, event.language ?? "off");
   });
 
-  for (const event of ["firstplay", "ended", "pause", "play"] as const) {
+  for (const event of [
+    "forward",
+    "back",
+    "firstplay",
+    "ended",
+    "pause",
+    "play",
+  ] as const) {
     tracker.on(event, buildHandler(event));
   }
 


### PR DESCRIPTION
close #232 

確認したこと:
1. 開発用サーバーの起動
2. 学習者権限のアカウントでのYouTube動画の含まれるブックを起動
3. シークボタンを押す
4. サーバーのコンソールに"forward" "back" と共に押したタイミングでの再生時間 (秒) が含まれる文字列が出力