### PR TITLE
fix: 並び替えモードになった際にセクション・トピックが存在しない

### DIFF
--- a/components/organisms/BookEditChildren.tsx
+++ b/components/organisms/BookEditChildren.tsx
@@ -66,7 +66,9 @@ export default function BookEditChildren(props: Props) {
     if (sortable) onSectionsUpdate(sortableSections);
     setSortable(!sortable);
   };
-  const [sortableSections, setSortableSections] = useState<SectionSchema[]>([]);
+  const [sortableSections, setSortableSections] = useState<SectionSchema[]>(
+    sections
+  );
   const handleSectionsUpdate = (sortableSections: SectionSchema[]) => {
     setSortableSections(sortableSections);
   };


### PR DESCRIPTION
再現手順

1. 任意のブックの編集画面にアクセス
2. ブック内セクション・トピックがあらかじめ存在することを確認
3. 「並び替え・セクションの編集」ボタンをクリック

結果

「新しいセクション」ボタンのみ表示され、存在していたセクション・トピックが表示されない

---

という現象の修正です