### PR TITLE
chore: templates stories, use fullscreen layout

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,7 +3,6 @@ import type { Story } from "@storybook/react";
 import { Provider } from "jotai";
 import MuiThemeProvider from "@material-ui/styles/ThemeProvider";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import Container from "@material-ui/core/Container";
 import { ConfirmProvider } from "material-ui-confirm";
 import theme from "../theme";
 // NOTE: For VideoJs components.
@@ -25,9 +24,7 @@ export const decorators = [
     <Provider>
       <ThemeProvider>
         <ConfirmProvider>
-          <Container>
-            <Story />
-          </Container>
+          <Story />
         </ConfirmProvider>
       </ThemeProvider>
     </Provider>

--- a/components/templates/Book.stories.tsx
+++ b/components/templates/Book.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/Book" };
+export default {
+  title: "templates/Book",
+  parameters: { layout: "fullscreen" },
+};
 
 import { useEffect } from "react";
 import { useBookAtom } from "$store/book";

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/BookEdit" };
+export default {
+  title: "templates/BookEdit",
+  parameters: { layout: "fullscreen" },
+};
 
 import BookEdit from "./BookEdit";
 import { book } from "samples";

--- a/components/templates/BookImport.stories.tsx
+++ b/components/templates/BookImport.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/BookImport" };
+export default {
+  title: "templates/BookImport",
+  parameters: { layout: "fullscreen" },
+};
 
 import BookImport from "./BookImport";
 import Slide from "@material-ui/core/Slide";

--- a/components/templates/BookLink.stories.tsx
+++ b/components/templates/BookLink.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/BookLink" };
+export default {
+  title: "templates/BookLink",
+  parameters: { layout: "fullscreen" },
+};
 
 import BookLink from "./BookLink";
 import Slide from "@material-ui/core/Slide";

--- a/components/templates/BookNew.stories.tsx
+++ b/components/templates/BookNew.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/BookNew" };
+export default {
+  title: "templates/BookNew",
+  parameters: { layout: "fullscreen" },
+};
 
 import BookNew from "./BookNew";
 import { book } from "$samples";

--- a/components/templates/Books.stories.tsx
+++ b/components/templates/Books.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/Books" };
+export default {
+  title: "templates/Books",
+  parameters: { layout: "fullscreen" },
+};
 
 import Books from "./Books";
 import Slide from "@material-ui/core/Slide";

--- a/components/templates/Placeholder.stories.tsx
+++ b/components/templates/Placeholder.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/Placeholder" };
+export default {
+  title: "templates/Placeholder",
+  parameters: { layout: "fullscreen" },
+};
 
 import Placeholder from "./Placeholder";
 

--- a/components/templates/TopicEdit.stories.tsx
+++ b/components/templates/TopicEdit.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/TopicEdit" };
+export default {
+  title: "templates/TopicEdit",
+  parameters: { layout: "fullscreen" },
+};
 
 import TopicEdit from "./TopicEdit";
 import { topic } from "samples";

--- a/components/templates/TopicImport.stories.tsx
+++ b/components/templates/TopicImport.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/TopicImport" };
+export default {
+  title: "templates/TopicImport",
+  parameters: { layout: "fullscreen" },
+};
 
 import TopicImport from "./TopicImport";
 import Slide from "@material-ui/core/Slide";

--- a/components/templates/TopicNew.stories.tsx
+++ b/components/templates/TopicNew.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/TopicNew" };
+export default {
+  title: "templates/TopicNew",
+  parameters: { layout: "fullscreen" },
+};
 
 import TopicNew from "./TopicNew";
 import { useVideoTrackAtom } from "$store/videoTrack";

--- a/components/templates/Topics.stories.tsx
+++ b/components/templates/Topics.stories.tsx
@@ -1,4 +1,7 @@
-export default { title: "templates/Topics" };
+export default {
+  title: "templates/Topics",
+  parameters: { layout: "fullscreen" },
+};
 
 import Topics from "./Topics";
 import Slide from "@material-ui/core/Slide";


### PR DESCRIPTION
templates以下のコンポーネントのストーリーブックを見ていると画面端の余白が気になったのでそれを取り除きます。
