### PR TITLE
feat: 共有インジケーターをコンポーネントに切り出し&アイコン差し替え

### DIFF
--- a/components/atoms/SharedIndicator.stories.tsx
+++ b/components/atoms/SharedIndicator.stories.tsx
@@ -1,0 +1,5 @@
+export default { title: "atoms/SharedIndicator" };
+
+import SharedIndicator from "./SharedIndicator";
+
+export const Default = () => <SharedIndicator />;

--- a/components/atoms/SharedIndicator.tsx
+++ b/components/atoms/SharedIndicator.tsx
@@ -1,0 +1,20 @@
+import Tooltip from "@material-ui/core/Tooltip";
+import PeopleIcon from "@material-ui/icons/People";
+import { gray } from "$theme/colors";
+
+type Props = {
+  className?: string;
+};
+
+export default function SharedIndicator(props: Props) {
+  const { className } = props;
+  return (
+    <Tooltip title="教員に共有しています">
+      <PeopleIcon
+        className={className}
+        fontSize="small"
+        htmlColor={gray[700]}
+      />
+    </Tooltip>
+  );
+}

--- a/components/molecules/BookChildrenTree.tsx
+++ b/components/molecules/BookChildrenTree.tsx
@@ -2,15 +2,13 @@ import { ReactNode, MouseEvent } from "react";
 import IconButton from "@material-ui/core/IconButton";
 import TreeItem from "@material-ui/lab/TreeItem";
 import Checkbox from "@material-ui/core/Checkbox";
-import Tooltip from "@material-ui/core/Tooltip";
-import PublicIcon from "@material-ui/icons/Public";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
+import SharedIndicator from "$atoms/SharedIndicator";
 import useTreeItemStyle from "$styles/treeItem";
 import { SectionSchema } from "$server/models/book/section";
 import { TopicSchema } from "$server/models/topic";
 import { getOutline } from "$utils/outline";
-import { gray } from "$theme/colors";
 
 const useStyles = makeStyles((theme) => ({
   shared: {
@@ -136,13 +134,7 @@ export default function BookChildrenTree(props: Props) {
                     {getOutline(section, sectionIndex, topicIndex) + " "}
                     {topic.name}
                     {topic.shared && (
-                      <Tooltip title="教員に共有しています">
-                        <PublicIcon
-                          className={classes.shared}
-                          fontSize="small"
-                          htmlColor={gray[700]}
-                        />
-                      </Tooltip>
+                      <SharedIndicator className={classes.shared} />
                     )}
                     {isTopicEditable?.(topic) && onItemEditClick && (
                       <IconButton

--- a/components/molecules/BookTree.tsx
+++ b/components/molecules/BookTree.tsx
@@ -2,17 +2,15 @@ import IconButton from "@material-ui/core/IconButton";
 import TreeItem from "@material-ui/lab/TreeItem";
 // TODO: ブック単位でのインポートの実装
 // import Checkbox from "@material-ui/core/Checkbox";
-import Tooltip from "@material-ui/core/Tooltip";
-import PublicIcon from "@material-ui/icons/Public";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
 import CourseChip from "$atoms/CourseChip";
+import SharedIndicator from "$atoms/SharedIndicator";
 import BookChildrenTree from "$molecules/BookChildrenTree";
 import useTreeItemStyle from "$styles/treeItem";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
-import { gray } from "$theme/colors";
 
 const useStyles = makeStyles((theme) => ({
   shared: {
@@ -75,15 +73,7 @@ export default function BookTree(props: Props) {
           />
           )*/}
           {book.name}
-          {book.shared && (
-            <Tooltip title="教員に共有しています">
-              <PublicIcon
-                className={classes.shared}
-                fontSize="small"
-                htmlColor={gray[700]}
-              />
-            </Tooltip>
-          )}
+          {book.shared && <SharedIndicator className={classes.shared} />}
           <IconButton size="small" onClick={handle(onBookInfoClick)}>
             <InfoOutlinedIcon />
           </IconButton>

--- a/components/organisms/BookAccordion.tsx
+++ b/components/organisms/BookAccordion.tsx
@@ -7,8 +7,6 @@ import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Divider from "@material-ui/core/Divider";
 import TreeView from "@material-ui/lab/TreeView";
-import Tooltip from "@material-ui/core/Tooltip";
-import PublicIcon from "@material-ui/icons/Public";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
@@ -17,13 +15,13 @@ import { makeStyles } from "@material-ui/core/styles";
 import BookChildrenTree from "$molecules/BookChildrenTree";
 import CourseChip from "$atoms/CourseChip";
 import Item from "$atoms/Item";
+import SharedIndicator from "$atoms/SharedIndicator";
 import BookItemDialog from "$organisms/BookItemDialog";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
 import useAccordionStyle from "styles/accordion";
 import useAccordionSummaryStyle from "styles/accordionSummary";
 import useAccordionDetailStyle from "styles/accordionDetail";
-import { gray } from "$theme/colors";
 
 const useStyles = makeStyles((theme) => ({
   shared: {
@@ -97,15 +95,7 @@ export default function BookAccordion(props: Props) {
         expandIcon={<ExpandMoreIcon />}
       >
         <Typography variant="h6">{book.name}</Typography>
-        {book.shared && (
-          <Tooltip title="教員に共有しています">
-            <PublicIcon
-              className={classes.shared}
-              fontSize="small"
-              htmlColor={gray[700]}
-            />
-          </Tooltip>
-        )}
+        {book.shared && <SharedIndicator className={classes.shared} />}
         <IconButton onClick={handleInfoClick}>
           <InfoOutlinedIcon />
         </IconButton>

--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -6,19 +6,18 @@ import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Radio from "@material-ui/core/Radio";
-import Tooltip from "@material-ui/core/Tooltip";
-import PublicIcon from "@material-ui/icons/Public";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
 import Video from "$organisms/Video";
 import CourseChip from "$atoms/CourseChip";
 import Item from "$atoms/Item";
+import SharedIndicator from "$atoms/SharedIndicator";
 import BookItemDialog from "$organisms/BookItemDialog";
 import useCardStyle from "styles/card";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
-import { primary, gray } from "theme/colors";
+import { primary } from "theme/colors";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -96,15 +95,7 @@ export default function BookPreview(props: Props) {
             {...radioProps}
           />
           {book.name}
-          {book.shared && (
-            <Tooltip title="教員に共有しています">
-              <PublicIcon
-                className={classes.shared}
-                fontSize="small"
-                htmlColor={gray[700]}
-              />
-            </Tooltip>
-          )}
+          {book.shared && <SharedIndicator className={classes.shared} />}
           <IconButton onClick={handleInfoClick}>
             <InfoOutlinedIcon />
           </IconButton>

--- a/components/organisms/TopicPreview.tsx
+++ b/components/organisms/TopicPreview.tsx
@@ -5,12 +5,11 @@ import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import Checkbox from "@material-ui/core/Checkbox";
-import Tooltip from "@material-ui/core/Tooltip";
-import PublicIcon from "@material-ui/icons/Public";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
 import Video from "$organisms/Video";
 import Item from "$atoms/Item";
+import SharedIndicator from "$atoms/SharedIndicator";
 import { TopicSchema } from "$server/models/topic";
 import { primary, gray } from "theme/colors";
 
@@ -129,15 +128,7 @@ export default function TopicPreview(props: Props) {
           {...checkboxProps}
         >
           {topic.name}
-          {topic.shared && (
-            <Tooltip title="教員に共有しています">
-              <PublicIcon
-                className={classes.shared}
-                fontSize="small"
-                htmlColor={gray[700]}
-              />
-            </Tooltip>
-          )}
+          {topic.shared && <SharedIndicator className={classes.shared} />}
         </CheckableTitle>
         {onTopicEditClick && (
           <IconButton


### PR DESCRIPTION
アイコンは、変更前だと自分以外のある集団に共有しているというより、全世界に公開しているようなイメージになっており、より適切なものがあるのではないかというフィードバックをいただいての変更です

![image](https://user-images.githubusercontent.com/9744580/110878666-f48beb00-831e-11eb-8974-d887b406d95a.png)
