### PR TITLE
fix: publicディレクトリがdistに配置されない問題の修正

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,4 @@ node_modules/
 /.next/
 /server/dist/
 /openapi/
-public/
+/public/api/v2/swagger/

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "run-s build:prisma build:next build:export build:server",
     "build:prisma": "yarn --cwd server build:prisma",
     "build:next": "pathpida && next build",
-    "build:export": "next export -o server/public",
+    "build:export": "next export -o server/dist/public",
     "build:server": "yarn --cwd server build:app",
     "build:openapi": "openapi-generator-cli generate -i http://localhost:8080/api/v2/swagger/json -g typescript-fetch -o openapi",
     "start": "NODE_ENV=production node server/dist/index.js",

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,4 +1,3 @@
 /dist/
 /prisma/json-schema.json
 /certs/
-/public/


### PR DESCRIPTION
distディレクトリに配置されていないことによって `yarn build` 実施後、`node dist/index.js` 実行した際404になっていたため修正。

- fix: publicディレクトリがdistに配置されない問題の修正
- chore: eslintignore により具体的なパスを明示
