### PR TITLE
feat: TopicViewerContentの動画の最大高さ調整

### DIFF
--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       /* NOTE: 各動画プレイヤーのレスポンシブ対応により、高さはpaddingTopによってwidthのpercentage分
        * 確保されるため、heightによる制限ではなくwidthによる制限をおこなう必要がある */
-      // NOTE: 4:3前提なので、16:9では50vhよりも狭い高さになる
+      // NOTE: 4:3前提になっているが本当はアスペクト比に応じて最大高さを変えたい
       maxWidth: "calc(50vh * 4 / 3)",
       margin: "0 auto",
     },

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -24,8 +24,8 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       /* NOTE: 各動画プレイヤーのレスポンシブ対応により、高さはpaddingTopによってwidthのpercentage分
        * 確保されるため、heightによる制限ではなくwidthによる制限をおこなう必要がある */
-      // NOTE: 4:3前提になっているが本当はアスペクト比に応じて最大高さを変えたい
-      maxWidth: "calc(50vh * 4 / 3)",
+      // NOTE: 16:9前提になっているが本当はアスペクト比に応じて最大高さを変えたい
+      maxWidth: "calc(40vh * 16 / 9)",
       margin: "0 auto",
     },
   },

--- a/components/molecules/TopicViewerContent.tsx
+++ b/components/molecules/TopicViewerContent.tsx
@@ -24,8 +24,8 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       /* NOTE: 各動画プレイヤーのレスポンシブ対応により、高さはpaddingTopによってwidthのpercentage分
        * 確保されるため、heightによる制限ではなくwidthによる制限をおこなう必要がある */
-      // NOTE: 4:3前提なので、16:9では40vhよりも狭い高さになる
-      maxWidth: "calc(40vh * 4 / 3)",
+      // NOTE: 4:3前提なので、16:9では50vhよりも狭い高さになる
+      maxWidth: "calc(50vh * 4 / 3)",
       margin: "0 auto",
     },
   },


### PR DESCRIPTION
以下のフィードバックの反映
「半分よりちょっと大きい」というリクエストに対して、3:4の動画の場合でちょうど半分になる程度に変更をしています。
プレビュー用のStorybookで確認いただくなどして、引き続き調整が必要であれば、このPRにて変更したいと思います

> 私の，1920×1080の画面では、動画がかなり小さいので，ここは決めの問題だとおもうので，シェアが高いとされている，1920×1080の画面で，半分よりちょっと大きい位の高さにできますでしょうか．
https://gs.statcounter.com/screen-resolution-stats/desktop-tablet-console/japan/#monthly-202003-202103
> 
> <img width="1441" alt="image" src="https://user-images.githubusercontent.com/9005132/113128770-1c52dc80-9255-11eb-8d89-1d5c9397dcc8.png">

_Originally posted by @horimasumi in https://github.com/npocccties/ChibiCHiLO/pull/359#issuecomment-810950088_

before(1920x1080の画面)
![image](https://user-images.githubusercontent.com/9744580/113252516-e9fdb980-92fe-11eb-92b2-82624823d92d.png)

after(1920x1080の画面)
![image](https://user-images.githubusercontent.com/9744580/113252373-bd49a200-92fe-11eb-8d71-ee9228ad83cf.png)
