### PR TITLE
fix: 開発環境でクロスオリジンのときblob schemeの字幕が反映されない問題の解決

### DIFF
--- a/components/organisms/Video.stories.tsx
+++ b/components/organisms/Video.stories.tsx
@@ -39,5 +39,10 @@ export const Vimeo = () => (
   />
 );
 
-// TODO: 未サポート
-// export const Wowza = () => <Video type="wowza" src="sample.mp4" {...defaultProps} />;
+export const Wowza = () => (
+  <Video
+    providerUrl="https://wowzaec2demo.streamlock.net/"
+    url="https://wowzaec2demo.streamlock.net/vod/mp4/playlist.m3u8"
+    {...defaultProps}
+  />
+);

--- a/utils/buildTracks.ts
+++ b/utils/buildTracks.ts
@@ -2,14 +2,20 @@ import ISO6391 from "iso-639-1";
 import { VideoTrackSchema } from "$server/models/videoTrack";
 import { NEXT_PUBLIC_API_BASE_PATH } from "$utils/env";
 
-function buildTrack(
-  track: VideoTrackSchema
-): { kind: "subtitles"; src: string; srclang: string; label: string } {
+function buildTrack({
+  url,
+  language,
+}: VideoTrackSchema): {
+  kind: "subtitles";
+  src: string;
+  srclang: string;
+  label: string;
+} {
   return {
     kind: "subtitles",
-    src: `${NEXT_PUBLIC_API_BASE_PATH}${track.url}`,
-    srclang: track.language,
-    label: ISO6391.getNativeName(track.language),
+    src: /^blob:/i.test(url) ? url : `${NEXT_PUBLIC_API_BASE_PATH}${url}`,
+    srclang: language,
+    label: ISO6391.getNativeName(language),
   };
 }
 


### PR DESCRIPTION
- fix: Video.stories.tsxへのWowzaのデモ動画追加
- fix: 開発環境でクロスオリジンのときblob schemeの字幕が反映されない問題の解決

ローカルの環境で `yarn storybook` 等開発サーバーを起動したとき `blob:` から始まるURLの字幕が表示されていない問題があったので修正
