### PR TITLE
feat: ツリー表示をアイコンで表現している違和感を抑制するデザイン変更

### DIFF
--- a/components/atoms/BookChildrenItem.tsx
+++ b/components/atoms/BookChildrenItem.tsx
@@ -11,7 +11,7 @@ type IconProps = Pick<Parameters<typeof SvgIcon>[0], "className"> &
 function Icon({ variant, end = false, ...other }: IconProps) {
   const d = {
     section: {
-      middle: "M16 26C16 20.0582 15 16.3333 8.5 12C2 7.66667 1 1 1 1V26",
+      middle: "M16 26C16 20.0582 15 16.3333 8.5 12C2 7.66667 1 1 1 1V13",
       end: "M1 1C1 1 2 7.66667 8.5 12C15 16.3333 16 20.0582 16 26",
     },
     topic: {
@@ -20,7 +20,7 @@ function Icon({ variant, end = false, ...other }: IconProps) {
     },
   } as const;
   return (
-    <SvgIcon {...other} viewBox="0 0 19 27">
+    <SvgIcon {...other} viewBox="0 0 20 28">
       <path
         d={d[variant][end ? "end" : "middle"]}
         fill="none"
@@ -29,6 +29,22 @@ function Icon({ variant, end = false, ...other }: IconProps) {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
+      {variant === "section" && !end && (
+        <>
+          <path
+            d="M1 24V26"
+            stroke={gray[700]}
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+          <path
+            d="M1 16V21"
+            stroke={gray[700]}
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </>
+      )}
       {variant === "topic" && (
         <circle cx="15.5" cy="14.5" r="3.5" fill={gray[700]} />
       )}
@@ -46,7 +62,11 @@ const useStyles = makeStyles((theme: Theme) =>
       marginRight: theme.spacing(1),
       lineHeight: 1,
     },
-    title: {},
+    title: {
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+      textOverflow: "ellipsis",
+    },
   })
 );
 
@@ -70,11 +90,11 @@ export default function BookChildrenItem({
 }: Props) {
   const classes = useStyles({ depth });
   return (
-    <ListItem {...other}>
+    <ListItem dense {...other}>
       <Icon className={classes.icon} variant={variant} end={end} />
       <span className={classes.outlineNumber}>{outlineNumber}</span>
-      <ListItemText>
-        <span className={classes.title}>{name}</span>
+      <ListItemText className={classes.title} disableTypography>
+        {name}
       </ListItemText>
       {children}
     </ListItem>

--- a/components/atoms/BookChildrenItem.tsx
+++ b/components/atoms/BookChildrenItem.tsx
@@ -11,7 +11,7 @@ type IconProps = Pick<Parameters<typeof SvgIcon>[0], "className"> &
 function Icon({ variant, end = false, ...other }: IconProps) {
   const d = {
     section: {
-      middle: "M16 26C16 20.0582 15 16.3333 8.5 12C2 7.66667 1 1 1 1V13",
+      middle: "M16 26C16 20.0582 15 16.3333 8.5 12C2 7.66667 1 1 1 1V9",
       end: "M1 1C1 1 2 7.66667 8.5 12C15 16.3333 16 20.0582 16 26",
     },
     topic: {
@@ -32,13 +32,13 @@ function Icon({ variant, end = false, ...other }: IconProps) {
       {variant === "section" && !end && (
         <>
           <path
-            d="M1 24V26"
+            d="M1 21V26"
             stroke={gray[700]}
             strokeWidth="2"
             strokeLinecap="round"
           />
           <path
-            d="M1 16V21"
+            d="M1 12V18"
             stroke={gray[700]}
             strokeWidth="2"
             strokeLinecap="round"


### PR DESCRIPTION
https://github.com/npocccties/chibichilo/issues/410#issuecomment-878907091 への対応です

ツリー風の表示だが実際にはそれをアイコンで表現しているため、線が途切れ途切れになり違和感が生じていました。

- トピック、セクション名は折り返しせずはみ出た分は省略する
    - 副作用としてTypographyのスタイルを省いたためフォントサイズが少し小さくなっている
- ListItemの表示間隔を狭める
- 後続のあるセクションは途切れ線で線がとぎれていることを提示する

という対処をしました

PRと直接関係ない変更を1点おこないました

- svg viewBoxが現状だと端の丸み処理がみきれていたので少し広げた

変更前

![image](https://user-images.githubusercontent.com/9744580/126097825-de7324f3-1171-4525-a201-7553fcab5362.png)

変更後

![image](https://user-images.githubusercontent.com/9744580/126097844-1a8a90b6-f7c0-4c25-a0ba-a4d84e815886.png)
