### PR TITLE
feat: LTIのためのデータモデリングとスキーマの更新

### DIFF
--- a/components/organisms/LtiItemDialog.tsx
+++ b/components/organisms/LtiItemDialog.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import Typography from "@material-ui/core/Typography";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -18,10 +19,32 @@ type Props = {
   onClose: React.MouseEventHandler;
 };
 
+/** LTI v1.1 起動時リクエストっぽいオブジェクトへの変換 */
+function useLtiLaunchBody(session: SessionSchema) {
+  return useMemo(
+    () => ({
+      oauth_nonce: session.oauthClient.nonce,
+      oauth_consumer_key: session.oauthClient.id,
+      lti_version: session.ltiVersion,
+      resource_link_id: session.ltiResourceLinkRequest.id,
+      user_id: session.ltiUser.id,
+      roles: session.ltiRoles.join(","),
+      context_id: session.ltiContext.id,
+      resource_link_title: session.ltiResourceLinkRequest.title,
+      context_title: session.ltiContext.title,
+      context_label: session.ltiContext.label,
+      lis_person_name_full: session.ltiUser.name,
+      launch_presentation_return_url: session.ltiLaunchPresentation?.returnUrl,
+    }),
+    [session]
+  );
+}
+
 export default function LtiItemDialog(props: Props) {
   const cardClasses = useCardStyles();
   const classes = useStyles();
   const { session, open, onClose } = props;
+  const ltiLaunchBody = useLtiLaunchBody(session);
   return (
     <Dialog
       open={open}
@@ -34,10 +57,9 @@ export default function LtiItemDialog(props: Props) {
           LTI情報
         </Typography>
         <DescriptionList
-          value={Object.entries(session.ltiLaunchBody).map(([key, value]) => ({
-            key,
-            value,
-          }))}
+          value={Object.entries(ltiLaunchBody).flatMap(([key, value]) =>
+            value == null ? [] : [{ key, value }]
+          )}
         />
       </DialogContent>
     </Dialog>

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -108,6 +108,11 @@ export interface ApiV2EventPostRequest {
     body?: InlineObject8;
 }
 
+export interface ApiV2LtiCallbackPostRequest {
+    state: string;
+    idToken: string;
+}
+
 export interface ApiV2LtiLaunchPostRequest {
     oauthVersion: string;
     oauthNonce: string;
@@ -126,6 +131,24 @@ export interface ApiV2LtiLaunchPostRequest {
     contextLabel?: string;
     lisPersonNameFull?: string;
     launchPresentationReturnUrl?: string;
+}
+
+export interface ApiV2LtiLoginGetRequest {
+    iss: string;
+    loginHint: string;
+    targetLinkUri: string;
+    clientId: string;
+    ltiMessageHint?: string;
+    ltiDeploymentId?: string;
+}
+
+export interface ApiV2LtiLoginPostRequest {
+    iss: string;
+    loginHint: string;
+    targetLinkUri: string;
+    clientId: string;
+    ltiMessageHint?: string;
+    ltiDeploymentId?: string;
 }
 
 export interface ApiV2LtiLtiConsumerIdResourceLinkLtiResourceLinkIdDeleteRequest {
@@ -446,16 +469,47 @@ export class DefaultApi extends runtime.BaseAPI {
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのリダイレクトURIに指定して利用します。 成功時 http://localhost:3000/ にリダイレクトします。
      * LTI v1.3 リダイレクトURI
      */
-    async apiV2LtiCallbackPostRaw(): Promise<runtime.ApiResponse<void>> {
+    async apiV2LtiCallbackPostRaw(requestParameters: ApiV2LtiCallbackPostRequest): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.state === null || requestParameters.state === undefined) {
+            throw new runtime.RequiredError('state','Required parameter requestParameters.state was null or undefined when calling apiV2LtiCallbackPost.');
+        }
+
+        if (requestParameters.idToken === null || requestParameters.idToken === undefined) {
+            throw new runtime.RequiredError('idToken','Required parameter requestParameters.idToken was null or undefined when calling apiV2LtiCallbackPost.');
+        }
+
         const queryParameters: runtime.HTTPQuery = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
+
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            formParams = new FormData();
+        } else {
+            formParams = new URLSearchParams();
+        }
+
+        if (requestParameters.state !== undefined) {
+            formParams.append('state', requestParameters.state as any);
+        }
+
+        if (requestParameters.idToken !== undefined) {
+            formParams.append('id_token', requestParameters.idToken as any);
+        }
 
         const response = await this.request({
             path: `/api/v2/lti/callback`,
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -465,8 +519,8 @@ export class DefaultApi extends runtime.BaseAPI {
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのリダイレクトURIに指定して利用します。 成功時 http://localhost:3000/ にリダイレクトします。
      * LTI v1.3 リダイレクトURI
      */
-    async apiV2LtiCallbackPost(): Promise<void> {
-        await this.apiV2LtiCallbackPostRaw();
+    async apiV2LtiCallbackPost(requestParameters: ApiV2LtiCallbackPostRequest): Promise<void> {
+        await this.apiV2LtiCallbackPostRaw(requestParameters);
     }
 
     /**
@@ -631,8 +685,48 @@ export class DefaultApi extends runtime.BaseAPI {
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
      * LTI v1.3 ログイン初期化エンドポイント
      */
-    async apiV2LtiLoginGetRaw(): Promise<runtime.ApiResponse<void>> {
+    async apiV2LtiLoginGetRaw(requestParameters: ApiV2LtiLoginGetRequest): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.iss === null || requestParameters.iss === undefined) {
+            throw new runtime.RequiredError('iss','Required parameter requestParameters.iss was null or undefined when calling apiV2LtiLoginGet.');
+        }
+
+        if (requestParameters.loginHint === null || requestParameters.loginHint === undefined) {
+            throw new runtime.RequiredError('loginHint','Required parameter requestParameters.loginHint was null or undefined when calling apiV2LtiLoginGet.');
+        }
+
+        if (requestParameters.targetLinkUri === null || requestParameters.targetLinkUri === undefined) {
+            throw new runtime.RequiredError('targetLinkUri','Required parameter requestParameters.targetLinkUri was null or undefined when calling apiV2LtiLoginGet.');
+        }
+
+        if (requestParameters.clientId === null || requestParameters.clientId === undefined) {
+            throw new runtime.RequiredError('clientId','Required parameter requestParameters.clientId was null or undefined when calling apiV2LtiLoginGet.');
+        }
+
         const queryParameters: runtime.HTTPQuery = {};
+
+        if (requestParameters.iss !== undefined) {
+            queryParameters['iss'] = requestParameters.iss;
+        }
+
+        if (requestParameters.loginHint !== undefined) {
+            queryParameters['login_hint'] = requestParameters.loginHint;
+        }
+
+        if (requestParameters.targetLinkUri !== undefined) {
+            queryParameters['target_link_uri'] = requestParameters.targetLinkUri;
+        }
+
+        if (requestParameters.ltiMessageHint !== undefined) {
+            queryParameters['lti_message_hint'] = requestParameters.ltiMessageHint;
+        }
+
+        if (requestParameters.ltiDeploymentId !== undefined) {
+            queryParameters['lti_deployment_id'] = requestParameters.ltiDeploymentId;
+        }
+
+        if (requestParameters.clientId !== undefined) {
+            queryParameters['client_id'] = requestParameters.clientId;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -650,24 +744,79 @@ export class DefaultApi extends runtime.BaseAPI {
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
      * LTI v1.3 ログイン初期化エンドポイント
      */
-    async apiV2LtiLoginGet(): Promise<void> {
-        await this.apiV2LtiLoginGetRaw();
+    async apiV2LtiLoginGet(requestParameters: ApiV2LtiLoginGetRequest): Promise<void> {
+        await this.apiV2LtiLoginGetRaw(requestParameters);
     }
 
     /**
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
      * LTI v1.3 ログイン初期化エンドポイント
      */
-    async apiV2LtiLoginPostRaw(): Promise<runtime.ApiResponse<void>> {
+    async apiV2LtiLoginPostRaw(requestParameters: ApiV2LtiLoginPostRequest): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.iss === null || requestParameters.iss === undefined) {
+            throw new runtime.RequiredError('iss','Required parameter requestParameters.iss was null or undefined when calling apiV2LtiLoginPost.');
+        }
+
+        if (requestParameters.loginHint === null || requestParameters.loginHint === undefined) {
+            throw new runtime.RequiredError('loginHint','Required parameter requestParameters.loginHint was null or undefined when calling apiV2LtiLoginPost.');
+        }
+
+        if (requestParameters.targetLinkUri === null || requestParameters.targetLinkUri === undefined) {
+            throw new runtime.RequiredError('targetLinkUri','Required parameter requestParameters.targetLinkUri was null or undefined when calling apiV2LtiLoginPost.');
+        }
+
+        if (requestParameters.clientId === null || requestParameters.clientId === undefined) {
+            throw new runtime.RequiredError('clientId','Required parameter requestParameters.clientId was null or undefined when calling apiV2LtiLoginPost.');
+        }
+
         const queryParameters: runtime.HTTPQuery = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
+
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            formParams = new FormData();
+        } else {
+            formParams = new URLSearchParams();
+        }
+
+        if (requestParameters.iss !== undefined) {
+            formParams.append('iss', requestParameters.iss as any);
+        }
+
+        if (requestParameters.loginHint !== undefined) {
+            formParams.append('login_hint', requestParameters.loginHint as any);
+        }
+
+        if (requestParameters.targetLinkUri !== undefined) {
+            formParams.append('target_link_uri', requestParameters.targetLinkUri as any);
+        }
+
+        if (requestParameters.ltiMessageHint !== undefined) {
+            formParams.append('lti_message_hint', requestParameters.ltiMessageHint as any);
+        }
+
+        if (requestParameters.ltiDeploymentId !== undefined) {
+            formParams.append('lti_deployment_id', requestParameters.ltiDeploymentId as any);
+        }
+
+        if (requestParameters.clientId !== undefined) {
+            formParams.append('client_id', requestParameters.clientId as any);
+        }
 
         const response = await this.request({
             path: `/api/v2/lti/login`,
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -677,8 +826,8 @@ export class DefaultApi extends runtime.BaseAPI {
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
      * LTI v1.3 ログイン初期化エンドポイント
      */
-    async apiV2LtiLoginPost(): Promise<void> {
-        await this.apiV2LtiLoginPostRaw();
+    async apiV2LtiLoginPost(requestParameters: ApiV2LtiLoginPostRequest): Promise<void> {
+        await this.apiV2LtiLoginPostRaw(requestParameters);
     }
 
     /**

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -66,9 +66,6 @@ import {
     InlineResponse2005,
     InlineResponse2005FromJSON,
     InlineResponse2005ToJSON,
-    InlineResponse2006,
-    InlineResponse2006FromJSON,
-    InlineResponse2006ToJSON,
     InlineResponse201,
     InlineResponse201FromJSON,
     InlineResponse201ToJSON,
@@ -863,7 +860,7 @@ export class DefaultApi extends runtime.BaseAPI {
      * 自身に関する詳細な情報を取得します。
      * セッション情報
      */
-    async apiV2SessionGetRaw(): Promise<runtime.ApiResponse<InlineResponse2006>> {
+    async apiV2SessionGetRaw(): Promise<runtime.ApiResponse<{ [key: string]: object; }>> {
         const queryParameters: runtime.HTTPQuery = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -875,14 +872,14 @@ export class DefaultApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2006FromJSON(jsonValue));
+        return new runtime.JSONApiResponse<any>(response);
     }
 
     /**
      * 自身に関する詳細な情報を取得します。
      * セッション情報
      */
-    async apiV2SessionGet(): Promise<InlineResponse2006> {
+    async apiV2SessionGet(): Promise<{ [key: string]: object; }> {
         const response = await this.apiV2SessionGetRaw();
         return await response.value();
     }

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -443,6 +443,33 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
+     * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのリダイレクトURIに指定して利用します。 成功時 http://localhost:3000/ にリダイレクトします。
+     * LTI v1.3 リダイレクトURI
+     */
+    async apiV2LtiCallbackPostRaw(): Promise<runtime.ApiResponse<void>> {
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/api/v2/lti/callback`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        });
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのリダイレクトURIに指定して利用します。 成功時 http://localhost:3000/ にリダイレクトします。
+     * LTI v1.3 リダイレクトURI
+     */
+    async apiV2LtiCallbackPost(): Promise<void> {
+        await this.apiV2LtiCallbackPostRaw();
+    }
+
+    /**
      * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのURLに指定して利用します。 成功時 http://localhost:3000/ にリダイレクトします。
      * LTI起動エンドポイント
      */
@@ -598,6 +625,60 @@ export class DefaultApi extends runtime.BaseAPI {
      */
     async apiV2LtiLaunchPost(requestParameters: ApiV2LtiLaunchPostRequest): Promise<void> {
         await this.apiV2LtiLaunchPostRaw(requestParameters);
+    }
+
+    /**
+     * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
+     * LTI v1.3 ログイン初期化エンドポイント
+     */
+    async apiV2LtiLoginGetRaw(): Promise<runtime.ApiResponse<void>> {
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/api/v2/lti/login`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        });
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
+     * LTI v1.3 ログイン初期化エンドポイント
+     */
+    async apiV2LtiLoginGet(): Promise<void> {
+        await this.apiV2LtiLoginGetRaw();
+    }
+
+    /**
+     * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
+     * LTI v1.3 ログイン初期化エンドポイント
+     */
+    async apiV2LtiLoginPostRaw(): Promise<runtime.ApiResponse<void>> {
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/api/v2/lti/login`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        });
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * LTIツールとして起動するためのエンドポイントです。 このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。 Authorizationエンドポイントにリダイレクトします。
+     * LTI v1.3 ログイン初期化エンドポイント
+     */
+    async apiV2LtiLoginPost(): Promise<void> {
+        await this.apiV2LtiLoginPostRaw();
     }
 
     /**

--- a/openapi/models/index.ts
+++ b/openapi/models/index.ts
@@ -21,8 +21,6 @@ export * from './InlineResponse2002';
 export * from './InlineResponse2003';
 export * from './InlineResponse2004';
 export * from './InlineResponse2005';
-export * from './InlineResponse2006';
-export * from './InlineResponse2006LtiLaunchBody';
 export * from './InlineResponse201';
 export * from './InlineResponse2011';
 export * from './InlineResponse2012';

--- a/samples/session.ts
+++ b/samples/session.ts
@@ -1,24 +1,17 @@
+import { SessionSchema } from "$server/models/session";
 import ltiResourceLink from "./ltiResourceLink";
 import user from "./user";
 
-const session = {
-  ltiLaunchBody: {
-    oauth_version: "1.0",
-    oauth_nonce: "1234567890",
-    oauth_timestamp: "1234567890",
-    oauth_consumer_key: "key",
-    oauth_signature_method: "HMAC-SHA1",
-    oauth_signature: "1234567890abcdeABCDE",
-    lti_message_type: "basic-lti-launch-request",
-    lti_version: "LTI-1p0",
-    resource_link_id: "_1234_1",
-    user_id: "1234567890abcdefg",
-    roles: "urn:lti:role:ims/lis/Instructor",
-    context_id: "1234567890abcdefg",
-    resource_link_title: "テスト教材",
-    context_title: "テストコース",
-    context_label: "テストコース",
-    lis_person_name_full: "山田 太郎",
+const session: SessionSchema = {
+  oauthClient: { id: "key", nonce: "1234567890" },
+  ltiVersion: "1.0.0",
+  ltiUser: { id: "1234567890abcdefg", name: "山田 太郎" },
+  ltiRoles: ["urn:lti:role:ims/lis/Instructor"],
+  ltiResourceLinkRequest: { id: "_1234_1", title: "テスト教材" },
+  ltiContext: {
+    id: "1234567890abcdefg",
+    title: "テストコース",
+    label: "テストコース",
   },
   ltiResourceLink,
   user,

--- a/server/auth/authLtiLaunch.ts
+++ b/server/auth/authLtiLaunch.ts
@@ -1,5 +1,8 @@
 import type { FastifyRequest } from "fastify";
-import { LtiLaunchBody } from "$server/validators/ltiLaunchBody";
+import {
+  LtiLaunchBody,
+  toSessionSchema,
+} from "$server/validators/ltiLaunchBody";
 import { auth, valid } from "$server/utils/ltiv1p1/oauth";
 import prisma from "$server/utils/prisma";
 
@@ -24,7 +27,7 @@ async function authLtiLaunch(req: FastifyRequest) {
 
   if (!authorized) throw new Error("unauthorized");
 
-  req.session.ltiLaunchBody = body;
+  Object.assign(req.session, toSessionSchema(body));
 }
 
 export default authLtiLaunch;

--- a/server/auth/authLtiLaunch.ts
+++ b/server/auth/authLtiLaunch.ts
@@ -35,8 +35,11 @@ export default authLtiLaunch;
 async function lookupSecret(oauthConsumerKey: string) {
   const found = await prisma.ltiConsumer.findUnique({
     where: { id: oauthConsumerKey },
-    select: { secret: true },
+    select: { secret: true, platformId: true },
   });
+
+  // NOTE: LTI v1.3 なので無効
+  if (found?.platformId != null) return;
 
   return found?.secret;
 }

--- a/server/config/routes/lti.ts
+++ b/server/config/routes/lti.ts
@@ -9,7 +9,11 @@ export async function launch(fastify: FastifyInstance) {
   const { method, post } = ltiLaunchService;
   const hooks = makeHooks(fastify, ltiLaunchService.hooks);
 
-  fastify.post(path, { schema: method.post, ...hooks.post }, handler(post));
+  fastify.post<{ Body: ltiLaunchService.Props }>(
+    path,
+    { schema: method.post, ...hooks.post },
+    handler(post)
+  );
 }
 
 export async function resourceLink(fastify: FastifyInstance) {

--- a/server/config/routes/lti.ts
+++ b/server/config/routes/lti.ts
@@ -2,6 +2,8 @@ import { FastifyInstance } from "fastify";
 import makeHooks from "$server/utils/makeHooks";
 import handler from "$server/utils/handler";
 import * as ltiLaunchService from "$server/services/ltiLaunch";
+import * as ltiLoginService from "$server/services/ltiLogin";
+import * as ltiCallbackService from "$server/services/ltiCallback";
 import * as ltiResourceLinkService from "$server/services/ltiResourceLink";
 
 export async function launch(fastify: FastifyInstance) {
@@ -9,11 +11,31 @@ export async function launch(fastify: FastifyInstance) {
   const { method, post } = ltiLaunchService;
   const hooks = makeHooks(fastify, ltiLaunchService.hooks);
 
-  fastify.post<{ Body: ltiLaunchService.Props }>(
-    path,
-    { schema: method.post, ...hooks.post },
-    handler(post)
-  );
+  fastify.post<{
+    Body: ltiLaunchService.Props;
+  }>(path, { schema: method.post, ...hooks.post }, handler(post));
+}
+
+export async function login(fastify: FastifyInstance) {
+  const path = "/lti/login";
+  const { method, get, post } = ltiLoginService;
+
+  fastify.get<{
+    Params: ltiLoginService.Props;
+  }>(path, { schema: method.get }, handler(get));
+
+  fastify.post<{
+    Body: ltiLoginService.Props;
+  }>(path, { schema: method.post }, handler(post));
+}
+
+export async function callback(fastify: FastifyInstance) {
+  const path = "/lti/callback";
+  const { method, post } = ltiCallbackService;
+
+  fastify.post<{
+    Body: ltiCallbackService.Props;
+  }>(path, { schema: method.post }, handler(post));
 }
 
 export async function resourceLink(fastify: FastifyInstance) {

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -58,7 +58,7 @@ export class Event {
 
   /**
    * LTIに送られたリソース情報
-   * LtiLaunchBody["oauth_consumer_key"] + ":" + LtiLaunchBody["resource_link_id"]
+   * OauthClient["id"] + ":" + LtiResourceLinkRequest["id"]
    * ツール起動時に sessionStorage に記録したセッション情報を使い続け、ウィンドウ間で共有しない
    */
   @IsOptional()
@@ -67,7 +67,7 @@ export class Event {
 
   /**
    * LTIに送られたユーザ情報
-   * LtiLaunchBody["oauth_consumer_key"] + ":" + LtiLaunchBody["user_id"]
+   * OauthClient["id"] + ":" + LtiUser["id"]
    * ツール起動時に sessionStorage に記録したセッション情報を使い続け、ウィンドウ間で共有しない
    */
   @IsOptional()
@@ -76,7 +76,7 @@ export class Event {
 
   /**
    * LTIに送られたコース情報
-   * LtiLaunchBody["oauth_consumer_key"] + ":" + LtiLaunchBody["context_id"]
+   * OauthClient["id"] + ":" + LtiContext["id"]
    * ツール起動時に sessionStorage に記録したセッション情報を使い続け、ウィンドウ間で共有しない
    */
   @IsOptional()
@@ -85,7 +85,7 @@ export class Event {
 
   /**
    * LTIに送られたnonce
-   * ウィンドウ間で共有しない LtiLaunchBody["oauth_nonce"]
+   * ウィンドウ間で共有しない OauthClient["nonce"]
    * ツール起動時に sessionStorage に記録したセッション情報を使い続ける
    */
   @IsOptional()

--- a/server/models/ltiContext.ts
+++ b/server/models/ltiContext.ts
@@ -1,0 +1,16 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiContextSchema = {
+  title: "LTI Context",
+  type: "object",
+  required: ["id"],
+  properties: {
+    id: { title: "Context ID", type: "string" },
+    label: { title: "コースコード", type: "string" },
+    title: { title: "コースタイトルまたはコース名", type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+/** LTI Context */
+export type LtiContextSchema = FromSchema<typeof LtiContextSchema>;

--- a/server/models/ltiLaunchPresentation.ts
+++ b/server/models/ltiLaunchPresentation.ts
@@ -1,0 +1,15 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiLaunchPresentationSchema = {
+  title: "LTI Launch Presentation",
+  type: "object",
+  properties: {
+    returnUrl: { title: "return_url", type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+/** LTI Launch Presentation */
+export type LtiLaunchPresentationSchema = FromSchema<
+  typeof LtiLaunchPresentationSchema
+>;

--- a/server/models/ltiResourceLinkRequest.ts
+++ b/server/models/ltiResourceLinkRequest.ts
@@ -1,0 +1,17 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiResourceLinkRequestSchema = {
+  title: "LTI Resource Link Request",
+  type: "object",
+  required: ["id"],
+  properties: {
+    id: { title: "LTI Resource Link ID", type: "string" },
+    title: { title: "Title", type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+/** LTI Resource Link Request */
+export type LtiResourceLinkRequestSchema = FromSchema<
+  typeof LtiResourceLinkRequestSchema
+>;

--- a/server/models/ltiRoles.ts
+++ b/server/models/ltiRoles.ts
@@ -1,0 +1,10 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiRolesSchema = {
+  title: "LTI Roles - LTI バージョンに対応する語彙の文字列の配列",
+  type: "array",
+  items: { type: "string" },
+} as const;
+
+/** LTI Roles - LTI バージョンに対応する語彙の文字列の配列 */
+export type LtiRolesSchema = FromSchema<typeof LtiRolesSchema>;

--- a/server/models/ltiUser.ts
+++ b/server/models/ltiUser.ts
@@ -1,0 +1,15 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiUserSchema = {
+  title: "LTI User",
+  type: "object",
+  required: ["id"],
+  properties: {
+    id: { title: "End-User ID", type: "string" },
+    name: { title: "End-User's full name in displayable", type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+/** LTI User */
+export type LtiUserSchema = FromSchema<typeof LtiUserSchema>;

--- a/server/models/ltiVersion.ts
+++ b/server/models/ltiVersion.ts
@@ -1,0 +1,10 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiVersionSchema = {
+  title: "LTI Version - semver.valid な文字列",
+  type: "string",
+  enum: ["1.0.0", "1.3.0"],
+} as const;
+
+/** LTI Version - semver.valid な文字列 */
+export type LtiVersionSchema = FromSchema<typeof LtiVersionSchema>;

--- a/server/models/oauthClient.ts
+++ b/server/models/oauthClient.ts
@@ -1,0 +1,15 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const OauthClientSchema = {
+  title: "OAuth 2.0 Client",
+  type: "object",
+  required: ["id", "nonce"],
+  properties: {
+    id: { title: "Client ID", type: "string" },
+    nonce: { title: "nonce", type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+/** OAuth 2.0 Client */
+export type OauthClientSchema = FromSchema<typeof OauthClientSchema>;

--- a/server/models/session.ts
+++ b/server/models/session.ts
@@ -1,15 +1,25 @@
 import {
-  LtiLaunchBody,
-  ltiLaunchBodySchema,
-} from "$server/validators/ltiLaunchBody";
-import {
   LtiResourceLinkSchema,
   ltiResourceLinkSchema,
 } from "./ltiResourceLink";
 import { UserSchema, userSchema } from "$server/models/user";
+import { OauthClientSchema } from "./oauthClient";
+import { LtiVersionSchema } from "./ltiVersion";
+import { LtiUserSchema } from "./ltiUser";
+import { LtiRolesSchema } from "./ltiRoles";
+import { LtiResourceLinkRequestSchema } from "./ltiResourceLinkRequest";
+import { LtiContextSchema } from "./ltiContext";
+import { LtiLaunchPresentationSchema } from "./ltiLaunchPresentation";
 
+/** セッション */
 export type SessionSchema = {
-  ltiLaunchBody: LtiLaunchBody;
+  oauthClient: OauthClientSchema;
+  ltiVersion: LtiVersionSchema;
+  ltiUser: LtiUserSchema;
+  ltiRoles: LtiRolesSchema;
+  ltiResourceLinkRequest: LtiResourceLinkRequestSchema;
+  ltiContext: LtiContextSchema;
+  ltiLaunchPresentation?: LtiLaunchPresentationSchema;
   ltiResourceLink: null | LtiResourceLinkSchema;
   user: UserSchema;
 };
@@ -17,12 +27,28 @@ export type SessionSchema = {
 export const sessionSchema = {
   description: "セッション情報",
   type: "object",
+  required: [
+    "oauthClient",
+    "ltiVersion",
+    "ltiUser",
+    "ltiRoles",
+    "ltiResourceLinkRequest",
+    "ltiContext",
+    "user",
+  ],
   properties: {
-    ltiLaunchBody: ltiLaunchBodySchema,
+    oauthClient: OauthClientSchema,
+    ltiVersion: LtiVersionSchema,
+    ltiUser: LtiUserSchema,
+    ltiRoles: LtiRolesSchema,
+    ltiResourceLinkRequest: LtiResourceLinkRequestSchema,
+    ltiContext: LtiContextSchema,
+    ltiLaunchPresentation: LtiLaunchPresentationSchema,
     ltiResourceLink: {
       ...ltiResourceLinkSchema,
       nullable: true,
     },
     user: userSchema,
   },
-};
+  additionalProperties: false,
+} as const;

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "node-scp": "^0.0.14",
     "nodemon": "^2.0.7",
     "npm-run-all": "^4.1.5",
+    "openid-client": "^4.7.4",
     "outdent": "^0.8.0",
     "pino-pretty": "^4.7.1",
     "prisma": "^2.19.0",

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
     "fastify-session": "^5.2.1",
     "fastify-swagger": "^4.4.2",
     "jest": "^26.6.3",
+    "json-schema-to-ts": "^1.6.4",
     "node-interval-tree": "^1.3.3",
     "node-scp": "^0.0.14",
     "nodemon": "^2.0.7",

--- a/server/prisma/migrations/20210629053001_lti_platform/migration.sql
+++ b/server/prisma/migrations/20210629053001_lti_platform/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "lti_consumer" ADD COLUMN     "platform_id" TEXT,
+ALTER COLUMN "secret" SET DEFAULT E'';
+
+-- CreateTable
+CREATE TABLE "lti_platform" (
+    "issuer" TEXT NOT NULL,
+    "metadata" JSONB NOT NULL,
+
+    PRIMARY KEY ("issuer")
+);
+
+-- AddForeignKey
+ALTER TABLE "lti_consumer" ADD FOREIGN KEY ("platform_id") REFERENCES "lti_platform"("issuer") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -102,6 +102,18 @@ model Keyword {
 
 // Map Objects/Learning Contents
 
+/// LTI Platform
+model LtiPlatform {
+  /// OpenID Connect Issuer ID
+  issuer   String        @id
+  /// OpenID Connect Issuer Metadata: authorization_endpoint, jwks_uri, token_endpoint etc.
+  metadata Json
+  /// OpenID Connect Clients
+  clients  LtiConsumer[]
+
+  @@map("lti_platform")
+}
+
 /// LTI Consumer
 model LtiConsumer {
   ltiContext       LtiContext[]
@@ -110,7 +122,10 @@ model LtiConsumer {
   /// OAuth Consumer key ("" は無効)
   id               String            @id
   /// OAuth Consumer secret (LTI v1.1 の場合: "" は無効)
-  secret           String
+  secret           String            @default("")
+  /// LTI Platform (LTI v1.3 の場合: 必須)
+  platform         LtiPlatform?      @relation(fields: [platformId], references: [issuer])
+  platformId       String?           @map("platform_id")
 
   @@map("lti_consumer")
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -109,7 +109,7 @@ model LtiConsumer {
   users            User[]
   /// OAuth Consumer key ("" は無効)
   id               String            @id
-  /// OAuth Consumer secret
+  /// OAuth Consumer secret (LTI v1.1 の場合: "" は無効)
   secret           String
 
   @@map("lti_consumer")

--- a/server/services/init.ts
+++ b/server/services/init.ts
@@ -1,9 +1,12 @@
 import { FastifyRequest } from "fastify";
+import { FRONTEND_ORIGIN, FRONTEND_PATH } from "$server/utils/env";
 import { upsertUser } from "$server/utils/user";
 import {
   findLtiResourceLink,
   upsertLtiResourceLink,
 } from "$server/utils/ltiResourceLink";
+
+const frontendUrl = `${FRONTEND_ORIGIN}${FRONTEND_PATH}`;
 
 /** 起動時の初期化プロセス */
 async function init({ session }: FastifyRequest) {
@@ -28,6 +31,17 @@ async function init({ session }: FastifyRequest) {
   });
 
   Object.assign(session, { ltiResourceLink, user });
+
+  return {
+    status: 302,
+    headers: { location: frontendUrl },
+  } as const;
 }
+
+/** OpenAPI Responses Object */
+init.response = { 302: {} } as const;
+
+/** 成功時のリダイレクト先のフロントエンドのURL */
+init.frontendUrl = frontendUrl;
 
 export default init;

--- a/server/services/init.ts
+++ b/server/services/init.ts
@@ -1,0 +1,33 @@
+import { FastifyRequest } from "fastify";
+import { upsertUser } from "$server/utils/user";
+import {
+  findLtiResourceLink,
+  upsertLtiResourceLink,
+} from "$server/utils/ltiResourceLink";
+
+/** 起動時の初期化プロセス */
+async function init({ session }: FastifyRequest) {
+  const ltiResourceLink = await findLtiResourceLink({
+    consumerId: session.oauthClient.id,
+    id: session.ltiResourceLinkRequest.id,
+  });
+
+  if (ltiResourceLink) {
+    await upsertLtiResourceLink({
+      ...ltiResourceLink,
+      title: session.ltiResourceLinkRequest.title ?? ltiResourceLink.title,
+      contextTitle: session.ltiContext.title ?? ltiResourceLink.contextTitle,
+      contextLabel: session.ltiContext.label ?? ltiResourceLink.contextLabel,
+    });
+  }
+
+  const user = await upsertUser({
+    ltiConsumerId: session.oauthClient.id,
+    ltiUserId: session.ltiUser.id,
+    name: session.ltiUser.name ?? "",
+  });
+
+  Object.assign(session, { ltiResourceLink, user });
+}
+
+export default init;

--- a/server/services/ltiCallback.ts
+++ b/server/services/ltiCallback.ts
@@ -35,10 +35,7 @@ export async function post(req: FastifyRequest<{ Body: Props }>) {
   const client = await findClient(req.session.oauthClient.id);
 
   if (!client) {
-    await new Promise((res) =>
-      req.sessionStore.destroy(req.session.sessionId, res)
-    );
-
+    await new Promise(req.destroySession.bind(req));
     return { status: 401 };
   }
 
@@ -82,10 +79,7 @@ export async function post(req: FastifyRequest<{ Body: Props }>) {
       headers: { location: frontendUrl },
     };
   } catch {
-    await new Promise((res) =>
-      req.sessionStore.destroy(req.session.sessionId, res)
-    );
-
+    await new Promise(req.destroySession.bind(req));
     return { status: 401 };
   }
 }

--- a/server/services/ltiCallback.ts
+++ b/server/services/ltiCallback.ts
@@ -5,7 +5,6 @@ import { LtiRolesSchema } from "$server/models/ltiRoles";
 import { LtiResourceLinkRequestSchema } from "$server/models/ltiResourceLinkRequest";
 import { LtiContextSchema } from "$server/models/ltiContext";
 import { LtiLaunchPresentationSchema } from "$server/models/ltiLaunchPresentation";
-import { FRONTEND_ORIGIN, FRONTEND_PATH } from "$server/utils/env";
 import findClient from "$server/utils/ltiv1p3/findClient";
 import init from "./init";
 
@@ -14,18 +13,16 @@ export type Props = {
   state: string;
 };
 
-const frontendUrl = `${FRONTEND_ORIGIN}${FRONTEND_PATH}`;
-
 export const method = {
   post: {
     summary: "LTI v1.3 リダイレクトURI",
     description: outdent`
       LTIツールとして起動するためのエンドポイントです。
       このエンドポイントをLMSのLTIツールのリダイレクトURIに指定して利用します。
-      成功時 ${frontendUrl} にリダイレクトします。`,
+      成功時 ${init.frontendUrl} にリダイレクトします。`,
     consumes: ["application/x-www-form-urlencoded"],
     response: {
-      302: {},
+      ...init.response,
       401: {},
     },
   },
@@ -82,12 +79,7 @@ export async function post(req: FastifyRequest<{ Body: Props }>) {
       ...(ltiLaunchPresentation && { ltiLaunchPresentation }),
     });
 
-    await init(req);
-
-    return {
-      status: 302,
-      headers: { location: frontendUrl },
-    };
+    return await init(req);
   } catch (error) {
     req.log.error(error);
     await new Promise(req.destroySession.bind(req));

--- a/server/services/ltiCallback.ts
+++ b/server/services/ltiCallback.ts
@@ -7,11 +7,9 @@ import { LtiContextSchema } from "$server/models/ltiContext";
 import { LtiLaunchPresentationSchema } from "$server/models/ltiLaunchPresentation";
 import findClient from "$server/utils/ltiv1p3/findClient";
 import init from "./init";
+import { LtiCallbackBody } from "$server/validators/ltiCallbackBody";
 
-export type Props = {
-  id_token: string;
-  state: string;
-};
+export type Props = LtiCallbackBody;
 
 export const method = {
   post: {
@@ -21,6 +19,7 @@ export const method = {
       このエンドポイントをLMSのLTIツールのリダイレクトURIに指定して利用します。
       成功時 ${init.frontendUrl} にリダイレクトします。`,
     consumes: ["application/x-www-form-urlencoded"],
+    body: LtiCallbackBody,
     response: {
       ...init.response,
       401: {},

--- a/server/services/ltiCallback.ts
+++ b/server/services/ltiCallback.ts
@@ -35,6 +35,7 @@ export async function post(req: FastifyRequest<{ Body: Props }>) {
   const client = await findClient(req.session.oauthClient.id);
 
   if (!client) {
+    req.log.error(`Client "${req.session.oauthClient.id}" が存在しません`);
     await new Promise(req.destroySession.bind(req));
     return { status: 401 };
   }
@@ -78,7 +79,8 @@ export async function post(req: FastifyRequest<{ Body: Props }>) {
       status: 302,
       headers: { location: frontendUrl },
     };
-  } catch {
+  } catch (error) {
+    req.log.error(error);
     await new Promise(req.destroySession.bind(req));
     return { status: 401 };
   }

--- a/server/services/ltiLaunch.ts
+++ b/server/services/ltiLaunch.ts
@@ -1,7 +1,6 @@
 import { FastifyRequest } from "fastify";
 import { outdent } from "outdent";
 import authLtiLaunch from "$server/auth/authLtiLaunch";
-import { FRONTEND_ORIGIN, FRONTEND_PATH } from "$server/utils/env";
 import {
   LtiLaunchBody,
   ltiLaunchBodySchema,
@@ -10,20 +9,16 @@ import init from "./init";
 
 export type Props = LtiLaunchBody;
 
-const frontendUrl = `${FRONTEND_ORIGIN}${FRONTEND_PATH}`;
-
 export const method = {
   post: {
     summary: "LTI起動エンドポイント",
     description: outdent`
       LTIツールとして起動するためのエンドポイントです。
       このエンドポイントをLMSのLTIツールのURLに指定して利用します。
-      成功時 ${frontendUrl} にリダイレクトします。`,
+      成功時 ${init.frontendUrl} にリダイレクトします。`,
     consumes: ["application/x-www-form-urlencoded"],
     body: ltiLaunchBodySchema,
-    response: {
-      302: {},
-    },
+    response: init.response,
   },
 };
 
@@ -32,10 +27,5 @@ export const hooks = {
 };
 
 export async function post(req: FastifyRequest<{ Body: Props }>) {
-  await init(req);
-
-  return {
-    status: 302,
-    headers: { location: frontendUrl },
-  };
+  return await init(req);
 }

--- a/server/services/ltiLogin.ts
+++ b/server/services/ltiLogin.ts
@@ -2,16 +2,10 @@ import { FastifyRequest } from "fastify";
 import { outdent } from "outdent";
 import { LtiVersionSchema } from "$server/models/ltiVersion";
 import { OauthClientSchema } from "$server/models/oauthClient";
+import { LtiLoginProps } from "$server/validators/ltiLoginProps";
 import createAccount from "$server/utils/ltiv1p3/createAccount";
 
-export type Props = {
-  client_id: string;
-  iss: string;
-  login_hint: string;
-  target_link_uri: string;
-  lti_message_hint?: string;
-  lti_deployment_id?: string;
-};
+export type Props = LtiLoginProps;
 
 const baseSchema = {
   summary: "LTI v1.3 ログイン初期化エンドポイント",
@@ -19,15 +13,22 @@ const baseSchema = {
     LTIツールとして起動するためのエンドポイントです。
     このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。
     Authorizationエンドポイントにリダイレクトします。`,
-  consumes: [],
   response: {
     302: {},
   },
 };
 
 export const method = {
-  get: baseSchema,
-  post: { ...baseSchema, consumes: ["application/x-www-form-urlencoded"] },
+  get: {
+    ...baseSchema,
+    consumes: [],
+    querystring: LtiLoginProps,
+  },
+  post: {
+    ...baseSchema,
+    consumes: ["application/x-www-form-urlencoded"],
+    body: LtiLoginProps,
+  },
 };
 
 async function baseAction(req: FastifyRequest, props: Props) {

--- a/server/services/ltiLogin.ts
+++ b/server/services/ltiLogin.ts
@@ -1,0 +1,56 @@
+import { FastifyRequest } from "fastify";
+import { outdent } from "outdent";
+import { LtiVersionSchema } from "$server/models/ltiVersion";
+import { OauthClientSchema } from "$server/models/oauthClient";
+import createAccount from "$server/utils/ltiv1p3/createAccount";
+
+export type Props = {
+  client_id: string;
+  iss: string;
+  login_hint: string;
+  target_link_uri: string;
+  lti_message_hint?: string;
+  lti_deployment_id?: string;
+};
+
+const baseSchema = {
+  summary: "LTI v1.3 ログイン初期化エンドポイント",
+  description: outdent`
+    LTIツールとして起動するためのエンドポイントです。
+    このエンドポイントをLMSのLTIツールのログイン初期化エンドポイントに指定して利用します。
+    Authorizationエンドポイントにリダイレクトします。`,
+  consumes: [],
+  response: {
+    302: {},
+  },
+};
+
+export const method = {
+  get: baseSchema,
+  post: { ...baseSchema, consumes: ["application/x-www-form-urlencoded"] },
+};
+
+async function baseAction(req: FastifyRequest, props: Props) {
+  const callbackUrl = `${req.protocol}://${req.hostname}/api/v2/lti/callback`;
+  const { state, nonce, authorizationUrl } = await createAccount(
+    props,
+    callbackUrl
+  );
+  const oauthClient: OauthClientSchema = { id: props.client_id, nonce };
+  const ltiVersion: LtiVersionSchema = "1.3.0";
+
+  Object.assign(req.session, { state, oauthClient, ltiVersion });
+
+  return {
+    status: 302,
+    headers: { location: authorizationUrl },
+  };
+}
+
+export async function get(req: FastifyRequest<{ Params: Props }>) {
+  return await baseAction(req, req.params);
+}
+
+export async function post(req: FastifyRequest<{ Body: Props }>) {
+  return await baseAction(req, req.body);
+}

--- a/server/services/session.ts
+++ b/server/services/session.ts
@@ -18,14 +18,8 @@ export const hooks = {
 };
 
 export async function show({ session }: FastifyRequest) {
-  const { ltiLaunchBody, ltiResourceLink, user } = session;
-
   return {
     status: 200,
-    body: {
-      ltiLaunchBody,
-      ltiResourceLink,
-      user,
-    },
+    body: session,
   };
 }

--- a/server/types/fastifySession.ts
+++ b/server/types/fastifySession.ts
@@ -2,7 +2,13 @@ import type { SessionSchema } from "$server/models/session";
 
 declare module "fastify" {
   interface Session {
-    ltiLaunchBody: SessionSchema["ltiLaunchBody"];
+    oauthClient: SessionSchema["oauthClient"];
+    ltiVersion: SessionSchema["ltiVersion"];
+    ltiUser: SessionSchema["ltiUser"];
+    ltiRoles: SessionSchema["ltiRoles"];
+    ltiResourceLinkRequest: SessionSchema["ltiResourceLinkRequest"];
+    ltiContext: SessionSchema["ltiContext"];
+    ltiLaunchPresentation: SessionSchema["ltiLaunchPresentation"];
     ltiResourceLink: SessionSchema["ltiResourceLink"];
     user: SessionSchema["user"];
   }

--- a/server/utils/ltiv1p1/oauth.test.ts
+++ b/server/utils/ltiv1p1/oauth.test.ts
@@ -182,7 +182,7 @@ describe("auth()", function () {
   });
 
   test("oauth_signature が異なる", async function () {
-    const oauthConsumerKey = "another-key";
+    const oauthConsumerKey = "key";
     const oauthConsumerSecret = "secret";
     const lookupNonce = async () => false;
     const url = "http://localhost:8080/api/v2/lti/lauch";
@@ -229,5 +229,27 @@ describe("auth()", function () {
     expect(
       await auth(url, params, empty, oauthConsumerSecret, lookupNonce)
     ).toBe(false);
+  });
+
+  test("OAuth Consumer Secret が空", async function () {
+    const oauthConsumerKey = "key";
+    const empty = "";
+    const lookupNonce = async () => false;
+    const url = "http://localhost:8080/api/v2/lti/lauch";
+    const params = {
+      oauth_version: "1.0",
+      oauth_nonce: "0878c39c4c274c2072d3af6604a75c64",
+      oauth_timestamp: "1605829208",
+      oauth_consumer_key: "key",
+      oauth_signature_method: "HMAC-SHA1",
+      oauth_signature: "IeMP6CeHaVU47hNucWgW5y1TGQI=",
+      lti_message_type: "basic-lti-launch-request",
+      lti_version: "LTI-1p0",
+      resource_link_id: "1",
+    } as const;
+
+    expect(await auth(url, params, oauthConsumerKey, empty, lookupNonce)).toBe(
+      false
+    );
   });
 });

--- a/server/utils/ltiv1p1/oauth.ts
+++ b/server/utils/ltiv1p1/oauth.ts
@@ -77,6 +77,7 @@ export async function auth(
   lookupNonce: (nonce: string, timestamp: number) => Promise<boolean>
 ) {
   if (oauthConsumerKey.length === 0) return false;
+  if (oauthConsumerSecret.length === 0) return false;
   const { oauth_signature, ...params } = reqBody;
   const noncePresence = await lookupNonce(
     params.oauth_nonce,

--- a/server/utils/ltiv1p1/roles.test.ts
+++ b/server/utils/ltiv1p1/roles.test.ts
@@ -1,5 +1,8 @@
 import { isInstructor } from "./roles";
-import { LtiLaunchBody } from "$server/validators/ltiLaunchBody";
+import {
+  LtiLaunchBody,
+  toSessionSchema,
+} from "$server/validators/ltiLaunchBody";
 
 describe("isInstructor()", function () {
   test("ロールが管理者", function () {
@@ -22,7 +25,7 @@ describe("isInstructor()", function () {
       lis_person_name_full: "Admin User",
     });
 
-    expect(isInstructor(ltiLaunchBody)).toBe(true);
+    expect(isInstructor(toSessionSchema(ltiLaunchBody).ltiRoles)).toBe(true);
   });
 
   test("LIS Context Role 名前空間の省略", function () {
@@ -44,6 +47,6 @@ describe("isInstructor()", function () {
       lis_person_name_full: "Instructor User",
     });
 
-    expect(isInstructor(ltiLaunchBody)).toBe(true);
+    expect(isInstructor(toSessionSchema(ltiLaunchBody).ltiRoles)).toBe(true);
   });
 });

--- a/server/utils/ltiv1p1/roles.ts
+++ b/server/utils/ltiv1p1/roles.ts
@@ -1,5 +1,5 @@
 import roleUrns from "$server/config/roles";
-import { LtiLaunchBody } from "$server/validators/ltiLaunchBody";
+import { LtiRolesSchema } from "$server/models/ltiRoles";
 
 /** LIS Context Role 名前空間の接頭辞 */
 const lisContextRolePrefix = "urn:lti:role:ims/lis/";
@@ -19,31 +19,28 @@ const roles = {
 
 /**
  * ロールが管理者か否か
- * @param ltiLaunchBody LTI v1.1 起動時リクエストボディ
+ * @param ltiRoles LTI v1.1 Roles
  * @return 管理者の場合 true、それ以外の場合 false
  */
-export function isAdministrator(ltiLaunchBody: LtiLaunchBody) {
-  return hasRole(ltiLaunchBody.roles, roles.administrator);
+export function isAdministrator(ltiRoles: LtiRolesSchema) {
+  return hasRole(ltiRoles, roles.administrator);
 }
 
 /**
  * ロールが教員・管理者か否か
- * @param ltiLaunchBody LTI v1.1 起動時リクエストボディ
+ * @param ltiRoles LTI v1.1 Roles
  * @return 教員または管理者の場合 true、それ以外の場合 false
  */
-export function isInstructor(ltiLaunchBody: LtiLaunchBody) {
-  return hasRole(ltiLaunchBody.roles, [
-    ...roles.instructor,
-    ...roles.administrator,
-  ]);
+export function isInstructor(ltiRoles: LtiRolesSchema) {
+  return hasRole(ltiRoles, [...roles.instructor, ...roles.administrator]);
 }
 
 /**
  * 特定のロールを持っているか否か
- * @param roles 持っているロール一覧。 `,` 区切り。
+ * @param ltiRoles 持っているロール一覧
  * @param roleToFind 対象のロール
  * @return 対象のロールを持っている場合 true、それ以外の場合 false
  */
-function hasRole(roles: string, roleToFind: readonly string[]) {
-  return roles.split(",").some((role) => roleToFind.includes(role));
+function hasRole(ltiRoles: LtiRolesSchema, roleToFind: readonly string[]) {
+  return ltiRoles.some((role) => roleToFind.includes(role));
 }

--- a/server/utils/ltiv1p3/createAccount.ts
+++ b/server/utils/ltiv1p3/createAccount.ts
@@ -1,0 +1,45 @@
+import { generators } from "openid-client";
+import getUnixTime from "date-fns/getUnixTime";
+import prisma from "$server/utils/prisma";
+import findClient from "./findClient";
+
+/** アカウントを登録し OpenID Connect Authorization URL を得る */
+async function createAccount(
+  {
+    client_id,
+    iss,
+    login_hint,
+    lti_message_hint,
+  }: {
+    client_id: string;
+    iss: string;
+    login_hint: string;
+    target_link_uri: string;
+    lti_message_hint?: string;
+  },
+  callbackUrl: string
+) {
+  const client = await findClient(client_id, [callbackUrl]);
+
+  if (client?.issuer.metadata.issuer !== iss) {
+    throw new Error("このプラットフォームは許可されていません");
+  }
+
+  const state = generators.state();
+  const nonce = generators.nonce();
+  const timestamp = getUnixTime(new Date());
+  await prisma.account.create({ data: { nonce, timestamp } });
+
+  const authorizationUrl = client.authorizationUrl({
+    state,
+    nonce,
+    login_hint,
+    response_mode: "form_post",
+    prompt: "none",
+    ...{ lti_message_hint },
+  });
+
+  return { state, nonce, authorizationUrl };
+}
+
+export default createAccount;

--- a/server/utils/ltiv1p3/findClient.ts
+++ b/server/utils/ltiv1p3/findClient.ts
@@ -1,0 +1,29 @@
+import { Issuer } from "openid-client";
+import prisma from "$server/utils/prisma";
+
+/** OpenID Connect Client を得る */
+async function findClient(clientId: string, redirectUris?: string[]) {
+  const consumer = await prisma.ltiConsumer.findUnique({
+    where: { id: clientId },
+    include: { platform: true },
+  });
+  const platform = consumer?.platform;
+
+  if (!platform?.issuer) return;
+
+  const metadata =
+    typeof platform.metadata === "object" ? platform.metadata : {};
+  const issuer = new Issuer({
+    ...metadata,
+    issuer: platform.issuer,
+  });
+  const client = new issuer.Client({
+    client_id: clientId,
+    redirect_uris: redirectUris,
+    response_types: ["id_token"],
+  });
+
+  return client;
+}
+
+export default findClient;

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -1,7 +1,7 @@
 import { User } from "@prisma/client";
 import { SessionSchema } from "$server/models/session";
-import { LtiLaunchBody } from "$server/validators/ltiLaunchBody";
-import * as ltiRoles from "./ltiv1p1/roles";
+import { LtiRolesSchema } from "$server/models/ltiRoles";
+import * as ltiv1p1Roles from "./ltiv1p1/roles";
 
 /**
  * セッションが管理者のものであるか否か
@@ -9,7 +9,7 @@ import * as ltiRoles from "./ltiv1p1/roles";
  * @return セッションが管理者のものの場合 true、それ以外の場合 false
  */
 export function isAdministrator(session: SessionSchema) {
-  return hasRole(session, ltiRoles.isAdministrator);
+  return hasRole(session, ltiv1p1Roles.isAdministrator);
 }
 
 /**
@@ -18,7 +18,7 @@ export function isAdministrator(session: SessionSchema) {
  * @return セッションが教員または管理者のものの場合 true、それ以外の場合 false
  */
 export function isInstructor(session: SessionSchema) {
-  return hasRole(session, ltiRoles.isInstructor);
+  return hasRole(session, ltiv1p1Roles.isInstructor);
 }
 
 /**
@@ -39,9 +39,9 @@ export function isUserOrAdmin(session: SessionSchema, user: Pick<User, "id">) {
  */
 function hasRole(
   session: SessionSchema,
-  roleToFind: (ltiLaunchBody: LtiLaunchBody) => boolean
+  roleToFind: (ltiRoles: LtiRolesSchema) => boolean
 ) {
-  return roleToFind(session.ltiLaunchBody);
+  return roleToFind(session.ltiRoles);
 }
 
 /**

--- a/server/validators/ltiCallbackBody.ts
+++ b/server/validators/ltiCallbackBody.ts
@@ -1,0 +1,15 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiCallbackBody = {
+  title: "LTI v1.3 リダイレクトURIのリクエストボディ",
+  type: "object",
+  required: ["state", "id_token"],
+  properties: {
+    state: { type: "string" },
+    id_token: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+/** LTI v1.3 リダイレクトURIのリクエストボディ */
+export type LtiCallbackBody = FromSchema<typeof LtiCallbackBody>;

--- a/server/validators/ltiClaims.ts
+++ b/server/validators/ltiClaims.ts
@@ -1,0 +1,91 @@
+import {
+  Equals,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from "class-validator";
+
+/** LTI v1.3 Message Claims */
+export class LtiClaims {
+  constructor(props?: Partial<LtiClaims>) {
+    Object.assign(this, {
+      ...props,
+      "https://purl.imsglobal.org/spec/lti/claim/resource_link": new ResourceLinkClaim(
+        props?.["https://purl.imsglobal.org/spec/lti/claim/resource_link"]
+      ),
+      "https://purl.imsglobal.org/spec/lti/claim/context": new ContextClaim(
+        props?.["https://purl.imsglobal.org/spec/lti/claim/context"]
+      ),
+      "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": new LaunchPresentationClaim(
+        props?.["https://purl.imsglobal.org/spec/lti/claim/launch_presentation"]
+      ),
+    });
+  }
+  @Equals("LtiResourceLinkRequest")
+  "https://purl.imsglobal.org/spec/lti/claim/message_type"!: "LtiResourceLinkRequest";
+  @Equals("1.3.0")
+  "https://purl.imsglobal.org/spec/lti/claim/version"!: "1.3.0";
+  @IsNotEmpty()
+  @MaxLength(255)
+  "https://purl.imsglobal.org/spec/lti/claim/deployment_id"!: string;
+  @IsNotEmpty()
+  "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"!: string;
+  @IsNotEmpty()
+  @ValidateNested()
+  "https://purl.imsglobal.org/spec/lti/claim/resource_link"!: ResourceLinkClaim;
+  @IsNotEmpty()
+  @IsString({ each: true })
+  "https://purl.imsglobal.org/spec/lti/claim/roles"!: string[];
+  @IsNotEmpty() // TODO: 依存している実装箇所が存在するため必須にしているが本来任意なので修正したい
+  @ValidateNested()
+  "https://purl.imsglobal.org/spec/lti/claim/context"!: ContextClaim;
+  @IsOptional()
+  "https://purl.imsglobal.org/spec/lti/claim/tool_platform"?: unknown;
+  @IsOptional()
+  "https://purlimsglobal.org/spec/lti/claim/role_scope_mentor"?: unknown;
+  @IsOptional()
+  @ValidateNested()
+  "https://purl.imsglobal.org/spec/lti/claim/launch_presentation"?: LaunchPresentationClaim;
+  @IsOptional()
+  "https://purl.imsglobal.org/spec/lti/claim/lis"?: unknown;
+  @IsOptional()
+  "https://purl.imsglobal.org/spec/lti/claim/custom"?: unknown;
+}
+
+class ResourceLinkClaim {
+  constructor(props?: Partial<ResourceLinkClaim>) {
+    Object.assign(this, props);
+  }
+  @IsNotEmpty()
+  @IsString()
+  id!: string;
+  @IsOptional()
+  @IsString()
+  title?: string;
+}
+
+class ContextClaim {
+  constructor(props?: Partial<ContextClaim>) {
+    Object.assign(this, props);
+  }
+  @IsNotEmpty()
+  @IsString()
+  id!: string;
+  @IsOptional()
+  @IsString()
+  label?: string;
+  @IsOptional()
+  @IsString()
+  title?: string;
+}
+
+class LaunchPresentationClaim {
+  constructor(props?: Partial<LaunchPresentationClaim>) {
+    Object.assign(this, props);
+  }
+  @IsOptional()
+  @IsString()
+  return_url?: string;
+}

--- a/server/validators/ltiLoginProps.ts
+++ b/server/validators/ltiLoginProps.ts
@@ -1,0 +1,24 @@
+import { FromSchema } from "json-schema-to-ts";
+
+export const LtiLoginProps = {
+  title: "LTI v1.3 ログイン初期化エンドポイントのリクエストパラメーター",
+  type: "object",
+  required: [
+    "iss",
+    "login_hint",
+    "target_link_uri",
+    // TODO: client_id に依存している実装箇所が存在するため必須にしているが本来任意なので修正したい
+    "client_id",
+  ],
+  properties: {
+    iss: { type: "string" },
+    login_hint: { type: "string" },
+    target_link_uri: { type: "string" },
+    lti_message_hint: { type: "string" },
+    lti_deployment_id: { type: "string" },
+    client_id: { type: "string" },
+  },
+} as const;
+
+/** LTI v1.3 ログイン初期化エンドポイントのリクエストパラメーター */
+export type LtiLoginProps = FromSchema<typeof LtiLoginProps>;

--- a/store/session.ts
+++ b/store/session.ts
@@ -59,5 +59,5 @@ export function useUpdateSessionAtom() {
 
 export function useLmsUrl() {
   const { session } = useSessionAtom();
-  return session?.ltiLaunchBody.launch_presentation_return_url;
+  return session?.ltiLaunchPresentation?.returnUrl;
 }

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -6,9 +6,9 @@ import getFilePath from "./getFilePath";
 
 /** v1のときのトラッキング用コードの移植 */
 function send(eventType: EventType, event: PlayerEvent, detail?: string) {
-  const ltiLaunchBody = load();
-  if (!ltiLaunchBody) return;
-  const { oauth_consumer_key: idPrefix } = ltiLaunchBody;
+  const session = load();
+  if (!session) return;
+  const idPrefix = session.oauthClient.id;
   const id = (id: string) => [idPrefix, id].join(":");
   const body = {
     event: eventType,
@@ -16,10 +16,10 @@ function send(eventType: EventType, event: PlayerEvent, detail?: string) {
     file: getFilePath(event),
     query: event.url.split("?")[1],
     current: event.currentTime.toString(),
-    rid: id(ltiLaunchBody.resource_link_id),
-    uid: id(ltiLaunchBody.user_id),
-    cid: id(ltiLaunchBody.context_id),
-    nonce: ltiLaunchBody.oauth_nonce,
+    rid: id(session.ltiResourceLinkRequest.id),
+    uid: id(session.ltiUser.id),
+    cid: id(session.ltiContext.id),
+    nonce: session.oauthClient.nonce,
   };
   return api.apiV2EventPost({ body });
 }

--- a/utils/eventLogger/loggerSessionPersister.ts
+++ b/utils/eventLogger/loggerSessionPersister.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { SessionSchema } from "$server/models/session";
-import { LtiLaunchBody } from "$server/validators/ltiLaunchBody";
 import { isInstructor } from "$utils/session";
 
 const key = "loggerSessionPersister";
@@ -10,15 +9,15 @@ export function load() {
   const item = sessionStorage.getItem(key);
   if (item == null) return;
   try {
-    return JSON.parse(item) as LtiLaunchBody;
+    return JSON.parse(item) as SessionSchema;
   } catch {
     return;
   }
 }
 
-function save(ltiLaunchBody: LtiLaunchBody) {
+function save(session: SessionSchema) {
   if (typeof window === "undefined") return;
-  sessionStorage.setItem(key, JSON.stringify(ltiLaunchBody));
+  sessionStorage.setItem(key, JSON.stringify(session));
 }
 
 function clear() {
@@ -28,7 +27,7 @@ function clear() {
 
 /**
  * 初回処理。
- * それぞれ学習者のセッション (LtiLaunchBody) を
+ * それぞれ学習者のセッションを
  * ウィンドウごとに区別する目的でsessionStorageに永続化し
  * あとでlogger.tsで使う。
  * もし教員や管理者ならば永続化せず空にする。
@@ -37,6 +36,6 @@ export function useLoggerInit(session: SessionSchema | undefined) {
   useEffect(() => {
     if (!session) return;
     if (isInstructor(session)) clear();
-    else save(session.ltiLaunchBody);
+    else save(session);
   }, [session]);
 }

--- a/utils/getLtiResourceLink.ts
+++ b/utils/getLtiResourceLink.ts
@@ -5,7 +5,7 @@ import type {
 } from "$server/models/ltiResourceLink";
 
 /**
- * ltiLaunchBodyからltiResourceLinkを作成
+ * セッションからltiResourceLinkを作成
  * @param session セッション
  * @return authorIdとbookIdを除いたLTIリソースリンク
  */
@@ -15,16 +15,15 @@ function getLtiResourceLink(
   LtiResourceLinkSchema & LtiResourceLinkProps,
   "authorId" | "bookId"
 > | null {
-  const ltiLaunchBody = session?.ltiLaunchBody;
-  if (ltiLaunchBody == null) return null;
+  if (session == null) return null;
 
   const ltiResourceLink = {
-    consumerId: ltiLaunchBody.oauth_consumer_key,
-    id: ltiLaunchBody.resource_link_id,
-    title: ltiLaunchBody.resource_link_title ?? "",
-    contextId: ltiLaunchBody.context_id,
-    contextTitle: ltiLaunchBody.context_title ?? "",
-    contextLabel: ltiLaunchBody.context_label ?? "",
+    consumerId: session.oauthClient.id,
+    id: session.ltiResourceLinkRequest.id,
+    title: session.ltiResourceLinkRequest.title ?? "",
+    contextId: session.ltiContext.id,
+    contextTitle: session.ltiContext.title ?? "",
+    contextLabel: session.ltiContext.label ?? "",
   };
 
   return ltiResourceLink;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9162,6 +9162,14 @@ json-schema-resolver@^1.2.0:
     rfdc "^1.1.4"
     uri-js "^4.2.2"
 
+json-schema-to-ts@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz#63e4fe854dff093923be9e8b59b39ee9a7971ba4"
+  integrity sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ts-toolbelt "^6.15.5"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -13774,6 +13782,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+ts-toolbelt@^6.15.5:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
+  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tslib@1.13.0:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,6 +1941,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
+"@panva/asn1.js@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
+  integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -2110,6 +2115,11 @@
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
+"@sindresorhus/is@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
+  integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -2869,6 +2879,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
+  integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
 "@timsuchanek/copy@^1.4.5":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@timsuchanek/copy/-/copy-1.4.5.tgz#8e9658c056e24e1928a88bed45f9eac6a72b7c40"
@@ -2932,6 +2949,16 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
 
+"@types/cacheable-request@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
@@ -2993,6 +3020,11 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
   integrity sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
 
+"@types/http-cache-semantics@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
 "@types/is-function@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/is-function/-/is-function-1.0.0.tgz#1b0b819b1636c7baf0d6785d030d12edf70c3e83"
@@ -3029,6 +3061,13 @@
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/keyv@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/lodash.throttle@^4.1.6":
   version "4.1.6"
@@ -3162,6 +3201,13 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/retry@^0.12.0":
   version "0.12.0"
@@ -3625,7 +3671,7 @@ agent-base@6:
   dependencies:
     debug "4"
 
-aggregate-error@^3.0.0:
+aggregate-error@^3.0.0, aggregate-error@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
   integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
@@ -4695,6 +4741,11 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -4707,6 +4758,19 @@ cacheable-request@^6.0.0:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^1.0.2"
+
+cacheable-request@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
+  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -5706,6 +5770,13 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -5742,6 +5813,11 @@ defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+
+defer-to-connect@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -7554,6 +7630,23 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
+got@^11.8.0:
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
+  integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.1"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -7935,6 +8028,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -9056,6 +9157,13 @@ jmespath@^0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
+jose@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-2.0.5.tgz#29746a18d9fff7dcf9d5d2a6f62cb0c7cd27abd3"
+  integrity sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==
+  dependencies:
+    "@panva/asn1.js" "^1.0.0"
+
 jotai@^0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/jotai/-/jotai-0.15.3.tgz#323dcdc2b1a7f7ec777997b2d827e61bada2ede3"
@@ -9142,6 +9250,11 @@ json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
@@ -9330,6 +9443,13 @@ keyv@^3.0.0:
   integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
   dependencies:
     json-buffer "3.0.0"
+
+keyv@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"
+  integrity sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==
+  dependencies:
+    json-buffer "3.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -9678,7 +9798,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -10083,6 +10203,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -10518,6 +10643,11 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
 npm-run-all@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
@@ -10603,6 +10733,11 @@ object-hash@2.1.1:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
   integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
 
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
@@ -10681,6 +10816,11 @@ objectorarray@^1.0.4:
   resolved "https://registry.yarnpkg.com/objectorarray/-/objectorarray-1.0.4.tgz#d69b2f0ff7dc2701903d308bb85882f4ddb49483"
   integrity sha512-91k8bjcldstRz1bG6zJo8lWD7c6QXcB4nTDUqiEvIL1xAsLoZlOOZZG+nd6YPz+V7zY1580J4Xxh1vZtyv4i/w==
 
+oidc-token-hash@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
+  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -10726,6 +10866,19 @@ openapi3-ts@^2.0.0:
   integrity sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==
   dependencies:
     yaml "^1.10.0"
+
+openid-client@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-4.7.4.tgz#bd9978456d53d38adb89856b14a8fbd094f7732e"
+  integrity sha512-n+RURXYuR0bBZo9i0pn+CXZSyg5JYQ1nbwEwPQvLE7EcJt/vMZ2iIMjLehl5DvCN53XUoPVZs9KAE5r6d9fxsw==
+  dependencies:
+    aggregate-error "^3.1.0"
+    got "^11.8.0"
+    jose "^2.0.5"
+    lru-cache "^6.0.0"
+    make-error "^1.3.6"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -10782,6 +10935,11 @@ p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
+p-cancelable@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
 
 p-each-series@^2.1.0:
   version "2.2.0"
@@ -11593,6 +11751,11 @@ quick-format-unescaped@4.0.1:
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
   integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
 
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
 raf-schd@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
@@ -12316,6 +12479,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resolve-alpn@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.1.2.tgz#30b60cfbb0c0b8dc897940fe13fe255afcdd4d28"
+  integrity sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -12359,6 +12527,13 @@ responselike@^1.0.2:
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
   dependencies:
     lowercase-keys "^1.0.0"
+
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
関連: #17

確認したこと:
従来どおりLTI v1.0/v1.1 ツールとして起動可能であること

やったこと:

- feat: 起動時パラメータの一般化/SessionSchemaからLtiLaunchBodyの除去
- feat: LTI v1.1ならばOAuth Consumer Secretが空のとき無効
- feat: LTI v1.3 のためのデータモデリングとスキーマへの反映
- fix: 誤ってSession.ltiLaunchBody にアクセスしているコードの除去 関連: 206d5b29333409d121483614ffbd972916e0d291
- feat: LTI v1.3 Authorization flow の実装 (実験的)
- fix: use req.destroySession
- fix: エラーの出力
- fix: LMSに戻るリンクが表示されない問題の修正
- refactor: initにResponses Objectとresponseも宣言
- fix: Platformをもつならv1.1は無効
- fix: スキーマによるリクエストボディパラメーターのバリデーション
- chore: yarn build:openapi
- fix: LTI v1.3 に必須なクレイムのバリデーション
