### PR TITLE
fix: 機能しないボタンをdisabled/非表示に

### DIFF
--- a/components/organisms/BookPreview.tsx
+++ b/components/organisms/BookPreview.tsx
@@ -148,7 +148,11 @@ export default function BookPreview(props: Props) {
         >
           {getSectionsOutline(book.sections)}
         </p>
-        <Button size="small" color="primary">
+        <Button
+          size="small"
+          color="primary"
+          disabled={true /* TODO: BookPreviewDialogを実装したら取り除く */}
+        >
           もっと詳しく...
         </Button>
       </div>

--- a/components/templates/BookLink.tsx
+++ b/components/templates/BookLink.tsx
@@ -129,14 +129,11 @@ export default function BookLink(props: Props) {
           >
             キャンセル
           </Button>
-          <Button
-            color="primary"
-            size="large"
-            variant="outlined"
-            disabled={true /* TODO: 連携解除機能を追加したら取り除くべき */}
-          >
+          {/* TODO: 連携解除機能の実装
+          <Button color="primary" size="large" variant="outlined">
             提供解除
           </Button>
+          */}
           <Button
             color="primary"
             size="large"


### PR DESCRIPTION
それぞれ

- 「提供解除」ボタン: #316 
- 「もっと詳しく...」ボタン: #148

に対応しています

![image](https://user-images.githubusercontent.com/9744580/111431165-c5baae00-873e-11eb-96f5-8a63a940566b.png)