### PR TITLE
feat: トピック・セクション一覧と動画プレーヤーのスクロール追従

### DIFF
--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -3,9 +3,10 @@ import { TopicSchema } from "$server/models/topic";
 import { format, formatDuration, intervalToDuration } from "date-fns";
 import { ja } from "date-fns/locale";
 import Typography from "@material-ui/core/Typography";
-import { makeStyles } from "@material-ui/core/styles";
+import { useTheme, makeStyles } from "@material-ui/core/styles";
 import Video from "$organisms/Video";
 import Item from "$atoms/Item";
+import useStickyProps from "$utils/useStickyProps";
 import languages from "$utils/languages";
 
 function formatInterval(start: Date | number, end: Date | number) {
@@ -15,16 +16,10 @@ function formatInterval(start: Date | number, end: Date | number) {
 
 const useStyles = makeStyles((theme) => ({
   video: {
-    marginTop: theme.spacing(-2),
     marginRight: theme.spacing(-3),
     marginBottom: theme.spacing(2),
     marginLeft: theme.spacing(-3),
-    "&$sticky": {
-      position: "sticky",
-      top: theme.spacing(-2),
-    },
   },
-  sticky: {},
   title: {
     marginBottom: theme.spacing(2),
   },
@@ -44,17 +39,30 @@ type Props = {
   topic: TopicSchema;
   onEnded?: () => void;
   top?: number;
-  sticky?: boolean;
+  dialog?: boolean;
 };
 
 export default function TopicViewerContent(props: Props) {
-  const { topic, onEnded, sticky = false } = props;
+  const { topic, onEnded, dialog = false, top } = props;
   const classes = useStyles();
+  const theme = useTheme();
+  const { classes: stickyClasses, scroll, desktop, mobile } = useStickyProps({
+    backgroundColor: "transparent",
+    top: top ?? theme.spacing(-2),
+    zIndex: 1,
+    dialog,
+  });
   return (
     <>
       {"providerUrl" in topic.resource && (
         <Video
-          className={clsx(classes.video, { [classes.sticky]: sticky })}
+          className={clsx(
+            classes.video,
+            stickyClasses.sticky,
+            { [stickyClasses.scroll]: scroll },
+            { [stickyClasses.desktop]: desktop },
+            { [stickyClasses.mobile]: mobile }
+          )}
           {...topic.resource}
           onEnded={onEnded}
           autoplay

--- a/components/organisms/ActionHeader.tsx
+++ b/components/organisms/ActionHeader.tsx
@@ -2,11 +2,9 @@ import { ComponentProps } from "react";
 import clsx from "clsx";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Typography";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import useScrollTrigger from "@material-ui/core/useScrollTrigger";
 import { useTheme, makeStyles } from "@material-ui/core/styles";
-import { gray } from "theme/colors";
-import { useSessionAtom } from "$store/session";
+import { gray } from "$theme/colors";
+import useStickyProps from "$utils/useStickyProps";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,32 +34,6 @@ const useStyles = makeStyles((theme) => ({
   container: {
     padding: 0,
   },
-  sticky: {
-    zIndex: 1,
-    top: -theme.spacing(2),
-    position: "sticky",
-    backgroundColor: gray[50],
-    transition: theme.transitions.create("top", {
-      duration: theme.transitions.duration.enteringScreen,
-      easing: theme.transitions.easing.easeOut,
-    }),
-    "&$scroll": {
-      transition: theme.transitions.create("top", {
-        duration: theme.transitions.duration.leavingScreen,
-        easing: theme.transitions.easing.sharp,
-      }),
-    },
-    "&$desktop$instructor": {
-      top: 65 - theme.spacing(2),
-    },
-    "&$mobile$instructor": {
-      top: 55 - theme.spacing(2),
-    },
-  },
-  scroll: {},
-  desktop: {},
-  mobile: {},
-  instructor: {},
 }));
 
 type Props = Pick<ComponentProps<typeof Container>, "maxWidth"> & {
@@ -73,9 +45,11 @@ export default function ActionHeader(props: Props) {
   const { maxWidth, title, action } = props;
   const classes = useStyles();
   const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.up("sm"));
-  const { isInstructor } = useSessionAtom();
-  const trigger = useScrollTrigger();
+  const { classes: stickyClasses, scroll, desktop, mobile } = useStickyProps({
+    backgroundColor: gray[50],
+    top: theme.spacing(-2),
+    zIndex: 2,
+  });
   return (
     <>
       {title && (
@@ -94,13 +68,10 @@ export default function ActionHeader(props: Props) {
         <Container
           className={clsx(
             { [classes.container]: !maxWidth },
-            { [classes.instructor]: isInstructor },
-            classes.sticky,
-            trigger
-              ? classes.scroll
-              : matches
-              ? classes.desktop
-              : classes.mobile
+            { [stickyClasses.scroll]: scroll },
+            { [stickyClasses.desktop]: desktop },
+            { [stickyClasses.mobile]: mobile },
+            stickyClasses.sticky
           )}
           maxWidth={maxWidth}
         >

--- a/components/organisms/TopicPreviewDialog.tsx
+++ b/components/organisms/TopicPreviewDialog.tsx
@@ -19,7 +19,7 @@ export default function TopicPreviewDialog(props: Props) {
       PaperProps={{ classes: cardClasses }}
       fullWidth
     >
-      <TopicViewerContent topic={topic} sticky />
+      <TopicViewerContent topic={topic} dialog />
     </Dialog>
   );
 }

--- a/components/organisms/TopicViewer.tsx
+++ b/components/organisms/TopicViewer.tsx
@@ -1,20 +1,30 @@
+import clsx from "clsx";
 import { TopicSchema } from "$server/models/topic";
 import Card from "@material-ui/core/Card";
+import { makeStyles } from "@material-ui/core/styles";
 import TopicViewerContent from "$molecules/TopicViewerContent";
 import useCardStyles from "styles/card";
+
+const useStyles = makeStyles({
+  root: {
+    overflow: "visible",
+  },
+});
 
 type Props = {
   className?: string;
   topic: TopicSchema;
   onEnded?: () => void;
+  top?: number;
 };
 
 export default function TopicViewer(props: Props) {
+  const classes = useStyles();
   const cardClasses = useCardStyles();
-  const { className, topic, onEnded } = props;
+  const { className, topic, onEnded, top } = props;
   return (
-    <Card classes={cardClasses} className={className}>
-      <TopicViewerContent topic={topic} onEnded={onEnded} />
+    <Card classes={cardClasses} className={clsx(classes.root, className)}>
+      <TopicViewerContent topic={topic} onEnded={onEnded} top={top} />
     </Card>
   );
 }

--- a/components/templates/BookLink.tsx
+++ b/components/templates/BookLink.tsx
@@ -88,7 +88,7 @@ export default function BookLink(props: Props) {
               ブックの作成
             </Button>
             <Typography variant="body1">
-             提供するブックを選んで下さい
+              提供するブックを選んで下さい
             </Typography>
           </>
         }

--- a/styles/sticky.ts
+++ b/styles/sticky.ts
@@ -1,0 +1,40 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+export type StickyProps = {
+  backgroundColor: string;
+  top: number;
+  zIndex: number;
+};
+
+// NOTE: nested selectorとpropsが組み合わせられない
+// 例:
+// "&$desktop": {
+//   "top": (props: Props) => 65 + props.top
+// }
+// See also https://github.com/mui-org/material-ui/issues/15511
+const sticky = makeStyles((theme) => ({
+  sticky: (props: StickyProps) => ({
+    zIndex: props.zIndex,
+    position: "sticky",
+    top: props.top,
+    backgroundColor: props.backgroundColor,
+    transition: theme.transitions.create("top", {
+      duration: theme.transitions.duration.enteringScreen,
+      easing: theme.transitions.easing.easeOut,
+    }),
+  }),
+  scroll: {
+    transition: theme.transitions.create("top", {
+      duration: theme.transitions.duration.leavingScreen,
+      easing: theme.transitions.easing.sharp,
+    }),
+  },
+  desktop: (props: StickyProps) => ({
+    top: 65 + props.top,
+  }),
+  mobile: (props: StickyProps) => ({
+    top: 55 + props.top,
+  }),
+}));
+
+export default sticky;

--- a/utils/useStickyProps.ts
+++ b/utils/useStickyProps.ts
@@ -1,0 +1,31 @@
+import useStickyStyles from "$styles/sticky";
+import type { StickyProps } from "$styles/sticky";
+import { useSessionAtom } from "$store/session";
+import { useTheme } from "@material-ui/core/styles";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
+
+function useStickyProps({
+  backgroundColor,
+  top,
+  zIndex,
+  dialog = false,
+}: StickyProps & { dialog?: boolean }) {
+  const classes = useStickyStyles({
+    backgroundColor,
+    top,
+    zIndex,
+  });
+  const trigger = useScrollTrigger();
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.up("sm"));
+  const { isInstructor } = useSessionAtom();
+  return {
+    classes,
+    scroll: trigger && !dialog,
+    desktop: !trigger && !dialog && matches && isInstructor,
+    mobile: !trigger && !dialog && !matches && isInstructor,
+  };
+}
+
+export default useStickyProps;


### PR DESCRIPTION
#299 に関連しています

アプリケーションバー、タイトルバーにスタックして、BookChildrenとTopicPlayerがStickyにスクロール追従します

![image](https://user-images.githubusercontent.com/9744580/111409895-1b7d5f00-871b-11eb-907c-e5359dcf4a71.png)
