### PR TITLE
feat: 閲覧時の動画は40vhを最大高さに&Vimeoの表示領域を確保するように

### DIFF
--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -21,6 +21,10 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(2),
     marginLeft: theme.spacing(-3),
     backgroundColor: gray[800],
+    "& > *": {
+      maxWidth: "calc(40vh * 16 / 9)",
+      margin: "0 auto",
+    },
   },
   title: {
     marginBottom: theme.spacing(0.5),

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -22,7 +22,9 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(-3),
     backgroundColor: gray[800],
     "& > *": {
-      maxWidth: "calc(40vh * 16 / 9)",
+      // NOTE: 各動画プレイヤーのレスポンシブ対応により、高さはpaddingTopによってwidthのpercentage分
+      // 確保されるため、heightによる制限ではなくwidthによる制限をおこなう必要がある
+      maxWidth: "calc(40vh * 4 / 3)",
       margin: "0 auto",
     },
   },

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -22,8 +22,9 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(-3),
     backgroundColor: gray[800],
     "& > *": {
-      // NOTE: 各動画プレイヤーのレスポンシブ対応により、高さはpaddingTopによってwidthのpercentage分
-      // 確保されるため、heightによる制限ではなくwidthによる制限をおこなう必要がある
+      /* NOTE: 各動画プレイヤーのレスポンシブ対応により、高さはpaddingTopによってwidthのpercentage分
+       * 確保されるため、heightによる制限ではなくwidthによる制限をおこなう必要がある */
+      // NOTE: 4:3前提なので、16:9では40vhよりも狭い高さになる
       maxWidth: "calc(40vh * 4 / 3)",
       margin: "0 auto",
     },

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -8,6 +8,7 @@ import Video from "$organisms/Video";
 import Item from "$atoms/Item";
 import useStickyProps from "$utils/useStickyProps";
 import languages from "$utils/languages";
+import { gray } from "$theme/colors";
 
 function formatInterval(start: Date | number, end: Date | number) {
   const duration = intervalToDuration({ start, end });
@@ -19,6 +20,7 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(-3),
     marginBottom: theme.spacing(2),
     marginLeft: theme.spacing(-3),
+    backgroundColor: gray[800],
   },
   title: {
     marginBottom: theme.spacing(0.5),

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -25,10 +25,6 @@ const useStyles = makeStyles((theme) => ({
       maxWidth: "calc(40vh * 16 / 9)",
       margin: "0 auto",
     },
-    "& div:empty": {
-      // NOTE: Viemoでiframeがぶら下がる前の高さを確保する
-      paddingTop: "56.25%",
-    },
   },
   title: {
     marginBottom: theme.spacing(0.5),

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -25,6 +25,10 @@ const useStyles = makeStyles((theme) => ({
       maxWidth: "calc(40vh * 16 / 9)",
       margin: "0 auto",
     },
+    "& div:empty": {
+      // NOTE: Viemoでiframeがぶら下がる前の高さを確保する
+      paddingTop: "56.25%",
+    },
   },
   title: {
     marginBottom: theme.spacing(0.5),

--- a/components/organisms/Video/Vimeo.tsx
+++ b/components/organisms/Video/Vimeo.tsx
@@ -5,8 +5,8 @@ import volumePersister from "$utils/volumePersister";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles({
-  root: {
-    "& div:empty": {
+  player: {
+    "&:empty": {
       // NOTE: @vimeo/player によって iframe がぶら下がる前の高さを確保する
       paddingTop: "56.25%",
     },
@@ -27,6 +27,7 @@ export function Vimeo({ options }: VimeoProps) {
   const classes = useStyles();
   useEffect(() => {
     const element = document.createElement("div");
+    element.classList.add(classes.player);
     ref.current.appendChild(element);
     const player = new Player(element, {
       ...defaultOptions,
@@ -40,6 +41,6 @@ export function Vimeo({ options }: VimeoProps) {
       player.pause();
       element.style.display = "none";
     };
-  }, [options, tracking]);
-  return <div className={classes.root} ref={ref} />;
+  }, [options, tracking, classes]);
+  return <div ref={ref} />;
 }

--- a/components/organisms/Video/Vimeo.tsx
+++ b/components/organisms/Video/Vimeo.tsx
@@ -2,6 +2,16 @@ import { useEffect, useRef } from "react";
 import Player, { Options } from "@vimeo/player";
 import { usePlayerTrackingAtom } from "$store/playerTracker";
 import volumePersister from "$utils/volumePersister";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles({
+  root: {
+    "& div:empty": {
+      // NOTE: @vimeo/player によって iframe がぶら下がる前の高さを確保する
+      paddingTop: "56.25%",
+    },
+  },
+});
 
 type VimeoProps = {
   options: Options;
@@ -14,6 +24,7 @@ const defaultOptions: Options = {
 export function Vimeo({ options }: VimeoProps) {
   const ref = useRef(document.createElement("div"));
   const tracking = usePlayerTrackingAtom();
+  const classes = useStyles();
   useEffect(() => {
     const element = document.createElement("div");
     ref.current.appendChild(element);
@@ -30,5 +41,5 @@ export function Vimeo({ options }: VimeoProps) {
       element.style.display = "none";
     };
   }, [options, tracking]);
-  return <div ref={ref} />;
+  return <div className={classes.root} ref={ref} />;
 }


### PR DESCRIPTION
close #354 , close #352 

- feat: 動画プレイヤーの背景色
- feat: 動画は最大40vhで解説領域を確保
- fix: Vimeoで動画表示前に高さが確保されない 

確認したこと

- 十分な文章量の解説を含んだトピックを作成し、ブック閲覧にてブラウザの縦幅を短くする
    - 40vhの高さで動画領域が縮小されることを確認
- Vimeoの動画を登録したトピックを作成し、ブック閲覧にて当該トピックを表示する
    - 16:9相当の領域がグレーの背景色とともに確保されていることを確認

![image](https://user-images.githubusercontent.com/9744580/112968076-e515fa00-9186-11eb-908b-8f0b2bfbfc7f.png)