### PR TITLE
fix: TextField multilineの下辺の余白がない

### DIFF
--- a/styles/input.ts
+++ b/styles/input.ts
@@ -8,9 +8,6 @@ const input = makeStyles((theme) => ({
     borderRadius: "6px",
     fontSize: "1rem",
     transition: theme.transitions.create(["border-color"]),
-    "&$focused": {
-      borderColor: theme.palette.primary.main,
-    },
   },
   input: {
     height: "100%",
@@ -27,14 +24,15 @@ const input = makeStyles((theme) => ({
     borderRadius: "6px",
     padding: `${theme.spacing(1.25)}px ${theme.spacing(1.75)}px`,
     transition: theme.transitions.create(["border-color"]),
-    "&$focused": {
-      borderColor: theme.palette.primary.main,
-    },
   },
   inputMultiline: {
     padding: 0,
   },
-  focused: {},
+  focused: {
+    "&$root, &$multiline": {
+      borderColor: theme.palette.primary.main,
+    },
+  },
 }));
 
 export default input;

--- a/styles/input.ts
+++ b/styles/input.ts
@@ -2,17 +2,19 @@ import { makeStyles } from "@material-ui/core/styles";
 import gray from "theme/colors/gray";
 
 const input = makeStyles((theme) => ({
-  input: {
+  root: {
     backgroundColor: theme.palette.common.white,
     border: `1px solid ${gray[500]}`,
     borderRadius: "6px",
-    height: "100%",
     fontSize: "1rem",
-    padding: `${theme.spacing(1.25)}px ${theme.spacing(1.75)}px`,
     transition: theme.transitions.create(["border-color"]),
-    "&:focus": {
+    "&$focused": {
       borderColor: theme.palette.primary.main,
     },
+  },
+  input: {
+    height: "100%",
+    padding: `${theme.spacing(1.25)}px ${theme.spacing(1.75)}px`,
   },
   formControl: {
     "label + &": {
@@ -20,8 +22,19 @@ const input = makeStyles((theme) => ({
     },
   },
   multiline: {
+    backgroundColor: theme.palette.common.white,
+    border: `1px solid ${gray[500]}`,
+    borderRadius: "6px",
+    padding: `${theme.spacing(1.25)}px ${theme.spacing(1.75)}px`,
+    transition: theme.transitions.create(["border-color"]),
+    "&$focused": {
+      borderColor: theme.palette.primary.main,
+    },
+  },
+  inputMultiline: {
     padding: 0,
   },
+  focused: {},
 }));
 
 export default input;


### PR DESCRIPTION
MuiTextFieldのスタイルのカスタマイズが不十分で、複数行入力の際の下辺の余白がなくつまっている状態でした。それを解消する変更です。

```
div.MuiInputBase-root
    inputあるいはtextarea
```

というマークアップ構造で、単一行(input)時はinputに対してborderとpaddingを設定するので問題なかったのですが、複数行(textarea)時は、アウターdivに対してborderとpaddingの設定をしないと意図した余白になりませんでした。

変更前

![image](https://user-images.githubusercontent.com/9744580/122891457-7f00d380-d37f-11eb-926a-0036069d25eb.png)

変更後

![image](https://user-images.githubusercontent.com/9744580/122893708-8923d180-d381-11eb-97c5-9d0eb4d1191e.png)
