### PR TITLE
fix: セッションのエラーが適切にハンドリングされず読み込み中になり続ける問題の修正

### DIFF
--- a/store/session.ts
+++ b/store/session.ts
@@ -30,19 +30,19 @@ const sessionAtom = atom<SessionWithState>({
 
 const updateSessionAtom = atom<
   null,
-  { session: SessionSchema; error: boolean }
+  { session: SessionSchema | undefined; error: boolean }
 >(null, (get, set, { session, error }) => {
-  const isAdministrator = isAdministratorSession(session);
-  const isInstructor = isInstructorSession(session);
+  const isAdministrator = Boolean(session && isAdministratorSession(session));
+  const isInstructor = Boolean(session && isInstructorSession(session));
   const sessionWithState = {
     session,
     isAdministrator,
     isInstructor,
     isTopicEditable(topic: Pick<TopicSchema, "creator">) {
-      return isAdministrator || topicCreateBy(topic, session.user);
+      return isAdministrator || topicCreateBy(topic, session?.user);
     },
     isBookEditable(book: Pick<BookSchema, "author">) {
-      return isAdministrator || bookCreateBy(book, session.user);
+      return isAdministrator || bookCreateBy(book, session?.user);
     },
     error,
   };

--- a/utils/session.ts
+++ b/utils/session.ts
@@ -15,12 +15,10 @@ export function useSessionInit() {
   });
   const [state, update] = useUpdateSessionAtom();
   useEffect(() => {
-    if (data) {
-      update({
-        session: data,
-        error: Boolean(error),
-      });
-    }
+    update({
+      session: data,
+      error: Boolean(error),
+    });
   }, [data, error, update]);
 
   return state;


### PR DESCRIPTION
セッションを持たずアクセスしたときエラー画面が表示されるように修正しました。
