### PR TITLE
fix: 自動切り換えの時 changepage イベントログが得られない不具合の修正

### DIFF
--- a/components/organisms/Video/HlsPlayer.tsx
+++ b/components/organisms/Video/HlsPlayer.tsx
@@ -7,8 +7,6 @@ type PlayerProps = {
   url: string;
   tracks: VideoTrackSchema[];
   autoplay?: boolean;
-  onEnded?: () => void;
-  onDurationChange?: (duration: number) => void;
 };
 
 function HlsPlayerBase(props: PlayerProps) {
@@ -24,8 +22,6 @@ function HlsPlayerBase(props: PlayerProps) {
         autoplay: props.autoplay,
       }}
       tracks={buildTracks(props.tracks)}
-      onEnded={props.onEnded}
-      onDurationChange={props.onDurationChange}
     />
   );
 }

--- a/components/organisms/Video/VideoJs.tsx
+++ b/components/organisms/Video/VideoJs.tsx
@@ -9,8 +9,6 @@ import volumePersister from "$utils/volumePersister";
 type VideoJsProps = {
   options: VideoJsPlayerOptions;
   tracks?: videojs.TextTrackOptions[];
-  onEnded?: () => void;
-  onDurationChange?: (duration: number) => void;
 };
 
 const defaultOptions: VideoJsPlayerOptions = {
@@ -25,12 +23,7 @@ const defaultOptions: VideoJsPlayerOptions = {
   languages: { ja },
 };
 
-export function VideoJs({
-  options,
-  tracks,
-  onEnded,
-  onDurationChange,
-}: VideoJsProps) {
+export function VideoJs({ options, tracks }: VideoJsProps) {
   const ref = useRef(document.createElement("div"));
   const tracking = usePlayerTrackingAtom();
   useEffect(() => {
@@ -47,15 +40,6 @@ export function VideoJs({
     player.ready(() => {
       tracking(player);
       volumePersister(player);
-      if (onEnded) player.on("ended", onEnded);
-      if (onDurationChange) {
-        // NOTE: YouTubeの場合、playイベント発火より前だと`player.duration()`に失敗
-        const handlePlay = () => {
-          onDurationChange(player.duration());
-          player.off("play", handlePlay);
-        };
-        player.on("play", handlePlay);
-      }
     });
     return () => {
       // TODO: played() に失敗するので dispose() せず一時停止して保持
@@ -63,7 +47,7 @@ export function VideoJs({
       player.pause();
       current.textContent = "";
     };
-  }, [options, onEnded, onDurationChange, tracking]);
+  }, [options, tracking]);
   const tracksRef = useRef<HTMLTrackElement[]>([]);
   useEffect(() => {
     if (!tracks || tracks.length === 0) return;

--- a/components/organisms/Video/Vimeo.tsx
+++ b/components/organisms/Video/Vimeo.tsx
@@ -5,15 +5,13 @@ import volumePersister from "$utils/volumePersister";
 
 type VimeoProps = {
   options: Options;
-  onEnded?: () => void;
-  onDurationChange?: (duration: number) => void;
 };
 
 const defaultOptions: Options = {
   responsive: true,
 };
 
-export function Vimeo(props: VimeoProps) {
+export function Vimeo({ options }: VimeoProps) {
   const ref = useRef(document.createElement("div"));
   const tracking = usePlayerTrackingAtom();
   useEffect(() => {
@@ -21,20 +19,16 @@ export function Vimeo(props: VimeoProps) {
     ref.current.appendChild(element);
     const player = new Player(element, {
       ...defaultOptions,
-      ...props.options,
+      ...options,
     });
     tracking(player);
     volumePersister(player);
-    if (props.onEnded) player.on("ended", props.onEnded);
-    if (props.onDurationChange) {
-      player.getDuration().then(props.onDurationChange);
-    }
     return () => {
       // TODO: 要素を取り除くと学習活動の記録のために使われている getPlayed() が resolve しないので残す
       //       メモリリークにつながるので避けたほうが望ましく、学習活動の送信後すみやかに取り除くべき
       player.pause();
       element.style.display = "none";
     };
-  }, [props.options, props.onEnded, props.onDurationChange, tracking]);
+  }, [options, tracking]);
   return <div ref={ref} />;
 }

--- a/components/organisms/Video/VimeoPlayer.tsx
+++ b/components/organisms/Video/VimeoPlayer.tsx
@@ -4,8 +4,6 @@ import { Vimeo } from "./Vimeo";
 type PlayerProps = {
   url: string;
   autoplay?: boolean;
-  onEnded?: () => void;
-  onDurationChange?: (duration: number) => void;
 };
 
 function VimeoPlayerBase(props: PlayerProps) {
@@ -16,8 +14,6 @@ function VimeoPlayerBase(props: PlayerProps) {
         // NOTE: boolean に割り当てなければ自動再生されうる
         autoplay: Boolean(props.autoplay),
       }}
-      onEnded={props.onEnded}
-      onDurationChange={props.onDurationChange}
     />
   );
 }

--- a/components/organisms/Video/YouTubePlayer.tsx
+++ b/components/organisms/Video/YouTubePlayer.tsx
@@ -7,8 +7,6 @@ type PlayerProps = {
   url: string;
   tracks: VideoTrackSchema[];
   autoplay?: boolean;
-  onEnded?: () => void;
-  onDurationChange?: (duration: number) => void;
 };
 
 function YouTubePlayerBase(props: PlayerProps) {
@@ -25,8 +23,6 @@ function YouTubePlayerBase(props: PlayerProps) {
         autoplay: props.autoplay,
       }}
       tracks={buildTracks(props.tracks)}
-      onEnded={props.onEnded}
-      onDurationChange={props.onDurationChange}
     />
   );
 }

--- a/components/templates/Book.stories.tsx
+++ b/components/templates/Book.stories.tsx
@@ -35,12 +35,7 @@ function SlideAppBar() {
 }
 
 export const Default = () => {
-  const {
-    updateBook,
-    itemIndex,
-    updateItemIndex,
-    nextItemIndex,
-  } = useBookAtom();
+  const { updateBook, itemIndex, updateItemIndex } = useBookAtom();
   useEffect(() => {
     updateBook(defaultProps.book);
   }, [updateBook]);
@@ -49,14 +44,14 @@ export const Default = () => {
     <Book
       {...defaultProps}
       index={itemIndex}
-      onTopicEnded={nextItemIndex}
+      onTopicEnded={updateItemIndex}
       onItemClick={updateItemIndex}
     />
   );
 };
 
 export const Empty = () => {
-  const { itemIndex, updateItemIndex, nextItemIndex } = useBookAtom();
+  const { itemIndex, updateItemIndex } = useBookAtom();
 
   return (
     <>
@@ -65,7 +60,7 @@ export const Empty = () => {
         {...defaultProps}
         book={null}
         index={itemIndex}
-        onTopicEnded={nextItemIndex}
+        onTopicEnded={updateItemIndex}
         onItemClick={updateItemIndex}
       />
     </>
@@ -73,7 +68,7 @@ export const Empty = () => {
 };
 
 export const EmptySection = () => {
-  const { itemIndex, updateItemIndex, nextItemIndex } = useBookAtom();
+  const { itemIndex, updateItemIndex } = useBookAtom();
 
   return (
     <>
@@ -82,7 +77,7 @@ export const EmptySection = () => {
         {...defaultProps}
         book={{ ...defaultProps.book, sections: [] }}
         index={itemIndex}
-        onTopicEnded={nextItemIndex}
+        onTopicEnded={updateItemIndex}
         onItemClick={updateItemIndex}
       />
     </>
@@ -90,12 +85,7 @@ export const EmptySection = () => {
 };
 
 export const ForInstructor = () => {
-  const {
-    updateBook,
-    itemIndex,
-    updateItemIndex,
-    nextItemIndex,
-  } = useBookAtom();
+  const { updateBook, itemIndex, updateItemIndex } = useBookAtom();
   const [, updateSession] = useUpdateSessionAtom();
   useEffect(() => {
     updateBook(defaultProps.book);
@@ -108,7 +98,7 @@ export const ForInstructor = () => {
       <Book
         {...defaultProps}
         index={itemIndex}
-        onTopicEnded={nextItemIndex}
+        onTopicEnded={updateItemIndex}
         onItemClick={updateItemIndex}
       />
     </>

--- a/components/templates/BookLink.tsx
+++ b/components/templates/BookLink.tsx
@@ -88,7 +88,7 @@ export default function BookLink(props: Props) {
               ブックの作成
             </Button>
             <Typography variant="body1">
-             提供するブックを選んで下さい
+              提供するブックを選んで下さい
             </Typography>
           </>
         }

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useRouter } from "next/router";
 import { BookSchema } from "$server/models/book";
 import { usePlayerTrackerAtom } from "$store/playerTracker";
@@ -19,9 +19,9 @@ function Show(query: Query) {
   const {
     book,
     itemIndex,
+    nextItemIndex,
     itemExists,
     updateItemIndex,
-    nextItemIndex,
     error,
   } = useBook(
     query.bookId,
@@ -34,11 +34,14 @@ function Show(query: Query) {
   useEffect(() => {
     if (playerTracker) logger(playerTracker);
   }, [playerTracker]);
-  const handleItemClick = (index: ItemIndex) => {
-    const topic = itemExists(index);
-    if (topic) playerTracker?.next(topic.id);
-    updateItemIndex(index);
-  };
+  const handleTopicNext = useCallback(
+    (index: ItemIndex = nextItemIndex) => {
+      const topic = itemExists(index);
+      if (topic) playerTracker?.next(topic.id);
+      updateItemIndex(index);
+    },
+    [playerTracker, nextItemIndex, itemExists, updateItemIndex]
+  );
   const router = useRouter();
   const handleBookEditClick = () => {
     const action = book && isBookEditable(book) ? "edit" : "generate";
@@ -54,8 +57,8 @@ function Show(query: Query) {
   };
   const handlers = {
     linked: query.bookId === session?.ltiResourceLink?.bookId,
-    onTopicEnded: nextItemIndex,
-    onItemClick: handleItemClick,
+    onTopicEnded: handleTopicNext,
+    onItemClick: handleTopicNext,
     onBookEditClick: handleBookEditClick,
     onBookLinkClick: handleBookLinkClick,
     onTopicEditClick: handleTopicEditClick,

--- a/store/book.ts
+++ b/store/book.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { atom, useAtom } from "jotai";
-import { RESET, atomWithReset, useUpdateAtom } from "jotai/utils";
+import { RESET, atomWithReset, useUpdateAtom, useAtomValue } from "jotai/utils";
 import type { BookSchema } from "$server/models/book";
 import type { TopicSchema } from "$server/models/topic";
 
@@ -16,6 +16,18 @@ const bookAtom = atomWithReset<BookState>({
   itemExists: () => undefined,
 });
 
+const nextItemIndexAtom = atom((get) => {
+  const { itemIndex, itemExists } = get(bookAtom);
+  const [prevSectionIndex, prevTopicIndex] = itemIndex;
+  const nextTopicIndex = [prevSectionIndex, prevTopicIndex + 1] as const;
+  const nextSectionIndex = [prevSectionIndex + 1, 0] as const;
+
+  if (itemExists(nextTopicIndex)) return nextTopicIndex;
+  if (itemExists(nextSectionIndex)) return nextSectionIndex;
+
+  return itemIndex;
+});
+
 const updateBookAtom = atom<undefined, BookSchema>(
   () => undefined,
   (_, set, book) => {
@@ -28,9 +40,9 @@ const updateBookAtom = atom<undefined, BookSchema>(
   }
 );
 
-const updateItemIndexAtom = atom<undefined, ItemIndex>(
+const updateItemIndexAtom = atom<undefined, ItemIndex | undefined>(
   () => undefined,
-  (get, set, itemIndex) => {
+  (get, set, itemIndex = get(nextItemIndexAtom)) => {
     const { book, itemExists } = get(bookAtom);
     if (itemExists(itemIndex)) {
       set(bookAtom, { book, itemIndex, itemExists });
@@ -38,39 +50,11 @@ const updateItemIndexAtom = atom<undefined, ItemIndex>(
   }
 );
 
-const nextItemIndexAtom = atom(
-  () => undefined,
-  (get, set) => {
-    const {
-      book,
-      itemIndex: [prevSectionIndex, prevTopicIndex],
-      itemExists,
-    } = get(bookAtom);
-
-    const nextTopicIndex = [prevSectionIndex, prevTopicIndex + 1] as const;
-    const nextSectionIndex = [prevSectionIndex + 1, 0] as const;
-
-    if (itemExists(nextTopicIndex)) {
-      set(bookAtom, {
-        book,
-        itemIndex: nextTopicIndex,
-        itemExists,
-      });
-    } else if (itemExists(nextSectionIndex)) {
-      set(bookAtom, {
-        book,
-        itemIndex: nextSectionIndex,
-        itemExists,
-      });
-    }
-  }
-);
-
 export function useBookAtom() {
   const [state, reset] = useAtom(bookAtom);
+  const nextItemIndex = useAtomValue(nextItemIndexAtom);
   const updateBook = useUpdateAtom(updateBookAtom);
   const updateItemIndex = useUpdateAtom(updateItemIndexAtom);
-  const nextItemIndex = useUpdateAtom(nextItemIndexAtom);
   useEffect(
     () => () => {
       reset(RESET);

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -30,8 +30,8 @@ const buildHandler = <T extends EventType & keyof PlayerEvents>(
   eventType: T
 ) => (event: PlayerEvents[T]) => send(eventType, event);
 
-const buildSender = (event: EventType, tracker: PlayerTracker) => async () =>
-  send(event, await tracker.stats());
+const buildSender = (event: EventType, tracker: PlayerTracker) => () =>
+  send(event, tracker.stats);
 
 /** ロギング開始 */
 function logger(tracker: PlayerTracker) {
@@ -95,17 +95,15 @@ function logger(tracker: PlayerTracker) {
     "visibilitychange",
     prevHandlers.visibilitychange
   );
-  handlers.visibilitychange = async function () {
-    if (document.visibilityState === "hidden")
-      send("hidden-ended", await tracker.stats());
+  handlers.visibilitychange = function () {
+    if (document.visibilityState === "hidden") {
+      send("hidden-ended", tracker.stats);
+    }
   };
   document.addEventListener("visibilitychange", handlers.visibilitychange);
 
   clearInterval(prevHandlers.timer?.());
-  const timer = setInterval(
-    async () => send("current-time", await tracker.stats()),
-    10000
-  );
+  const timer = setInterval(() => send("current-time", tracker.stats), 10000);
   handlers.timer = () => timer;
 
   // @ts-expect-error TODO: Window オブジェクトを介さない排他制御にしたい

--- a/utils/eventLogger/playerTracker.ts
+++ b/utils/eventLogger/playerTracker.ts
@@ -39,12 +39,6 @@ export type PlayerEvents = {
   firstplay: PlayerEvent;
 } & CustomEvents;
 
-const nullEvent = {
-  providerUrl: "https://www.youtube.com/",
-  url: "",
-  currentTime: 0,
-} as const;
-
 const youtubeType = "video/youtube";
 
 /** プレイヤーのトラッキング用 */
@@ -52,7 +46,11 @@ export class PlayerTracker extends (EventEmitter as {
   new (): StrictEventEmitter<EventEmitter, PlayerEvents>;
 }) {
   readonly player: VideoJsPlayer | VimeoPlayer;
-  readonly stats: () => Promise<PlayerEvent>;
+  readonly providerUrl: string;
+  /** ビデオURL */
+  url = "";
+  /** 現在再生時間 */
+  currentTime = 0;
   /** 再生した時間範囲の取得 */
   readonly getPlayed: () => Promise<[number, number][]>;
 
@@ -61,14 +59,18 @@ export class PlayerTracker extends (EventEmitter as {
     this.player = player;
 
     if (player instanceof VimeoPlayer) {
-      this.stats = async () => vimeoStats(player);
+      this.providerUrl = "https://vimeo.com/";
       this.getPlayed = player.getPlayed.bind(player);
       this.intoVimeo(player);
     } else {
       // NOTE: YouTube Player API に存在しない API の再現
       youtubePlayedShims(player);
 
-      this.stats = async () => videoJsStats(player);
+      this.providerUrl =
+        player.currentType() === youtubeType
+          ? "https://www.youtube.com/"
+          : `${new URL(player.src()).origin}/`;
+
       this.getPlayed = async () => {
         const timeRanges = player.played() as TimeRanges;
         return [...Array(timeRanges.length)].map((_, i) => [
@@ -81,49 +83,53 @@ export class PlayerTracker extends (EventEmitter as {
     }
   }
 
-  async next(video: number) {
-    this.emit("nextvideo", { ...(await this.stats()), video });
+  next(video: number) {
+    this.emit("nextvideo", { ...this.stats, video });
+  }
+
+  get stats() {
+    const { providerUrl, url, currentTime } = this;
+    return { providerUrl, url, currentTime };
   }
 
   private intoVideoJs(player: VideoJsPlayer) {
+    this.url = player.src();
+    player.on("timeupdate", () => {
+      this.currentTime = player.currentTime();
+    });
+
     for (const event of basicEventsMap) {
-      player.on(event, async () => this.emit(event, await this.stats()));
+      player.on(event, () => this.emit(event, this.stats));
     }
 
-    player.on("firstplay", async () =>
-      this.emit("firstplay", await this.stats())
-    );
-    player.on("ratechange", async () => {
+    player.on("firstplay", () => this.emit("firstplay", this.stats));
+    player.on("ratechange", () => {
       this.emit("playbackratechange", {
-        ...(await this.stats()),
+        ...this.stats,
         playbackRate: player.playbackRate(),
       });
     });
 
     // NOTE: texttrackchange イベントは表示の都度発火されるため使用しない
-    player.remoteTextTracks().addEventListener("change", async () => {
+    player.remoteTextTracks().addEventListener("change", () => {
       const showingSubtitle = Array.from(player.remoteTextTracks()).find(
         ({ kind, mode }) => kind === "subtitles" && mode === "showing"
       );
       this.emit("texttrackchange", {
-        ...(await this.stats()),
+        ...this.stats,
         language: showingSubtitle?.language,
       });
     });
 
     // @ts-expect-error NOTE: videojs-seek-buttons 由来
     const { seekForward, seekBack } = player.controlBar;
-    seekForward.on("click", async () => {
-      this.emit("forward", await this.stats());
-    });
-    seekBack.on("click", async () => {
-      this.emit("back", await this.stats());
-    });
+    seekForward.on("click", () => this.emit("forward", this.stats));
+    seekBack.on("click", () => this.emit("back", this.stats));
 
     // NOTE: YouTubeの場合、playイベント発火より前だと`player.duration()`に失敗
-    const handlePlay = async () => {
+    const handlePlay = () => {
       this.emit("durationchange", {
-        ...(await this.stats()),
+        ...this.stats,
         duration: player.duration(),
       });
       player.off("play", handlePlay);
@@ -132,66 +138,41 @@ export class PlayerTracker extends (EventEmitter as {
   }
 
   private intoVimeo(player: VimeoPlayer) {
+    player.getVideoUrl().then((url) => {
+      this.url = url;
+    });
+    player.on("timeupdate", ({ seconds }: { seconds: number }) => {
+      this.currentTime = seconds;
+    });
+
     for (const event of basicEventsMap) {
-      player.on(event, async () => this.emit(event, await vimeoStats(player)));
+      player.on(event, () => this.emit(event, this.stats));
     }
 
-    player.on("playbackratechange", async (data: { playbackRate: number }) => {
+    player.on("playbackratechange", (data: { playbackRate: number }) => {
       this.emit("playbackratechange", {
-        ...(await this.stats()),
+        ...this.stats,
         playbackRate: data.playbackRate,
       });
     });
     player.on(
       "texttrackchange",
-      async (data: {
+      (data: {
         kind: "captions" | "subtitles";
         label: string;
         language: string;
       }) => {
         if (data.kind !== "subtitles") return;
         this.emit("texttrackchange", {
-          ...(await this.stats()),
+          ...this.stats,
           language: data.language,
         });
       }
     );
-
-    Promise.all([
-      this.stats(),
-      player.getDuration(),
-    ]).then(([stats, duration]) =>
-      this.emit("durationchange", { ...stats, duration })
-    );
-  }
-}
-
-function videoJsStats(player: VideoJsPlayer): PlayerEvent {
-  // @ts-expect-error: @types/video.js@^7.3.11 Unsupported
-  if (player.isDisposed()) return nullEvent;
-
-  return {
-    providerUrl:
-      player.currentType() === youtubeType
-        ? "https://www.youtube.com/"
-        : `${new URL(player.src()).origin}/`,
-    url: player.src(),
-    currentTime: player.currentTime(),
-  };
-}
-
-async function vimeoStats(player: VimeoPlayer): Promise<PlayerEvent> {
-  try {
-    const [url, currentTime] = await Promise.all([
-      player.getVideoUrl(),
-      player.getCurrentTime(),
-    ]);
-    return {
-      providerUrl: "https://vimeo.com/",
-      url,
-      currentTime,
-    };
-  } catch {
-    return nullEvent;
+    player
+      .getDuration()
+      .then((duration) =>
+        this.emit("durationchange", { ...this.stats, duration })
+      );
   }
 }


### PR DESCRIPTION
fix #21 

- pages/book/index.tsx: 次のトピックの再生に進む処理とnextvideoイベント発火の共通化
- Videoコンポーネント: propsでイベントハンドラーを渡さずPlayerTrackerを介して依存性 (onEnded, onDurationChange) 注入することで繰り返し描画され続ける問題を回避

確認したこと:

`yarn build && yarn start | grep changepage` して開発サーバーを起動後、学習者としてシステムにアクセス、手動・自動問わず切り替えたタイミングで適切にコンテンツ(トピックのID)が得られることを確認 (YouTube, Vimeo, Wowza)。