### PR TITLE
feat: 共有中のブック・トピックを識別できるように

### DIFF
--- a/components/molecules/BookTree.tsx
+++ b/components/molecules/BookTree.tsx
@@ -2,7 +2,8 @@ import IconButton from "@material-ui/core/IconButton";
 import TreeItem from "@material-ui/lab/TreeItem";
 // TODO: ブック単位でのインポートの実装
 // import Checkbox from "@material-ui/core/Checkbox";
-import { InfoOutlined, EditOutlined } from "@material-ui/icons";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import CourseChip from "$atoms/CourseChip";
 import BookChildrenTree from "$molecules/BookChildrenTree";
 import useTreeItemStyle from "$styles/treeItem";
@@ -64,11 +65,11 @@ export default function BookTree(props: Props) {
           )*/}
           {book.name}
           <IconButton size="small" onClick={handle(onBookInfoClick)}>
-            <InfoOutlined />
+            <InfoOutlinedIcon />
           </IconButton>
           {onBookEditClick && (
             <IconButton size="small" onClick={handle(onBookEditClick)}>
-              <EditOutlined />
+              <EditOutlinedIcon />
             </IconButton>
           )}
           {book.ltiResourceLinks.map((ltiResourceLink) => (

--- a/components/molecules/BookTree.tsx
+++ b/components/molecules/BookTree.tsx
@@ -2,13 +2,23 @@ import IconButton from "@material-ui/core/IconButton";
 import TreeItem from "@material-ui/lab/TreeItem";
 // TODO: ブック単位でのインポートの実装
 // import Checkbox from "@material-ui/core/Checkbox";
+import Tooltip from "@material-ui/core/Tooltip";
+import PublicIcon from "@material-ui/icons/Public";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
+import { makeStyles } from "@material-ui/core/styles";
 import CourseChip from "$atoms/CourseChip";
 import BookChildrenTree from "$molecules/BookChildrenTree";
 import useTreeItemStyle from "$styles/treeItem";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
+import { gray } from "$theme/colors";
+
+const useStyles = makeStyles((theme) => ({
+  shared: {
+    margin: theme.spacing(0, 0.5),
+  },
+}));
 
 type Props = {
   book: BookSchema;
@@ -32,6 +42,7 @@ export default function BookTree(props: Props) {
     selectedIndexes,
     isTopicEditable,
   } = props;
+  const classes = useStyles();
   const treeItemClasses = useTreeItemStyle();
   const nodeId = `${book.id}`;
   const handle = (handler?: (book: BookSchema) => void) => (
@@ -64,6 +75,15 @@ export default function BookTree(props: Props) {
           />
           )*/}
           {book.name}
+          {book.shared && (
+            <Tooltip title="教員に共有しています">
+              <PublicIcon
+                className={classes.shared}
+                fontSize="small"
+                htmlColor={gray[700]}
+              />
+            </Tooltip>
+          )}
           <IconButton size="small" onClick={handle(onBookInfoClick)}>
             <InfoOutlinedIcon />
           </IconButton>

--- a/components/organisms/BookAccordion.tsx
+++ b/components/organisms/BookAccordion.tsx
@@ -7,6 +7,8 @@ import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Divider from "@material-ui/core/Divider";
 import TreeView from "@material-ui/lab/TreeView";
+import Tooltip from "@material-ui/core/Tooltip";
+import PublicIcon from "@material-ui/icons/Public";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
@@ -21,8 +23,12 @@ import { TopicSchema } from "$server/models/topic";
 import useAccordionStyle from "styles/accordion";
 import useAccordionSummaryStyle from "styles/accordionSummary";
 import useAccordionDetailStyle from "styles/accordionDetail";
+import { gray } from "$theme/colors";
 
 const useStyles = makeStyles((theme) => ({
+  shared: {
+    margin: theme.spacing(0, 1),
+  },
   chips: {
     padding: theme.spacing(0, 2),
     "& > *": {
@@ -91,6 +97,15 @@ export default function BookAccordion(props: Props) {
         expandIcon={<ExpandMoreIcon />}
       >
         <Typography variant="h6">{book.name}</Typography>
+        {book.shared && (
+          <Tooltip title="教員に共有しています">
+            <PublicIcon
+              className={classes.shared}
+              fontSize="small"
+              htmlColor={gray[700]}
+            />
+          </Tooltip>
+        )}
         <IconButton onClick={handleInfoClick}>
           <InfoOutlinedIcon />
         </IconButton>

--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -6,6 +6,8 @@ import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Radio from "@material-ui/core/Radio";
+import Tooltip from "@material-ui/core/Tooltip";
+import PublicIcon from "@material-ui/icons/Public";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
@@ -16,7 +18,7 @@ import BookItemDialog from "$organisms/BookItemDialog";
 import useCardStyle from "styles/card";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
-import { primary } from "theme/colors";
+import { primary, gray } from "theme/colors";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,6 +38,9 @@ const useStyles = makeStyles((theme) => ({
   },
   checkBox: {
     marginLeft: theme.spacing(-1.5),
+  },
+  shared: {
+    margin: theme.spacing(0, 1),
   },
   chips: {
     "& > *": {
@@ -91,6 +96,15 @@ export default function BookPreview(props: Props) {
             {...radioProps}
           />
           {book.name}
+          {book.shared && (
+            <Tooltip title="教員に共有しています">
+              <PublicIcon
+                className={classes.shared}
+                fontSize="small"
+                htmlColor={gray[700]}
+              />
+            </Tooltip>
+          )}
           <IconButton onClick={handleInfoClick}>
             <InfoOutlinedIcon />
           </IconButton>

--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -6,7 +6,8 @@ import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Radio from "@material-ui/core/Radio";
-import { InfoOutlined, EditOutlined } from "@material-ui/icons";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
 import Video from "$organisms/Video";
 import CourseChip from "$atoms/CourseChip";
@@ -91,11 +92,11 @@ export default function BookPreview(props: Props) {
           />
           {book.name}
           <IconButton onClick={handleInfoClick}>
-            <InfoOutlined />
+            <InfoOutlinedIcon />
           </IconButton>
           {onEditClick && (
             <IconButton color="primary" onClick={handle(onEditClick)}>
-              <EditOutlined />
+              <EditOutlinedIcon />
             </IconButton>
           )}
         </Typography>

--- a/components/organisms/TopicPreview.tsx
+++ b/components/organisms/TopicPreview.tsx
@@ -15,9 +15,9 @@ import { primary, gray } from "theme/colors";
 const useCardStyles = makeStyles((theme) => ({
   root: {
     border: `1px solid ${gray[400]}`,
-    borderRadius: "12px",
+    borderRadius: 12,
     boxShadow: "none",
-    padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
+    padding: theme.spacing(1, 2),
   },
 }));
 
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(-1.5),
   },
   video: {
-    margin: `0 ${theme.spacing(-2)}px`,
+    margin: theme.spacing(0, -2),
   },
   description: {
     color: gray[700],

--- a/components/organisms/TopicPreview.tsx
+++ b/components/organisms/TopicPreview.tsx
@@ -5,6 +5,8 @@ import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Checkbox from "@material-ui/core/Checkbox";
+import Tooltip from "@material-ui/core/Tooltip";
+import PublicIcon from "@material-ui/icons/Public";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
 import Video from "$organisms/Video";
@@ -44,6 +46,10 @@ const useStyles = makeStyles((theme) => ({
   },
   checkbox: {
     marginLeft: theme.spacing(-1.5),
+  },
+  shared: {
+    verticalAlign: "middle",
+    marginLeft: theme.spacing(0.5),
   },
   editButton: {
     marginRight: theme.spacing(-1.5),
@@ -123,6 +129,15 @@ export default function TopicPreview(props: Props) {
           {...checkboxProps}
         >
           {topic.name}
+          {topic.shared && (
+            <Tooltip title="教員に共有しています">
+              <PublicIcon
+                className={classes.shared}
+                fontSize="small"
+                htmlColor={gray[700]}
+              />
+            </Tooltip>
+          )}
         </CheckableTitle>
         {onTopicEditClick && (
           <IconButton


### PR DESCRIPTION
close #284

- マイブック
- マイトピック
- LTIリソースとのリンク
- ブックからインポート
- インポート

の箇所で、共有中のブック・トピックは専用のインジケータが表示されるようにしました (クリッカブルな部品との識別があまりよくないようにみえますが、その点は別途改善したいです)

![image](https://user-images.githubusercontent.com/9744580/110739974-8808e180-8275-11eb-8ff7-9510b6f89020.png)
