### PR TITLE
feat: ブック閲覧周りのスタイル調整

### DIFF
--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { TopicSchema } from "$server/models/topic";
 import { format, formatDuration, intervalToDuration } from "date-fns";
 import { ja } from "date-fns/locale";
@@ -14,13 +15,16 @@ function formatInterval(start: Date | number, end: Date | number) {
 
 const useStyles = makeStyles((theme) => ({
   video: {
-    position: "sticky",
-    top: theme.spacing(-2),
     marginTop: theme.spacing(-2),
     marginRight: theme.spacing(-3),
     marginBottom: theme.spacing(2),
     marginLeft: theme.spacing(-3),
+    "&$sticky": {
+      position: "sticky",
+      top: theme.spacing(-2),
+    },
   },
+  sticky: {},
   title: {
     marginBottom: theme.spacing(2),
   },
@@ -39,16 +43,18 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   topic: TopicSchema;
   onEnded?: () => void;
+  top?: number;
+  sticky?: boolean;
 };
 
 export default function TopicViewerContent(props: Props) {
+  const { topic, onEnded, sticky = false } = props;
   const classes = useStyles();
-  const { topic, onEnded } = props;
   return (
     <>
       {"providerUrl" in topic.resource && (
         <Video
-          className={classes.video}
+          className={clsx(classes.video, { [classes.sticky]: sticky })}
           {...topic.resource}
           onEnded={onEnded}
           autoplay

--- a/components/organisms/TopicPreviewDialog.tsx
+++ b/components/organisms/TopicPreviewDialog.tsx
@@ -19,7 +19,7 @@ export default function TopicPreviewDialog(props: Props) {
       PaperProps={{ classes: cardClasses }}
       fullWidth
     >
-      <TopicViewerContent topic={topic} />
+      <TopicViewerContent topic={topic} sticky />
     </Dialog>
   );
 }

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -19,10 +19,22 @@ import { useSessionAtom } from "$store/session";
 import useContainerStyles from "styles/container";
 
 const useStyles = makeStyles((theme) => ({
-  title: {
+  header: {
+    display: "flex",
+    alignItems: "baseline",
+    width: "100%",
     "& > *": {
       marginRight: theme.spacing(1),
     },
+    "&$mobile": {
+      fontSize: "1.75rem",
+      alignItems: "center",
+    },
+  },
+  title: {
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
   },
   icon: {
     marginRight: theme.spacing(0.5),
@@ -30,18 +42,19 @@ const useStyles = makeStyles((theme) => ({
   inner: {
     display: "grid",
     gap: `${theme.spacing(2)}px`,
-  },
-  innerDesktop: {
-    gridTemplateAreas: `
+    "&$desktop": {
+      gridTemplateAreas: `
       "bookChildren topicViewer"
     `,
-    gridTemplateColumns: "30% 1fr",
-  },
-  innerMobile: {
-    gridTemplateAreas: `
+      gridTemplateColumns: "30% 1fr",
+    },
+    "&$mobile": {
+      gridTemplateAreas: `
       "topicViewer"
       "bookChildren"
-    `,
+
+`,
+    },
   },
   topicViewer: {
     gridArea: "topicViewer",
@@ -49,6 +62,8 @@ const useStyles = makeStyles((theme) => ({
   bookChildren: {
     gridArea: "bookChildren",
   },
+  desktop: {},
+  mobile: {},
 }));
 
 type Props = {
@@ -102,11 +117,11 @@ export default function Book(props: Props) {
       <ActionHeader
         action={
           <Typography
-            className={classes.title}
+            className={clsx(classes.header, { [classes.mobile]: !matches })}
             variant="h4"
             gutterBottom={true}
           >
-            {book?.name}
+            <span className={classes.title}>{book?.name}</span>
             <IconButton onClick={handleInfoClick}>
               <InfoOutlinedIcon />
             </IconButton>
@@ -129,7 +144,7 @@ export default function Book(props: Props) {
       <div
         className={clsx(
           classes.inner,
-          matches ? classes.innerDesktop : classes.innerMobile
+          matches ? classes.desktop : classes.mobile
         )}
       >
         {topic && (


### PR DESCRIPTION
- BookPreviewのmediaQuery周りのスタイルを `&$modifier` に移動
- TopicViewerContentのstickyをpropsで分離
- ブック閲覧の見出しをモバイル表示時フォントを小さく&折り返さず省略

![image](https://user-images.githubusercontent.com/9744580/111272359-deab5c80-8675-11eb-9b76-7cf11fc05ae7.png)

>  TopicViewerContentのstickyをpropsで分離

TopicViewerにもposition: stickyが効いていたのですが、実際にはブック閲覧ページにてstickyのスクロール追従が機能していなかった(TopicViewerに対して `overflow: visible` の設定が必要)でした。機能していないスタイルが当たっている状態は改善すべき立ったので取り除かれるようにしました