### PR TITLE
fix: シェアされていないブックを閲覧している際にフォークが可能

### DIFF
--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -147,12 +147,10 @@ export default function Book(props: Props) {
             <IconButton onClick={handleInfoClick}>
               <InfoOutlinedIcon />
             </IconButton>
-            {((book && isBookEditable(book)) || book?.shared) && (
-              <>
-                <IconButton color="primary" onClick={handleEditClick}>
-                  <EditOutlinedIcon />
-                </IconButton>
-              </>
+            {isInstructor && book && (isBookEditable(book) || book.shared) && (
+              <IconButton color="primary" onClick={handleEditClick}>
+                <EditOutlinedIcon />
+              </IconButton>
             )}
             {isInstructor && linked && (
               <Button size="small" color="primary" onClick={onBookLinkClick}>

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -107,7 +107,7 @@ export default function Book(props: Props) {
     onItemClick,
   } = props;
   const topic = book?.sections[sectionIndex]?.topics[topicIndex];
-  const { isInstructor, isTopicEditable } = useSessionAtom();
+  const { isInstructor, isBookEditable, isTopicEditable } = useSessionAtom();
   const classes = useStyles();
   const { classes: stickyClasses, scroll, desktop, mobile } = useStickyProps({
     backgroundColor: "transparent",
@@ -147,7 +147,7 @@ export default function Book(props: Props) {
             <IconButton onClick={handleInfoClick}>
               <InfoOutlinedIcon />
             </IconButton>
-            {isInstructor && (
+            {((book && isBookEditable(book)) || book?.shared) && (
               <>
                 <IconButton color="primary" onClick={handleEditClick}>
                   <EditOutlinedIcon />


### PR DESCRIPTION
close #315 

ローカル環境にて、

1. 教員1が他の教員にシェアしないブックを任意のLTIリンクに提供
2. それぞれのアカウントから 1\. のLTIリンクにアクセス

という手順で

管理者: 鉛筆ボタンが表示される
教員1: 鉛筆ボタンが表示される
教員2: 鉛筆ボタンが表示されない

という結果になることを確認しました