### PR TITLE
feat: 保存は保存ボタンで&リセットできるように&変更未保存はアラートする

### DIFF
--- a/styles/card.ts
+++ b/styles/card.ts
@@ -4,9 +4,9 @@ import gray from "theme/colors/gray";
 const card = makeStyles((theme) => ({
   root: {
     border: `1px solid ${gray[400]}`,
-    borderRadius: "12px",
+    borderRadius: 12,
     boxShadow: "none",
-    padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+    padding: theme.spacing(2, 3),
   },
 }));
 

--- a/utils/useSortableSectionsProps.ts
+++ b/utils/useSortableSectionsProps.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import type { SectionSchema } from "$server/models/book/section";
+
+function useSortableSectionsProps(
+  sections: SectionSchema[],
+  onSubmit: (sections: SectionSchema[]) => void
+) {
+  const [sortable, setSortable] = useState(false);
+  const [inProgress, setInProgress] = useState(false);
+  const handleSortableChange = () => setSortable(!sortable);
+  const [sortableSections, setSortableSections] = useState<SectionSchema[]>([]);
+  useEffect(() => {
+    setSortableSections(sections);
+  }, [setSortableSections, sections]);
+  const handleSectionsUpdate = (sortableSections: SectionSchema[]) => {
+    setSortableSections(sortableSections);
+    setInProgress(true);
+  };
+  const handleSectionsReset = () => {
+    setSortableSections(sections);
+    setInProgress(false);
+  };
+  const handleSectionsSave = () => {
+    onSubmit(sortableSections);
+    setInProgress(false);
+    setSortable(false);
+  };
+  const handleSectionCreate = () => {
+    setSortableSections([
+      ...sortableSections,
+      {
+        id: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+        name: null,
+        topics: [],
+      },
+    ]);
+    setInProgress(true);
+  };
+  return {
+    sortable,
+    sortableSections,
+    inProgress,
+    handleSortableChange,
+    handleSectionsUpdate,
+    handleSectionsReset,
+    handleSectionsSave,
+    handleSectionCreate,
+  };
+}
+
+export default useSortableSectionsProps;


### PR DESCRIPTION
closes #259 #264 #265 #266

- 「並び替え・セクションの編集」は「セクションの編集」という文言に
- ボタンではなくスイッチで切り替えるように
- モード切替時に永続化ではなく、保存ボタンで永続化に (#264 ではなく #265 で実装)
- 編集中にリセットできるように
- 編集未保存時は保存していないことをアラートするように

![image](https://user-images.githubusercontent.com/9744580/110756900-1b4e1100-828e-11eb-873a-8d7ea92166ed.png)
