### PR TITLE
fix: VercelでSwagger UIにアクセスできない不具合の修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "build:server": "yarn --cwd server build:app",
     "build:openapi": "openapi-generator-cli generate -i http://localhost:8080/api/v2/swagger/json -g typescript-fetch -o openapi",
     "start": "NODE_ENV=production node server/dist/index.js",
-    "vercel-build": "yarn build && rm -rf public/api/v2/swagger && mkdir -p public/api/v2/swagger && cp -a server/dist/static public/api/v2/swagger/static",
+    "vercel-build": "run-s build:prisma build:next build:server && rm -rf public/api/v2/swagger && mkdir -p public/api/v2/swagger && cp -a server/dist/static public/api/v2/swagger/static",
     "format": "prettier --write .",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
fix #218

Vercelでのビルドプロセスから余計な build:export を取り除きました。

https://chibi-ch-i-lo-git-fix-vercel-swagger-ui-ties-makimura.vercel.app/api/v2/swagger/static/index.html にアクセスできることを確認。