### PR TITLE
fix: 他者の作成したトピック・ブックの編集画面への管理者のアクセス許可

### DIFF
--- a/server/services/book/update.ts
+++ b/server/services/book/update.ts
@@ -43,7 +43,7 @@ export async function update({
   if (!found) return { status: 404 };
   if (!isUserOrAdmin(session, { id: found.authorId })) return { status: 403 };
 
-  const created = await updateBook(session.user.id, {
+  const created = await updateBook(found.authorId, {
     ...body,
     id: params.book_id,
   });

--- a/server/services/topic/update.ts
+++ b/server/services/topic/update.ts
@@ -54,7 +54,7 @@ export async function update({
     return { status: 400 };
   }
 
-  const created = await upsertTopic(session.user.id, {
+  const created = await upsertTopic(found.creatorId, {
     ...body,
     id: params.topic_id,
   });

--- a/store/session.ts
+++ b/store/session.ts
@@ -3,7 +3,10 @@ import { useAtomValue, useUpdateAtom } from "jotai/utils";
 import type { TopicSchema } from "$server/models/topic";
 import type { BookSchema } from "$server/models/book";
 import type { SessionSchema } from "$server/models/session";
-import { isAdministrator, isInstructor } from "$utils/session";
+import {
+  isAdministrator as isAdministratorSession,
+  isInstructor as isInstructorSession,
+} from "$utils/session";
 import topicCreateBy from "$utils/topicCreateBy";
 import bookCreateBy from "$utils/bookCreateBy";
 
@@ -29,17 +32,17 @@ const updateSessionAtom = atom<
   null,
   { session: SessionSchema; error: boolean }
 >(null, (get, set, { session, error }) => {
+  const isAdministrator = isAdministratorSession(session);
+  const isInstructor = isInstructorSession(session);
   const sessionWithState = {
     session,
-    isAdministrator: isAdministrator(session),
-    isInstructor: isInstructor(session),
+    isAdministrator,
+    isInstructor,
     isTopicEditable(topic: Pick<TopicSchema, "creator">) {
-      // NOTE: 自身以外の作成したトピックに関しては編集不可
-      return topicCreateBy(topic, session.user);
+      return isAdministrator || topicCreateBy(topic, session.user);
     },
     isBookEditable(book: Pick<BookSchema, "author">) {
-      // NOTE: 自身以外の作成したブックに関しては編集不可
-      return bookCreateBy(book, session.user);
+      return isAdministrator || bookCreateBy(book, session.user);
     },
     error,
   };


### PR DESCRIPTION
fix #260

- fix: トピック・ブック更新時の作成者・著作者を変更しない
- fix: 管理者は他者の作成したトピック・ブックの編集画面にもアクセス

管理者権限は他者が作成したものも閲覧や編集、LTIリンクができることを確認。
