### PR TITLE
fix: ブック視聴時にトピックの編集ボタンが表示されない

### DIFF
--- a/components/atoms/BookChildrenItem.tsx
+++ b/components/atoms/BookChildrenItem.tsx
@@ -56,7 +56,7 @@ type Props = Parameters<typeof ListItem>[0] & {
   end?: boolean;
   outlineNumber?: string;
   name: string | null;
-  children?: React.Node;
+  children?: React.ReactNode;
 };
 
 export default function BookChildrenItem({

--- a/components/atoms/BookChildrenItem.tsx
+++ b/components/atoms/BookChildrenItem.tsx
@@ -56,6 +56,7 @@ type Props = Parameters<typeof ListItem>[0] & {
   end?: boolean;
   outlineNumber?: string;
   name: string | null;
+  children?: React.Node;
 };
 
 export default function BookChildrenItem({
@@ -64,6 +65,7 @@ export default function BookChildrenItem({
   end,
   outlineNumber,
   name,
+  children,
   ...other
 }: Props) {
   const classes = useStyles({ depth });
@@ -74,6 +76,7 @@ export default function BookChildrenItem({
       <ListItemText>
         <span className={classes.title}>{name}</span>
       </ListItemText>
+      {children}
     </ListItem>
   );
 }


### PR DESCRIPTION
#459 時点で children propsが用意されておらず編集ボタンが表示されなくなっていました

![image](https://user-images.githubusercontent.com/9744580/125937976-fc2d5c25-bc7d-401f-a060-ad63b21ca5a4.png)