### PR TITLE
fix: 開発用のDocker Composeサービスの構築に失敗する問題の対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@
 version: "3"
 services:
   mariadb:
-    image: "mariadb:10"
+    image: "mariadb:10.5.11-focal"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: bitnami_moodle
   moodle:
-    image: "bitnami/moodle:3"
+    image: "bitnami/moodle:3.11.1-debian-10-r13"
     ports: ["8081:8080"]
     environment:
       MOODLE_USERNAME: user
@@ -17,13 +17,13 @@ services:
       BITNAMI_DEBUG: "true"
     depends_on: [mariadb]
   db:
-    image: postgres:13-alpine
+    image: "postgres:13.3-alpine3.14"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports: ["5432:5432"]
   app:
-    image: node:lts-alpine
+    image: "node:14.17-alpine3.14"
     environment:
       FRONTEND_ORIGIN: "http://localhost:3000"
       SESSION_SECRET: super_secret_characters_for_session

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       MOODLE_PASSWORD: password
       ALLOW_EMPTY_PASSWORD: "yes"
       MOODLE_DATABASE_USER: root
+      BITNAMI_DEBUG: "true"
     depends_on: [mariadb]
   db:
     image: postgres:13-alpine

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db:
-    image: postgres:13-alpine
+    image: "postgres:13.3-alpine3.14"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
fix #473 変更は開発者向けで本番環境ならびに本番相当環境への影響は無いと判断するためマージ後クローズしますね > @ties-makimura, @horimasumi 

やったこと:

- fix: bitnami/moodle デバッグ用環境変数の宣言
- fix: バージョンの不整合によって開発用のDocker Composeサービスの構築での失敗への対応
