### PR TITLE
Show section text field only multiple topic

### DIFF
--- a/components/molecules/DraggableBookChildren.tsx
+++ b/components/molecules/DraggableBookChildren.tsx
@@ -91,13 +91,15 @@ function DraggableSection({
           {...provided.draggableProps}
           {...provided.dragHandleProps}
         >
-          <SectionTextField
-            label="セクション"
-            fullWidth
-            onChange={handleSectionNameChange}
-            disabled={snapshot.isDragging}
-            defaultValue={section.name}
-          />
+          {section.topics.length > 1 && (
+            <SectionTextField
+              label="セクション"
+              fullWidth
+              onChange={handleSectionNameChange}
+              disabled={snapshot.isDragging}
+              defaultValue={section.name}
+            />
+          )}
           {children}
         </div>
       )}

--- a/components/molecules/DraggableBookChildren.tsx
+++ b/components/molecules/DraggableBookChildren.tsx
@@ -289,6 +289,14 @@ const removeTopic = (
   return sections;
 };
 
+const removeSection = (
+  initialSections: SectionSchema[],
+  index: number
+): SectionSchema[] => {
+  const sections = remove(initialSections, index);
+  return sections;
+};
+
 const useStyles = makeStyles((theme) => ({
   placeholder: {
     margin: theme.spacing(1),
@@ -330,6 +338,9 @@ export default function DraggableBookChildren(props: Props) {
   const handleTopicRemove = (draggableId: DraggableId) => {
     onSectionsUpdate(removeTopic(sections, draggableId));
   };
+  const handleSectionRemove = (index: number) => () => {
+    onSectionsUpdate(removeSection(sections, index));
+  };
   const handleSectionCreate = () => onSectionCreate();
   return (
     <>
@@ -356,6 +367,15 @@ export default function DraggableBookChildren(props: Props) {
                   {section.topics.length === 0 && (
                     <p className={classes.placeholder}>
                       ここにトピックをドロップ
+                      <Tooltip title="このセクションを取り除く">
+                        <IconButton
+                          size="small"
+                          color="primary"
+                          onClick={handleSectionRemove(sectionIndex)}
+                        >
+                          <RemoveIcon />
+                        </IconButton>
+                      </Tooltip>
                     </p>
                   )}
                 </DragDropSection>

--- a/components/molecules/DraggableBookChildren.tsx
+++ b/components/molecules/DraggableBookChildren.tsx
@@ -253,6 +253,11 @@ const handleTopicDragEnd: DragEndHandler = (
       ...sections[sectionIndex.end],
       topics: topics.end,
     };
+
+    // NOTE: SectionTextFieldが非表示のときセクションは無名として同期
+    if (topics.start.length === 1) {
+      sections[sectionIndex.start].name = null;
+    }
   }
 
   return sections;

--- a/components/molecules/DraggableBookChildren.tsx
+++ b/components/molecules/DraggableBookChildren.tsx
@@ -12,7 +12,7 @@ import SectionTextField from "$atoms/SectionTextField";
 import { SectionSchema } from "$server/models/book/section";
 import { TopicSchema } from "$server/models/topic";
 import { gray, primary } from "$theme/colors";
-import reorder, { insert, remove } from "$utils/reorder";
+import reorder, { insert, update, remove } from "$utils/reorder";
 
 const useSectionCreateButtonStyles = makeStyles((theme) => ({
   root: {
@@ -262,9 +262,8 @@ const updateSection = (
   initialSections: SectionSchema[],
   section: SectionSchema
 ): SectionSchema[] => {
-  const sections = [...initialSections];
-  const index = sections.findIndex(({ id }) => id === section.id);
-  sections.splice(index, 1, section);
+  const index = initialSections.findIndex(({ id }) => id === section.id);
+  const sections = update(initialSections, index, section);
   return sections;
 };
 

--- a/utils/reorder.ts
+++ b/utils/reorder.ts
@@ -5,6 +5,13 @@ export function insert<T>(list: T[], index: number, item: T) {
   return result;
 }
 
+export function update<T>(list: T[], index: number, item: T) {
+  const result = [...list];
+  result.splice(index, 1, item);
+
+  return result;
+}
+
 export function remove<T>(list: T[], index: number) {
   const result = [...list];
   result.splice(index, 1);


### PR DESCRIPTION
close #268

- feat: 並び替え中にセクションを取り除く
- feat: セクション内トピックがひとつのときはsection.nameがnullになるように
- refactor: 単一セクション更新時spliceを使っていたのをreorder.tsに切り出し
- feat: SeactionTextFieldは複数のトピックが入っているときのみ表示

セクション入力欄はトピックが複数ある場合にのみ必要なので、
必要なときのみ表示することでセクションを目立たないようにしました

![image](https://user-images.githubusercontent.com/9744580/110594727-86c9ad00-81c0-11eb-8255-2d1605c7f52e.png)