### PR TITLE
fix: RFC 3986予約語が含まれる時の問題の修正

### DIFF
--- a/server/utils/ltiv1p1/oauth.test.ts
+++ b/server/utils/ltiv1p1/oauth.test.ts
@@ -19,6 +19,26 @@ describe("sign()", function () {
       "IeMP6CeHaVU47hNucWgW5y1TGQI="
     );
   });
+
+  test("RFC 3986 仕様予約語を正しくエンコードできる", function () {
+    const oauthConsumerSecret = "secret";
+    const url = "http://localhost:8080/api/v2/lti/lauch";
+    const params = {
+      oauth_version: "1.0",
+      oauth_nonce: "0878c39c4c274c2072d3af6604a75c64",
+      oauth_timestamp: "1605829208",
+      oauth_consumer_key: "key",
+      oauth_signature_method: "HMAC-SHA1",
+      lti_message_type: "basic-lti-launch-request",
+      lti_version: "LTI-1p0",
+      resource_link_id: "1",
+      resource_link_title: `RFC 3986 ":/?#[]@!$&'()*+,;="`,
+    } as const;
+
+    expect(sign(url, params, oauthConsumerSecret)).toBe(
+      "gbPiSxjJCBTUnnuQ8jF1pC+Vs8w="
+    );
+  });
 });
 
 describe("valid()", function () {

--- a/server/utils/ltiv1p1/oauth.test.ts
+++ b/server/utils/ltiv1p1/oauth.test.ts
@@ -39,6 +39,30 @@ describe("sign()", function () {
       "gbPiSxjJCBTUnnuQ8jF1pC+Vs8w="
     );
   });
+
+  test("RFC 3986 仕様予約語がパラメータの名前に含まれる場合", function () {
+    const oauthConsumerSecret = "secret";
+    const url = "http://localhost:8080/api/v2/lti/lauch";
+    const params = {
+      oauth_version: "1.0",
+      oauth_nonce: "0878c39c4c274c2072d3af6604a75c64",
+      oauth_timestamp: "1605829208",
+      oauth_consumer_key: "key",
+      oauth_signature_method: "HMAC-SHA1",
+      lti_message_type: "basic-lti-launch-request",
+      lti_version: "LTI-1p0",
+      resource_link_id: "1",
+      a0: "a",
+      // エンコード前後で順番が変わる文字列 ("a%40" < "a0")
+      "a@": "a",
+      // エンコード前後で順番が変わる文字列 ("a" < "a%40")
+      a: "a",
+    } as const;
+
+    expect(sign(url, params, oauthConsumerSecret)).toBe(
+      "g8em84DQAPFyb00SlFyh8BxQkOI="
+    );
+  });
 });
 
 describe("valid()", function () {

--- a/server/utils/ltiv1p1/oauth.ts
+++ b/server/utils/ltiv1p1/oauth.ts
@@ -17,8 +17,9 @@ export function sign(
     ...params,
     oauth_signature_method: "HMAC-SHA1",
   })
+    .map((es) => es.map(strictUriEncode).join("\0"))
     .sort()
-    .map((es) => es.map(strictUriEncode).join("="))
+    .map((s) => s.replace(/\0/g, "="))
     .join("&");
   const signatureBase = [method, url, orderedParams]
     .map(strictUriEncode)

--- a/server/utils/ltiv1p1/oauth.ts
+++ b/server/utils/ltiv1p1/oauth.ts
@@ -19,7 +19,7 @@ export function sign(
   })
     .map((es) => es.map(strictUriEncode).join("\0"))
     .sort()
-    .map((s) => s.replace(/\0/g, "="))
+    .map((s) => s.replace("\0", "="))
     .join("&");
   const signatureBase = [method, url, orderedParams]
     .map(strictUriEncode)

--- a/server/utils/ltiv1p1/oauth.ts
+++ b/server/utils/ltiv1p1/oauth.ts
@@ -18,7 +18,7 @@ export function sign(
     oauth_signature_method: "HMAC-SHA1",
   })
     .sort()
-    .map((es) => es.map(encodeURIComponent).join("="))
+    .map((es) => es.map(strictUriEncode).join("="))
     .join("&");
   const signatureBase = [method, url, orderedParams]
     .map(strictUriEncode)

--- a/server/utils/ltiv1p1/oauth.ts
+++ b/server/utils/ltiv1p1/oauth.ts
@@ -4,7 +4,7 @@ import strictUriEncode from "strict-uri-encode";
 /**
  * OAuth 1.0 プロトコルにおける署名の作成。ただし、POST メソッド固定。HMAC-SHA1 固定。
  * @param url スキーマ・ホスト名・パスを含む URL。スキームのデフォルトポートでない場合、ポート番号を含む。
- * @param param パラメーター。LTI v1.1 ではPOSTリクエストボディを解釈したもの。`oauth_signature` を含まない。
+ * @param params パラメーター。LTI v1.1 ではPOSTリクエストボディを解釈したもの。`oauth_signature` を含まない。
  * @param oauthConsumerSecret OAuth Consumer Secret
  */
 export function sign(


### PR DESCRIPTION
- docs: use plural form param→params
- fix: [RFC 3986](https://tools.ietf.org/html/rfc3986)予約語が含まれる時の問題の修正
