### PR TITLE
feat: 作成フォーム内の「他の編集者に共有」フィールドのデフォルトのcheckedを取り除く

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -46,7 +46,7 @@ export default function BookForm(props: Props) {
   const defaultValues: BookProps = {
     name: book?.name ?? "",
     description: book?.description ?? "",
-    shared: book?.shared ?? true,
+    shared: Boolean(book?.shared),
     language: book?.language ?? Object.getOwnPropertyNames(languages)[0],
     timeRequired: book?.timeRequired,
     sections: book?.sections,

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -91,7 +91,7 @@ export default function TopicForm(props: Props) {
   const defaultValues = {
     name: topic?.name,
     description: topic?.description ?? "",
-    shared: topic?.shared ?? true,
+    shared: Boolean(topic?.shared),
     language: topic?.language ?? Object.getOwnPropertyNames(languages)[0],
     timeRequired: topic?.timeRequired,
   };


### PR DESCRIPTION
close #283

スクショ:
![localhost_3000_book_new_context=books(iPad) (2)](https://user-images.githubusercontent.com/1730234/110722365-757eb000-8255-11eb-89d2-0db673de0946.png)
![localhost_3000_books](https://user-images.githubusercontent.com/1730234/110722519-c098c300-8255-11eb-8f76-84601bde308f.png)
