### PR TITLE
fix: `yarn --cwd server migrate:reset` の不具合の修正

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "build:app": "ncc build -t --no-asset-builds --target es2020",
     "build:prisma": "prisma generate",
     "migrate": "prisma migrate deploy --preview-feature",
-    "migrate:reset": "prisma migrate reset --preview-feature",
+    "migrate:reset": "prisma migrate reset --skip-seed --preview-feature",
     "seed": "ncc run -t --no-asset-builds prisma/seed.ts",
     "start": "NODE_ENV=production node dist/index.js"
   },


### PR DESCRIPTION
`yarn --cwd server migrate:reset` を実行する際にprisma/seed.tsが自動実行されるが失敗するので`--skip-seed` フラグでオプトアウト。
https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-reset
