### PR TITLE
feat: トピック・セクションの省略表示

### DIFF
--- a/components/molecules/BookChildrenTree.tsx
+++ b/components/molecules/BookChildrenTree.tsx
@@ -8,7 +8,7 @@ import SharedIndicator from "$atoms/SharedIndicator";
 import useTreeItemStyle from "$styles/treeItem";
 import { SectionSchema } from "$server/models/book/section";
 import { TopicSchema } from "$server/models/topic";
-import { getOutline } from "$utils/outline";
+import { isNamedSection, getOutlineNumber } from "$utils/outline";
 
 const useStyles = makeStyles((theme) => ({
   shared: {
@@ -41,7 +41,7 @@ function SectionTree({
     handler?.(nodeId);
   };
   */
-  if (section.name == null && section.topics.length < 2) return <>{children}</>;
+  if (!isNamedSection(section)) return <>{children}</>;
   return (
     <TreeItem
       nodeId={nodeId}
@@ -60,7 +60,7 @@ function SectionTree({
               }}
             />
           )*/}
-          {getOutline(section, sectionIndex) + " "}
+          {getOutlineNumber(section, sectionIndex) + " "}
           {section.name ?? "無名のセクション"}
         </>
       }
@@ -131,7 +131,7 @@ export default function BookChildrenTree(props: Props) {
                         }}
                       />
                     )}
-                    {getOutline(section, sectionIndex, topicIndex) + " "}
+                    {getOutlineNumber(section, sectionIndex, topicIndex) + " "}
                     {topic.name}
                     {topic.shared && (
                       <SharedIndicator className={classes.shared} />

--- a/components/organisms/BookChildren.tsx
+++ b/components/organisms/BookChildren.tsx
@@ -11,7 +11,7 @@ import { ExpandLess, ExpandMore, EditOutlined } from "@material-ui/icons";
 import { TopicSchema } from "$server/models/topic";
 import { SectionSchema } from "$server/models/book/section";
 import { primary } from "$theme/colors";
-import { getOutline } from "$utils/outline";
+import { isNamedSection, getOutlineNumber } from "$utils/outline";
 
 function Section({
   section,
@@ -26,13 +26,13 @@ function Section({
   open: boolean;
   children: ReactNode;
 }) {
-  if (section.name == null && section.topics.length < 2) return <>{children}</>;
+  if (!isNamedSection(section)) return <>{children}</>;
 
   return (
     <>
       <ListItem button onClick={onSectionClick}>
         <ListItemText>
-          {getOutline(section, sectionItemIndex) + " "}
+          {getOutlineNumber(section, sectionItemIndex) + " "}
           {section.name ?? "無名のセクション"}
         </ListItemText>
         {open ? <ExpandLess /> : <ExpandMore />}
@@ -109,7 +109,8 @@ export default function BookChildren(props: Props) {
               onClick={handleItemClick}
             >
               <ListItemText>
-                {getOutline(section, sectionItemIndex, topicItemIndex) + " "}
+                {getOutlineNumber(section, sectionItemIndex, topicItemIndex) +
+                  " "}
                 {topic.name}
               </ListItemText>
               {isTopicEditable(topic) && (

--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -4,7 +4,6 @@ import { format } from "date-fns";
 import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
-import Typography from "@material-ui/core/Typography";
 import Radio from "@material-ui/core/Radio";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
@@ -18,7 +17,7 @@ import useCardStyle from "styles/card";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
 import { getSectionsOutline } from "$utils/outline";
-import { primary } from "$theme/colors";
+import { gray, primary } from "$theme/colors";
 import useLineClampStyles from "$styles/lineClamp";
 
 const useStyles = makeStyles((theme) => ({
@@ -28,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
   },
   left: {
     flex: 1,
+    paddingRight: theme.spacing(1),
   },
   right: {
     flexShrink: 0,
@@ -36,8 +36,13 @@ const useStyles = makeStyles((theme) => ({
   title: {
     display: "flex",
     alignItems: "center",
+    fontWeight: 500,
   },
-  checkBox: {
+  outline: {
+    margin: 0,
+    color: gray[700],
+  },
+  checkbox: {
     marginLeft: theme.spacing(-1.5),
   },
   shared: {
@@ -69,9 +74,14 @@ type Props = Parameters<typeof Radio>[0] & {
 export default function BookPreview(props: Props) {
   const cardClasses = useCardStyle();
   const classes = useStyles();
-  const { clamp: outlineClamp } = useLineClampStyles({
-    fontSize: "0.875rem",
+  const titleClamp = useLineClampStyles({
+    fontSize: "1.25rem",
     lineClamp: 2,
+    lineHeight: 1.6,
+  });
+  const outlineClamp = useLineClampStyles({
+    fontSize: "0.875rem",
+    lineClamp: 3,
     lineHeight: 1.25,
   });
   const { book, onEditClick, checked, ...radioProps } = props;
@@ -88,20 +98,24 @@ export default function BookPreview(props: Props) {
   const handle = (handler?: (book: BookSchema) => void) => () => {
     handler?.(book);
   };
+  const id = `${book.id}`;
   return (
     <Card
       classes={cardClasses}
       className={clsx(classes.root, { [classes.selected]: checked })}
     >
       <div className={classes.left}>
-        <Typography variant="h6" className={classes.title}>
+        <div className={clsx(classes.title, titleClamp.placeholder)}>
           <Radio
-            className={classes.checkBox}
+            className={classes.checkbox}
             color="primary"
             checked={checked}
+            id={id}
             {...radioProps}
           />
-          {book.name}
+          <label className={titleClamp.clamp} htmlFor={id}>
+            {book.name}
+          </label>
           {book.shared && <SharedIndicator className={classes.shared} />}
           <IconButton onClick={handleInfoClick}>
             <InfoOutlinedIcon />
@@ -111,7 +125,7 @@ export default function BookPreview(props: Props) {
               <EditOutlinedIcon />
             </IconButton>
           )}
-        </Typography>
+        </div>
         <div className={classes.chips}>
           {book.ltiResourceLinks.map((ltiResourceLink) => (
             <CourseChip
@@ -125,7 +139,15 @@ export default function BookPreview(props: Props) {
           <Item itemKey="更新日" value={format(book.updatedAt, "yyyy.MM.dd")} />
           <Item itemKey="著者" value={book.author.name} />
         </div>
-        <p className={outlineClamp}>{getSectionsOutline(book.sections)}</p>
+        <p
+          className={clsx(
+            classes.outline,
+            outlineClamp.clamp,
+            outlineClamp.placeholder
+          )}
+        >
+          {getSectionsOutline(book.sections)}
+        </p>
         <Button size="small" color="primary">
           もっと詳しく...
         </Button>

--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import clsx from "clsx";
 import { format } from "date-fns";
 import Button from "@material-ui/core/Button";
@@ -17,7 +17,9 @@ import BookItemDialog from "$organisms/BookItemDialog";
 import useCardStyle from "styles/card";
 import { BookSchema } from "$server/models/book";
 import { TopicSchema } from "$server/models/topic";
-import { primary } from "theme/colors";
+import { getSectionsOutline } from "$utils/outline";
+import { primary } from "$theme/colors";
+import useLineClampStyles from "$styles/lineClamp";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,6 +69,11 @@ type Props = Parameters<typeof Radio>[0] & {
 export default function BookPreview(props: Props) {
   const cardClasses = useCardStyle();
   const classes = useStyles();
+  const { clamp: outlineClamp } = useLineClampStyles({
+    fontSize: "0.875rem",
+    lineClamp: 2,
+    lineHeight: 1.25,
+  });
   const { book, onEditClick, checked, ...radioProps } = props;
   const [topic] = useState<TopicSchema | undefined>(
     book.sections[0]?.topics[0]
@@ -118,21 +125,7 @@ export default function BookPreview(props: Props) {
           <Item itemKey="更新日" value={format(book.updatedAt, "yyyy.MM.dd")} />
           <Item itemKey="著者" value={book.author.name} />
         </div>
-        {book.sections.map((section, sectionIndex) => (
-          <Fragment key={section.id}>
-            {section.name && (
-              <p>
-                {sectionIndex + 1} {section.name}
-              </p>
-            )}
-            {section.topics.map((topic, topicIndex) => (
-              <p key={topic.id}>
-                {sectionIndex + 1}
-                {section.name && `.${topicIndex + 1}`} {topic.name}
-              </p>
-            ))}
-          </Fragment>
-        ))}
+        <p className={outlineClamp}>{getSectionsOutline(book.sections)}</p>
         <Button size="small" color="primary">
           もっと詳しく...
         </Button>

--- a/components/organisms/TopicPreview.tsx
+++ b/components/organisms/TopicPreview.tsx
@@ -3,7 +3,6 @@ import clsx from "clsx";
 import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
-import Typography from "@material-ui/core/Typography";
 import Checkbox from "@material-ui/core/Checkbox";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import { makeStyles } from "@material-ui/core/styles";
@@ -11,7 +10,8 @@ import Video from "$organisms/Video";
 import Item from "$atoms/Item";
 import SharedIndicator from "$atoms/SharedIndicator";
 import { TopicSchema } from "$server/models/topic";
-import { primary, gray } from "theme/colors";
+import { primary, gray } from "$theme/colors";
+import useLineClampStyles from "$styles/lineClamp";
 
 const useCardStyles = makeStyles((theme) => ({
   root: {
@@ -22,33 +22,71 @@ const useCardStyles = makeStyles((theme) => ({
   },
 }));
 
+const useCheckableHeaderStyles = makeStyles((theme) => ({
+  root: {
+    display: "flex",
+    alignItems: "center",
+  },
+  title: {
+    flex: 1,
+    fontWeight: 500,
+  },
+  checkbox: {
+    marginLeft: theme.spacing(-1.5),
+  },
+}));
+
+function CheckableHeader(
+  props: Parameters<typeof Checkbox>[0] & {
+    checkable: boolean;
+    children: ReactNode;
+    title: string;
+  }
+) {
+  const { checkable, children, title, ...checkboxProps } = props;
+  const classes = useCheckableHeaderStyles();
+  const lineClamp = useLineClampStyles({
+    fontSize: "0.875rem",
+    lineClamp: 2,
+    lineHeight: 1.375,
+  });
+
+  if (!checkable)
+    return (
+      <div className={clsx(classes.root, lineClamp.placeholder)}>
+        <h6 className={clsx(classes.title, lineClamp.clamp)}>{title}</h6>
+        {children}
+      </div>
+    );
+
+  return (
+    <div className={clsx(classes.root, lineClamp.placeholder)}>
+      <Checkbox
+        className={classes.checkbox}
+        size="small"
+        color="primary"
+        {...checkboxProps}
+      />
+      <label
+        className={clsx(classes.title, lineClamp.clamp)}
+        htmlFor={checkboxProps.id}
+      >
+        {title}
+      </label>
+      {children}
+    </div>
+  );
+}
+
 const useStyles = makeStyles((theme) => ({
   root: {
     "& > :not(:last-child)": {
       marginBottom: theme.spacing(0.5),
     },
   },
-  header: {
-    display: "flex",
-    height: "calc(0.875rem * 2 * 1.375)",
-    fontSize: "0.875rem",
-    lineHeight: 1.375,
-    alignItems: "center",
-  },
-  title: {
-    flex: 1,
-    maxHeight: "calc(0.875rem * 2 * 1.375)",
-    overflow: "hidden",
-    display: "-webkit-box",
-    WebkitBoxOrient: "vertical",
-    WebkitLineClamp: 2,
-  },
-  checkbox: {
-    marginLeft: theme.spacing(-1.5),
-  },
   shared: {
     verticalAlign: "middle",
-    marginLeft: theme.spacing(0.5),
+    margin: theme.spacing(0, 0.5),
   },
   editButton: {
     marginRight: theme.spacing(-1.5),
@@ -59,41 +97,11 @@ const useStyles = makeStyles((theme) => ({
   description: {
     color: gray[700],
     margin: 0,
-    fontSize: "0.75rem",
-    lineHeight: 1.43,
-    maxHeight: "calc(0.75rem * 2 * 1.43)",
-    overflow: "hidden",
   },
   selected: {
     backgroundColor: primary[50],
   },
 }));
-
-function CheckableTitle(
-  props: Parameters<typeof Checkbox>[0] & {
-    checkable: boolean;
-    children: ReactNode;
-  }
-) {
-  const { checkable, children, ...checkboxProps } = props;
-  const classes = useStyles();
-
-  if (!checkable) return <span className={classes.title}>{children}</span>;
-
-  return (
-    <>
-      <Checkbox
-        className={classes.checkbox}
-        size="small"
-        color="primary"
-        {...checkboxProps}
-      />
-      <label className={classes.title} htmlFor={checkboxProps.id}>
-        {children}
-      </label>
-    </>
-  );
-}
 
 type Props = Parameters<typeof Checkbox>[0] & {
   topic: TopicSchema;
@@ -104,6 +112,11 @@ type Props = Parameters<typeof Checkbox>[0] & {
 export default function TopicPreview(props: Props) {
   const cardClasses = useCardStyles();
   const classes = useStyles();
+  const lineClamp = useLineClampStyles({
+    fontSize: "0.75rem",
+    lineClamp: 2,
+    lineHeight: 1.5,
+  });
   const {
     topic,
     onTopicDetailClick,
@@ -120,16 +133,14 @@ export default function TopicPreview(props: Props) {
       classes={cardClasses}
       className={clsx(classes.root, { [classes.selected]: checked })}
     >
-      <Typography variant="h6" className={classes.header}>
-        <CheckableTitle
-          checkable={checkable}
-          id={`TopicPreview-topic:${topic.id}`}
-          checked={checked}
-          {...checkboxProps}
-        >
-          {topic.name}
-          {topic.shared && <SharedIndicator className={classes.shared} />}
-        </CheckableTitle>
+      <CheckableHeader
+        checkable={checkable}
+        id={`TopicPreview-topic:${topic.id}`}
+        checked={checked}
+        {...checkboxProps}
+        title={topic.name}
+      >
+        {topic.shared && <SharedIndicator className={classes.shared} />}
         {onTopicEditClick && (
           <IconButton
             className={classes.editButton}
@@ -140,12 +151,20 @@ export default function TopicPreview(props: Props) {
             <EditOutlinedIcon />
           </IconButton>
         )}
-      </Typography>
+      </CheckableHeader>
       {"providerUrl" in topic.resource && (
         <Video className={classes.video} {...topic.resource} />
       )}
       <Item itemKey="作成者" value={topic.creator.name} />
-      <p className={classes.description}>{topic.description}</p>
+      <p
+        className={clsx(
+          classes.description,
+          lineClamp.clamp,
+          lineClamp.placeholder
+        )}
+      >
+        {topic.description}
+      </p>
       <Button size="small" color="primary" onClick={handle(onTopicDetailClick)}>
         もっと詳しく...
       </Button>

--- a/styles/lineClamp.ts
+++ b/styles/lineClamp.ts
@@ -1,0 +1,26 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+type Props = {
+  fontSize: string;
+  lineClamp: number;
+  lineHeight: number;
+};
+
+const lineClamp = makeStyles({
+  placeholder: {
+    height: (props: Props) =>
+      `calc(${props.fontSize} * ${props.lineClamp} * ${props.lineHeight})`,
+  },
+  clamp: {
+    fontSize: (props) => props.fontSize,
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: (props: Props) => props.lineClamp,
+    lineHeight: (props: Props) => props.lineHeight,
+    maxHeight: (props: Props) =>
+      `calc(${props.fontSize} * ${props.lineClamp} * ${props.lineHeight})`,
+    overflow: "hidden",
+  },
+});
+
+export default lineClamp;

--- a/utils/outline.ts
+++ b/utils/outline.ts
@@ -1,15 +1,45 @@
 import { SectionSchema } from "$server/models/book/section";
+import { TopicSchema } from "$server/models/topic";
 
-export function getOutline(
+export function isNamedSection(
+  section: Pick<SectionSchema, "name" | "topics">
+): boolean {
+  return Boolean(section.name) || section.topics.length > 1;
+}
+
+export function getOutlineNumber(
   section: Pick<SectionSchema, "name" | "topics">,
   sectionIndex: number,
   topicIndex?: number
 ): string {
   const outlines = [`${sectionIndex + 1}`];
-  const isNamedSection = Boolean(section.name);
-  const hasMultipleTopic = section.topics.length > 1;
-  if (typeof topicIndex === "number" && (isNamedSection || hasMultipleTopic)) {
+  if (typeof topicIndex === "number" && isNamedSection(section)) {
     outlines.push(`${topicIndex + 1}`);
   }
   return outlines.join(".");
+}
+
+export function getTopicOutline(
+  section: SectionSchema,
+  sectionIndex: number,
+  topics: TopicSchema[]
+): string {
+  return topics
+    .map(
+      (topic, topicIndex) =>
+        `${getOutlineNumber(section, sectionIndex, topicIndex)} ${topic.name}`
+    )
+    .join(" ");
+}
+
+export function getSectionsOutline(sections: SectionSchema[]): string {
+  return sections
+    .map((section, sectionIndex) =>
+      !isNamedSection(section)
+        ? getTopicOutline(section, sectionIndex, section.topics)
+        : `${getOutlineNumber(section, sectionIndex)} ${
+            section.name ?? "無名のセクション"
+          } ${getTopicOutline(section, sectionIndex, section.topics)}`
+    )
+    .join(" ");
 }


### PR DESCRIPTION
close #151

- BookPreviewで使用する、章立てとタイトルの組み合わせでstringにする `getSectionsOutline` の実装
- "無名のセクション" などの章立てのロジックを `isNamedSection` に切り出し
- --webkit-line-clampとそのフォールバックのスタイルを生成する `$styles/lineClamp` の実装
- BookPreviewとTopicPreviewのスタイルの調整

![image](https://user-images.githubusercontent.com/9744580/111256855-59b44900-865d-11eb-9a54-7a07e93a88e4.png)

![image](https://user-images.githubusercontent.com/9744580/111256888-6df84600-865d-11eb-8806-a5a5d52a7e94.png)
