### PR TITLE
fix: プレビュー画面と視聴画面でインデントが異なる

### DIFF
--- a/components/organisms/BookChildren.tsx
+++ b/components/organisms/BookChildren.tsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: "0.875rem",
     },
     indent: {
-      "& > :not(:first-child) > $outlineNumber": {
+      "& > :not(:first-child) $outlineNumber": {
         marginLeft: `${0.875 * 1.2}rem`,
       },
     },


### PR DESCRIPTION
#477 への対応です

 `ListItem` に `ListItemSecondaryAction` が含まれているとcontainerが追加されマークアップ構造が変化し、CSSセレクタにマッチしないのが原因でした。子セレクタの代わりに子孫セレクタをつかうことで対処しています