### PR TITLE
feat: 提供中は提供に関するオプションを表示しない&シェアと見た目を統一

### DIFF
--- a/components/organisms/BookForm.stories.tsx
+++ b/components/organisms/BookForm.stories.tsx
@@ -1,10 +1,14 @@
+import type { Story } from "@storybook/react";
 import BookForm from "./BookForm";
 import { book } from "samples";
 
-export default { title: "organisms/BookForm" };
+export default { title: "organisms/BookForm", component: BookForm };
 
-const defaultProps = { book, onSubmit: console.log };
+const Template: Story<Parameters<typeof BookForm>[0]> = (args) => {
+  return <BookForm {...args} />;
+};
 
-export const Default = () => <BookForm {...defaultProps} />;
-
-export const Update = () => <BookForm variant="update" {...defaultProps} />;
+export const Default = Template.bind({});
+Default.args = {
+  book,
+};

--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -30,10 +30,6 @@ const useStyles = makeStyles((theme) => ({
   divider: {
     margin: theme.spacing(0, -3, 0),
   },
-  submitOption: {
-    display: "flex",
-    alignItems: "center",
-  },
 }));
 
 const label = {
@@ -50,19 +46,20 @@ const label = {
 type Props = {
   book?: BookSchema;
   id?: string;
+  linked?: boolean;
   className?: string;
   variant?: "create" | "update";
   onSubmit?: (book: BookPropsWithSubmitOptions) => void;
 };
 
-export default function BookForm(props: Props) {
-  const {
-    book,
-    className,
-    id,
-    variant = "create",
-    onSubmit = () => undefined,
-  } = props;
+export default function BookForm({
+  book,
+  className,
+  id,
+  linked = false,
+  variant = "create",
+  onSubmit = () => undefined,
+}: Props) {
   const cardClasses = useCardStyles();
   const inputLabelClasses = useInputLabelStyles();
   const classes = useStyles();
@@ -162,18 +159,20 @@ export default function BookForm(props: Props) {
         inputRef={register}
       />
       <Divider className={classes.divider} />
-      <div className={classes.submitOption}>
-        <Checkbox
-          id="submit-with-link"
-          name="submitWithLink"
-          inputRef={register}
-          defaultChecked={defaultValues.submitWithLink}
-          color="primary"
-        />
-        <InputLabel classes={inputLabelClasses} htmlFor="submit-with-link">
-          {label[variant].submitWithLink}
-        </InputLabel>
-      </div>
+      {!linked && (
+        <div>
+          <InputLabel classes={inputLabelClasses} htmlFor="submit-with-link">
+            {label[variant].submitWithLink}
+          </InputLabel>
+          <Checkbox
+            id="submit-with-link"
+            name="submitWithLink"
+            inputRef={register}
+            defaultChecked={defaultValues.submitWithLink}
+            color="primary"
+          />
+        </div>
+      )}
       <Button variant="contained" color="primary" type="submit">
         {label[variant].submit}
       </Button>

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -1,29 +1,18 @@
-export default {
-  title: "templates/BookEdit",
-  parameters: { layout: "fullscreen" },
-};
-
+import type { Story } from "@storybook/react";
 import BookEdit from "./BookEdit";
 import { book } from "samples";
 
-const handleSubmit = console.log;
-const handleDelete = console.log;
-const handleCancel = () => console.log("back");
-const handleSectionsUpdate = console.log;
-const handleTopicImportClick = () => console.log("onTopicImportClick");
-const handleTopicNewClick = () => console.log("onTopicNewClick");
-const handleBookImportClick = () => console.log("onBookImportClick");
-const handleTopicEditClick = console.log;
-const handlers = {
-  onSubmit: handleSubmit,
-  onDelete: handleDelete,
-  onCancel: handleCancel,
-  onSectionsUpdate: handleSectionsUpdate,
-  onTopicImportClick: handleTopicImportClick,
-  onTopicNewClick: handleTopicNewClick,
-  onTopicEditClick: handleTopicEditClick,
-  onBookImportClick: handleBookImportClick,
-  isTopicEditable: () => true,
+export default {
+  title: "templates/BookEdit",
+  component: BookEdit,
+  parameters: { layout: "fullscreen" },
 };
 
-export const Default = () => <BookEdit book={book} {...handlers} />;
+const Template: Story<Parameters<typeof BookEdit>[0]> = (args) => {
+  return <BookEdit {...args} isTopicEditable={() => true} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  book,
+};

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -52,21 +52,22 @@ type Props = {
   onTopicEditClick?(topic: TopicSchema): void;
   onBookImportClick(): void;
   isTopicEditable?(topic: TopicSchema): boolean | undefined;
+  linked?: boolean;
 };
 
-export default function BookEdit(props: Props) {
-  const {
-    book,
-    onSubmit,
-    onDelete,
-    onCancel,
-    onSectionsUpdate,
-    onTopicImportClick,
-    onTopicNewClick,
-    onTopicEditClick,
-    onBookImportClick,
-    isTopicEditable,
-  } = props;
+export default function BookEdit({
+  book,
+  onSubmit,
+  onDelete,
+  onCancel,
+  onSectionsUpdate,
+  onTopicImportClick,
+  onTopicNewClick,
+  onTopicEditClick,
+  onBookImportClick,
+  isTopicEditable,
+  linked = false,
+}: Props) {
   const classes = useStyles();
   const containerClasses = useContainerStyles();
   const confirm = useConfirm();
@@ -120,6 +121,7 @@ export default function BookEdit(props: Props) {
       <BookForm
         className={classes.content}
         book={book}
+        linked={linked}
         variant="update"
         onSubmit={onSubmit}
       />

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -15,7 +15,7 @@ export type Query = { bookId: BookSchema["id"]; context?: "books" };
 
 function Edit({ bookId, context }: Query) {
   const query = { bookId, ...(context && { context }) };
-  const { isBookEditable, isTopicEditable } = useSessionAtom();
+  const { session, isBookEditable, isTopicEditable } = useSessionAtom();
   const { book, error } = useBook(bookId, isBookEditable, isTopicEditable);
   const router = useRouter();
   const handleBookLink = useBookLinkHandler();
@@ -75,6 +75,7 @@ function Edit({ bookId, context }: Query) {
     return router.push(pagesPath.book.topic.import.$url({ query }));
   }
   const handlers = {
+    linked: bookId === session?.ltiResourceLink?.bookId,
     onSubmit: handleSubmit,
     onDelete: handleDelete,
     onCancel: handleCancel,


### PR DESCRIPTION
下記の対応です

> > 「他の教員にシェア」のチェックボックスの見せ方と，揃っていない
> 
> 意図はありまして、
> 
> - フォームの実線で区切ったものより上：ブックに持たせる情報の入力
> - 区切ったものより下：ブックに対する操作に関する情報の入力
> 
> なので何らかの方法で区別する必要があると考えていました
> 
> ただ「他の教員にシェア」と「更新したブックを提供」はフォーム内の他のラベルと異なり動名詞でのラベリングになっている点でも似ており、わざわざラベルのレイアウトで差別化するのは果たして適切なのかと自分でも思います
> 
> > すでに提供中なので，チェックできなくして提供中の文言に変えるなど，混乱しない配慮
> 
> 非活性にするのであればラベルの文言は変更せずに、注釈を別途表示するのがよいかと思いました。
> 
> 非表示にすることも考えられますが「提供中のブックに対して編集している」ことが分かる工夫がいずれにせよ必要になると思いました
> 
> _Originally posted by @knokmki612 in https://github.com/npocccties/chibichilo/issues/428#issuecomment-873759750_

> 非表示にすることも考えられますが「提供中のブックに対して編集している」ことが分かる工夫がいずれにせよ必要になると思いました

は検討してみたのですが、

- ブック編集に至るまでの動線で「提供中のブック(ブック視聴)」もしくは「ブック一覧」にて提供中のブックかどうか識別してアクセスするのでまったく提供中かどうかの情報提示がされないわけではない
- ブック編集上にブックの閲覧系の情報を配置したり動線を増やすのは #291 で検討したほうがいいのでは

という2点からこのプルリクエストでは対応しませんでした