### PR TITLE
fix: 提供中のブックの有無で領域の高さが異なり表示位置がずれる場合がある

### DIFF
--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -27,11 +27,11 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(2),
   },
   linkedBook: {
-    // NOTE: 決め打ち
+    // NOTE: 決め打ち (動画プレイヤーの高さに依存)
     minHeight: 270,
   },
   linkedBookPlaceholder: {
-    // NOTE: 決め打ち
+    // NOTE: 決め打ち (動画プレイヤーの高さに依存)
     minHeight: 205,
     display: "flex",
     alignItems: "center",

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
   },
   linkedBook: {
     // NOTE: 決め打ち (動画プレイヤーの高さに依存)
-    minHeight: 270,
+    minHeight: 255,
   },
   linkedBookPlaceholder: {
     // NOTE: 決め打ち (動画プレイヤーの高さに依存)

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -27,11 +27,11 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(2),
   },
   linkedBook: {
-    // NOTE: 決め打ち (動画プレイヤーの高さに依存)
+    // NOTE: BookPreviewに依存する&事前に高さを確定できないので決め打ち
     minHeight: 255,
   },
   linkedBookPlaceholder: {
-    // NOTE: 決め打ち (動画プレイヤーの高さに依存)
+    // NOTE: BookPreviewに依存する&事前に高さを確定できないので決め打ち
     minHeight: 205,
     display: "flex",
     alignItems: "center",

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -2,6 +2,7 @@ import useInfiniteScroll from "react-infinite-scroll-hook";
 import Skeleton from "@material-ui/lab/Skeleton";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Typography";
 import AddIcon from "@material-ui/icons/Add";
@@ -15,6 +16,7 @@ import type { LinkedBook } from "$types/linkedBook";
 import { SortOrder } from "$server/models/sortOrder";
 import { Filter } from "$types/filter";
 import useContainerStyles from "styles/container";
+import useCardStyles from "$styles/card";
 import { useSearchAtom } from "$store/search";
 
 const useStyles = makeStyles((theme) => ({
@@ -23,6 +25,18 @@ const useStyles = makeStyles((theme) => ({
   },
   title: {
     marginBottom: theme.spacing(2),
+  },
+  linkedBook: {
+    // NOTE: 決め打ち
+    minHeight: 270,
+  },
+  linkedBookPlaceholder: {
+    // NOTE: 決め打ち
+    minHeight: 205,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderStyle: "dashed",
   },
   books: {
     marginTop: theme.spacing(1),
@@ -66,6 +80,7 @@ export default function Books(props: Props) {
   const handleBookNewClick = () => onBookNewClick();
   const classes = useStyles();
   const containerClasses = useContainerStyles();
+  const cardClasses = useCardStyles();
   const infiniteRef = useInfiniteScroll<HTMLDivElement>({
     loading,
     hasNextPage,
@@ -85,7 +100,7 @@ export default function Books(props: Props) {
           </>
         }
         body={
-          <>
+          <div className={classes.linkedBook}>
             <Typography className={classes.title} variant="h5">
               提供中のブック
             </Typography>
@@ -102,13 +117,18 @@ export default function Books(props: Props) {
               />
             )}
             {!linkedBook && (
-              <Typography variant="body2">
-                提供中のブックがありません。
-                <br />
-                ブックを提供するには、提供したいブックの「このブックを提供」ボタンをクリックしてください。
-              </Typography>
+              <Card
+                classes={cardClasses}
+                className={classes.linkedBookPlaceholder}
+              >
+                <Typography variant="body2">
+                  提供中のブックがありません。
+                  <br />
+                  ブックを提供するには、提供したいブックの「このブックを提供」ボタンをクリックしてください。
+                </Typography>
+              </Card>
             )}
-          </>
+          </div>
         }
         action={
           <>


### PR DESCRIPTION
https://github.com/npocccties/chibichilo/issues/418#issuecomment-865507082 を改善します

変更前

![image](https://user-images.githubusercontent.com/9744580/122873296-8bc7fc00-d36c-11eb-9f7f-22bb79fe487c.png)

変更後

![image](https://user-images.githubusercontent.com/9744580/122873258-81a5fd80-d36c-11eb-9324-0ac694af8e5b.png)

「提供中のブック」の表示領域がウィンドウの表示領域内にある状態で異なるブックを提供すると、「提供中のブック」が存在しない場合に表示されるメッセージが瞬間的に表示される場合があります。その際のメッセージとBookPreviewの画面要素のheightが異なり、そのheight差分のぶん「ガクッと」一覧されるブックの表示位置が変動します。

この変更によって、「提供中のブック」がない場合に表示されるメッセージをBookPreviewの高さ相当に調節し、「ガクッと」表示位置が変動されることを抑制します。

また、この変更の副次的な要素としてBookPreviewに動画プレイヤーがない場合等の高さが微妙に異なる場合もあらかじめ所定の高さをminHeightによって指定しているため、こちらのケースについても表示位置の変動が抑制されます。