### PR TITLE
feat: 文言変更: 編集者→教員

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -83,7 +83,7 @@ export default function BookForm(props: Props) {
       />
       <div>
         <InputLabel classes={inputLabelClasses} htmlFor="shared">
-          他の編集者にシェア
+          他の教員にシェア
         </InputLabel>
         <Checkbox
           id="shared"

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -144,7 +144,7 @@ export default function TopicForm(props: Props) {
         />
         <div>
           <InputLabel classes={inputLabelClasses} htmlFor="shared">
-            他の編集者にシェア
+            他の教員にシェア
           </InputLabel>
           <Checkbox
             id="shared"


### PR DESCRIPTION
シェアインジケーター #289、アプリケーションバーでは、「編集者」ではなく「教員」という名称を用いているので、それに揃える変更になります