### PR TITLE
feat: 学習時間の自動集計・自動補完

### DIFF
--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -5,6 +5,7 @@ import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
 import Video from "$organisms/Video";
 import Item from "$atoms/Item";
+import languages from "$utils/languages";
 
 function formatInterval(start: Date | number, end: Date | number) {
   const duration = intervalToDuration({ start, end });
@@ -61,11 +62,13 @@ export default function TopicViewerContent(props: Props) {
           学習時間 {formatInterval(0, topic.timeRequired * 1000) || "10秒未満"}
         </Typography>
         <Typography className={classes.title} variant="h6">
-          日本語
+          {languages[topic.language]}
         </Typography>
+        {/* TODO: トピックがライセンスをプロパティに持つようになったら表示してください
         <Typography className={classes.title} variant="h6">
           ライセンス
         </Typography>
+        */}
       </div>
       <div className={classes.items}>
         <Item itemKey="作成日" value={format(topic.createdAt, "yyyy.MM.dd")} />

--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -48,7 +48,6 @@ export default function BookForm(props: Props) {
     description: book?.description ?? "",
     shared: Boolean(book?.shared),
     language: book?.language ?? Object.getOwnPropertyNames(languages)[0],
-    timeRequired: book?.timeRequired,
     sections: book?.sections,
   };
   const { handleSubmit, register, control } = useForm<BookProps>({
@@ -107,18 +106,6 @@ export default function BookForm(props: Props) {
             ))}
           </TextField>
         )}
-      />
-      <TextField
-        label="学習時間 (秒)"
-        name="timeRequired"
-        type="number"
-        inputProps={{
-          ref: register({
-            setValueAs: (value) => (value === "" ? null : +value),
-            min: 0,
-          }),
-          min: 0,
-        }}
       />
       <TextField
         label="解説"

--- a/components/organisms/BookItemDialog.tsx
+++ b/components/organisms/BookItemDialog.tsx
@@ -7,6 +7,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import Item from "$atoms/Item";
 import { BookSchema } from "$server/models/book";
 import useCardStyles from "$styles/card";
+import languages from "$utils/languages";
 
 function formatInterval(start: Date | number, end: Date | number) {
   const duration = intervalToDuration({ start, end });
@@ -39,6 +40,7 @@ export default function BookItemDialog(props: Props) {
   const cardClasses = useCardStyles();
   const classes = useStyles();
   const { book, open, onClose } = props;
+  const timeRequired = formatInterval(0, (book.timeRequired ?? 0) * 1000) || "10秒未満"
   return (
     <Dialog
       open={open}
@@ -52,15 +54,16 @@ export default function BookItemDialog(props: Props) {
         </Typography>
         <div className={classes.items}>
           <Typography className={classes.title} variant="h6">
-            学習時間
-            {formatInterval(0, book?.timeRequired ?? 0 * 1000) || "10秒未満"}
+            学習時間 {timeRequired}
           </Typography>
           <Typography className={classes.title} variant="h6">
-            日本語
+            {languages[book.language]}
           </Typography>
+          {/* TODO: ブックがライセンスをプロパティに持つようになったら表示してください
           <Typography className={classes.title} variant="h6">
             ライセンス
           </Typography>
+          */}
         </div>
         <div className={classes.items}>
           <Item itemKey="作成日" value={format(book.createdAt, "yyyy.MM.dd")} />

--- a/components/organisms/BookItemDialog.tsx
+++ b/components/organisms/BookItemDialog.tsx
@@ -40,7 +40,8 @@ export default function BookItemDialog(props: Props) {
   const cardClasses = useCardStyles();
   const classes = useStyles();
   const { book, open, onClose } = props;
-  const timeRequired = formatInterval(0, (book.timeRequired ?? 0) * 1000) || "10秒未満"
+  const timeRequired =
+    formatInterval(0, (book.timeRequired ?? 0) * 1000) || "10秒未満";
   return (
     <Dialog
       open={open}

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useCallback, useState } from "react";
 import Card from "@material-ui/core/Card";
 import Checkbox from "@material-ui/core/Checkbox";
 import Button from "@material-ui/core/Button";
@@ -95,11 +95,19 @@ export default function TopicForm(props: Props) {
     language: topic?.language ?? Object.getOwnPropertyNames(languages)[0],
     timeRequired: topic?.timeRequired,
   };
-  const { handleSubmit, register, control } = useForm<
+  const { handleSubmit, register, control, getValues, setValue } = useForm<
     Omit<TopicProps, "resource">
   >({
     defaultValues,
   });
+  const handleDurationChange = useCallback(
+    (duration: number) => {
+      const { timeRequired } = getValues();
+      if (timeRequired > 0) return;
+      setValue("timeRequired", Math.floor(duration));
+    },
+    [getValues, setValue]
+  );
 
   return (
     <>
@@ -178,7 +186,9 @@ export default function TopicForm(props: Props) {
             />
           )}
         />
-        {videoResource && <Video {...videoResource} />}
+        {videoResource && (
+          <Video {...videoResource} onDurationChange={handleDurationChange} />
+        )}
         <Controller
           name="language"
           control={control}

--- a/components/organisms/Video/HlsPlayer.tsx
+++ b/components/organisms/Video/HlsPlayer.tsx
@@ -8,6 +8,7 @@ type PlayerProps = {
   tracks: VideoTrackSchema[];
   autoplay?: boolean;
   onEnded?: () => void;
+  onDurationChange?: (duration: number) => void;
 };
 
 function HlsPlayerBase(props: PlayerProps) {
@@ -24,6 +25,7 @@ function HlsPlayerBase(props: PlayerProps) {
       }}
       tracks={buildTracks(props.tracks)}
       onEnded={props.onEnded}
+      onDurationChange={props.onDurationChange}
     />
   );
 }

--- a/components/organisms/Video/Vimeo.tsx
+++ b/components/organisms/Video/Vimeo.tsx
@@ -6,6 +6,7 @@ import volumePersister from "$utils/volumePersister";
 type VimeoProps = {
   options: Options;
   onEnded?: () => void;
+  onDurationChange?: (duration: number) => void;
 };
 
 const defaultOptions: Options = {
@@ -25,12 +26,15 @@ export function Vimeo(props: VimeoProps) {
     tracking(player);
     volumePersister(player);
     if (props.onEnded) player.on("ended", props.onEnded);
+    if (props.onDurationChange) {
+      player.getDuration().then(props.onDurationChange);
+    }
     return () => {
       // TODO: 要素を取り除くと学習活動の記録のために使われている getPlayed() が resolve しないので残す
       //       メモリリークにつながるので避けたほうが望ましく、学習活動の送信後すみやかに取り除くべき
       player.pause();
       element.style.display = "none";
     };
-  }, [props.options, props.onEnded, tracking]);
+  }, [props.options, props.onEnded, props.onDurationChange, tracking]);
   return <div ref={ref} />;
 }

--- a/components/organisms/Video/VimeoPlayer.tsx
+++ b/components/organisms/Video/VimeoPlayer.tsx
@@ -5,6 +5,7 @@ type PlayerProps = {
   url: string;
   autoplay?: boolean;
   onEnded?: () => void;
+  onDurationChange?: (duration: number) => void;
 };
 
 function VimeoPlayerBase(props: PlayerProps) {
@@ -16,6 +17,7 @@ function VimeoPlayerBase(props: PlayerProps) {
         autoplay: Boolean(props.autoplay),
       }}
       onEnded={props.onEnded}
+      onDurationChange={props.onDurationChange}
     />
   );
 }

--- a/components/organisms/Video/YouTubePlayer.tsx
+++ b/components/organisms/Video/YouTubePlayer.tsx
@@ -8,6 +8,7 @@ type PlayerProps = {
   tracks: VideoTrackSchema[];
   autoplay?: boolean;
   onEnded?: () => void;
+  onDurationChange?: (duration: number) => void;
 };
 
 function YouTubePlayerBase(props: PlayerProps) {
@@ -25,6 +26,7 @@ function YouTubePlayerBase(props: PlayerProps) {
       }}
       tracks={buildTracks(props.tracks)}
       onEnded={props.onEnded}
+      onDurationChange={props.onDurationChange}
     />
   );
 }

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -10,6 +10,7 @@ type VideoProps = Pick<
   className?: string;
   autoplay?: boolean;
   onEnded?: () => void;
+  onDurationChange?: (duration: number) => void;
 };
 
 export default function Video(props: VideoProps) {

--- a/openapi/models/InlineResponse200.ts
+++ b/openapi/models/InlineResponse200.ts
@@ -33,6 +33,12 @@ export interface InlineResponse200 {
     id: string;
     /**
      * 
+     * @type {number}
+     * @memberof InlineResponse200
+     */
+    authorId: number;
+    /**
+     * 
      * @type {string}
      * @memberof InlineResponse200
      */
@@ -75,6 +81,7 @@ export function InlineResponse200FromJSONTyped(json: any, ignoreDiscriminator: b
         
         'consumerId': json['consumerId'],
         'id': json['id'],
+        'authorId': json['authorId'],
         'contextId': json['contextId'],
         'contextTitle': json['contextTitle'],
         'contextLabel': json['contextLabel'],
@@ -94,6 +101,7 @@ export function InlineResponse200ToJSON(value?: InlineResponse200 | null): any {
         
         'consumerId': value.consumerId,
         'id': value.id,
+        'authorId': value.authorId,
         'contextId': value.contextId,
         'contextTitle': value.contextTitle,
         'contextLabel': value.contextLabel,

--- a/openapi/models/InlineResponse2001Books.ts
+++ b/openapi/models/InlineResponse2001Books.ts
@@ -60,6 +60,12 @@ export interface InlineResponse2001Books {
     language?: string;
     /**
      * 
+     * @type {number}
+     * @memberof InlineResponse2001Books
+     */
+    timeRequired?: number;
+    /**
+     * 
      * @type {boolean}
      * @memberof InlineResponse2001Books
      */
@@ -122,6 +128,7 @@ export function InlineResponse2001BooksFromJSONTyped(json: any, ignoreDiscrimina
         'name': !exists(json, 'name') ? undefined : json['name'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'language': !exists(json, 'language') ? undefined : json['language'],
+        'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
         'publishedAt': !exists(json, 'publishedAt') ? undefined : (new Date(json['publishedAt'])),
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
@@ -146,6 +153,7 @@ export function InlineResponse2001BooksToJSON(value?: InlineResponse2001Books | 
         'name': value.name,
         'description': value.description,
         'language': value.language,
+        'timeRequired': value.timeRequired,
         'shared': value.shared,
         'publishedAt': value.publishedAt === undefined ? undefined : (value.publishedAt.toISOString()),
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),

--- a/server/models/book.ts
+++ b/server/models/book.ts
@@ -16,7 +16,6 @@ export type BookProps = {
   name: string;
   description?: string;
   language?: string;
-  timeRequired?: number | null;
   shared?: boolean;
   sections?: SectionProps[];
 };
@@ -32,7 +31,6 @@ const {
   name,
   description,
   language,
-  timeRequired,
   shared,
   publishedAt,
   createdAt,
@@ -46,7 +44,6 @@ export const bookPropsSchema = {
     name,
     description,
     language: { ...language, nullable: true },
-    timeRequired: { ...timeRequired, nullable: true },
     shared: { ...shared, nullable: true },
     sections: {
       type: "array",
@@ -62,7 +59,7 @@ export const bookSchema = {
     name,
     description,
     language,
-    timeRequired,
+    timeRequired: { type: "integer", nullable: true },
     shared,
     publishedAt,
     createdAt,

--- a/server/utils/book/aggregateTimeRequired.ts
+++ b/server/utils/book/aggregateTimeRequired.ts
@@ -1,0 +1,23 @@
+import { BookProps } from "$server/models/book";
+import prisma from "$server/utils/prisma";
+
+/**
+ * 学習時間の集計
+ * 各セクションに含まれるすべてのトピックの学習時間の合計を返します
+ * @param book 計算対象のブック
+ * @return 学習時間 (秒)
+ */
+async function aggregateTimeRequired(
+  book: Pick<BookProps, "sections">
+): Promise<number> {
+  const ids =
+    book.sections?.flatMap(({ topics }) => topics.map(({ id }) => id)) ?? [];
+  const topics = await prisma.topic.findMany({
+    where: { id: { in: ids } },
+    select: { timeRequired: true },
+  });
+  const total = topics.reduce((acc, { timeRequired }) => acc + timeRequired, 0);
+  return Math.floor(total);
+}
+
+export default aggregateTimeRequired;

--- a/server/utils/book/createBook.ts
+++ b/server/utils/book/createBook.ts
@@ -1,6 +1,7 @@
 import { UserSchema } from "$server/models/user";
 import { BookProps, BookSchema } from "$server/models/book";
 import prisma from "$server/utils/prisma";
+import aggregateTimeRequired from "./aggregateTimeRequired";
 import findBook from "./findBook";
 import sectionCreateInput from "./sectionCreateInput";
 
@@ -8,11 +9,13 @@ async function createBook(
   authorId: UserSchema["id"],
   book: BookProps
 ): Promise<BookSchema | undefined> {
+  const timeRequired = await aggregateTimeRequired(book);
   const sectionsCreateInput = book.sections?.map(sectionCreateInput) ?? [];
 
   const { id } = await prisma.book.create({
     data: {
       ...book,
+      timeRequired,
       details: {},
       author: { connect: { id: authorId } },
       sections: { create: sectionsCreateInput },

--- a/server/utils/book/updateBook.ts
+++ b/server/utils/book/updateBook.ts
@@ -2,6 +2,7 @@ import { Prisma, User, Book } from "@prisma/client";
 import { BookProps, BookSchema } from "$server/models/book";
 import { SectionProps } from "$server/models/book/section";
 import prisma from "$server/utils/prisma";
+import aggregateTimeRequired from "./aggregateTimeRequired";
 import findBook from "./findBook";
 import sectionCreateInput from "./sectionCreateInput";
 import cleanupSections from "./cleanupSections";
@@ -17,14 +18,17 @@ function upsertSections(bookId: Book["id"], sections: SectionProps[]) {
 
 async function updateBook(
   authorId: User["id"],
-  { sections, id, ...book }: Pick<Book, "id"> & BookProps
+  { id, ...book }: Pick<Book, "id"> & BookProps
 ): Promise<BookSchema | undefined> {
+  const timeRequired = await aggregateTimeRequired(book);
   const cleanup = cleanupSections(id);
+  const { sections, ...other } = book;
   const upsert = upsertSections(id, sections ?? []);
   const update = (prisma.book.update({
     where: { id },
     data: {
-      ...book,
+      ...other,
+      timeRequired,
       author: { connect: { id: authorId } },
       updatedAt: new Date(),
     },


### PR DESCRIPTION
close: #33

- feat: トピックの学習時間の自動入力機能 - トピックの学習時間がまだ入力されていない、または無効値のとき、動画の情報をもとに自動入力されます - YouTube, Wowza については再生開始後取得
- fix: ブックの詳細のダイアログの表示項目の誤りを修正
- feat: ブックの学習時間の自動集計 - ブック作成・編集画面から学習時間フィールドを取り除く - Swagger フォーマットの修正 - yarn build:openapi
- fix: トピックの詳細の表示の誤りを修正

本PRにて各トピックの学習時間の合計を集計しブックの学習時間とする機能が加わりました。
それにともないブック作成・編集時の学習時間のフィールドは不要(少なくとも重要でない)と判断し取り除きました。(もし仮にブック作成・編集時の学習時間のフィールドを残すとして、その場合、自動集計の結果と手動入力の結果の不整合が発生しうる。その対処が必要となります。)
もし問題あるようであれば修正します。 > @horimasumi 