### PR TITLE
chore: migrate react-hook-form v6 → v7

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -7,7 +7,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Link from "@material-ui/core/Link";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
-import { useForm, Controller } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import clsx from "clsx";
 import TextField from "$atoms/TextField";
 import useCardStyles from "styles/card";
@@ -74,7 +74,7 @@ export default function BookForm({
   const {
     handleSubmit,
     register,
-    control,
+    setValue,
   } = useForm<BookPropsWithSubmitOptions>({
     defaultValues,
   });
@@ -85,13 +85,10 @@ export default function BookForm({
       className={clsx(classes.margin, className)}
       id={id}
       component="form"
-      onSubmit={handleSubmit((values: BookPropsWithSubmitOptions) => {
-        onSubmit({ ...defaultValues, ...values });
-      })}
+      onSubmit={handleSubmit(onSubmit)}
     >
       <TextField
-        name="name"
-        inputRef={register}
+        inputProps={register("name")}
         label={
           <>
             タイトル
@@ -114,25 +111,23 @@ export default function BookForm({
         <Checkbox
           id="shared"
           name="shared"
-          inputRef={register}
+          onChange={(_, checked) => setValue("shared", checked)}
           defaultChecked={defaultValues.shared}
           color="primary"
         />
       </div>
-      <Controller
-        name="language"
-        control={control}
+      <TextField
+        label="教材の主要な言語"
+        select
         defaultValue={defaultValues.language}
-        render={(props) => (
-          <TextField label="教材の主要な言語" select inputProps={props}>
-            {Object.entries(languages).map(([value, label]) => (
-              <MenuItem key={value} value={value}>
-                {label}
-              </MenuItem>
-            ))}
-          </TextField>
-        )}
-      />
+        inputProps={register("language")}
+      >
+        {Object.entries(languages).map(([value, label]) => (
+          <MenuItem key={value} value={value}>
+            {label}
+          </MenuItem>
+        ))}
+      </TextField>
       <TextField
         label={
           <>
@@ -155,8 +150,7 @@ export default function BookForm({
         }
         fullWidth
         multiline
-        name="description"
-        inputRef={register}
+        inputProps={register("description")}
       />
       <Divider className={classes.divider} />
       {!linked && (
@@ -167,7 +161,7 @@ export default function BookForm({
           <Checkbox
             id="submit-with-link"
             name="submitWithLink"
-            inputRef={register}
+            onChange={(_, checked) => setValue("submitWithLink", checked)}
             defaultChecked={defaultValues.submitWithLink}
             color="primary"
           />

--- a/components/organisms/BooksImportForm.tsx
+++ b/components/organisms/BooksImportForm.tsx
@@ -3,7 +3,7 @@ import Card from "@material-ui/core/Card";
 import Button from "@material-ui/core/Button";
 import MenuItem from "@material-ui/core/MenuItem";
 import { makeStyles } from "@material-ui/core/styles";
-import { useForm, Controller } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import clsx from "clsx";
 import TextField from "$atoms/TextField";
 import useCardStyles from "styles/card";
@@ -41,7 +41,7 @@ export default function BooksImportForm(props: Props) {
     provider: wowzaUrl,
     wowzaBaseUrl: `${NEXT_PUBLIC_API_BASE_PATH}/api/v2/wowza`,
   };
-  const { handleSubmit, register, control } = useForm<BooksImportParams>({
+  const { handleSubmit, register } = useForm<BooksImportParams>({
     defaultValues,
   });
 
@@ -57,7 +57,6 @@ export default function BooksImportForm(props: Props) {
             "load",
             function () {
               onSubmit({
-                ...defaultValues,
                 ...values,
                 file: Buffer.from(reader.result as ArrayBuffer).toString(
                   "base64"
@@ -66,32 +65,25 @@ export default function BooksImportForm(props: Props) {
             },
             false
           );
-          // eslint-disable-next-line tsc/config
-          reader.readAsArrayBuffer(values.file[0] as File);
+          reader.readAsArrayBuffer((values.file[0] as unknown) as File);
         } else {
-          onSubmit({ ...defaultValues, ...values, file: undefined });
+          onSubmit({ ...values, file: undefined });
         }
       })}
     >
-      <TextField label="file" name="file" type="file" inputRef={register} />
-      <Controller
-        name="provider"
-        control={control}
+      <TextField label="file" type="file" inputProps={register("file")} />
+      <TextField
+        label="動画ファイルをアップロードするサービス"
+        select
         defaultValue={defaultValues.provider}
-        render={(props) => (
-          <TextField
-            label="動画ファイルをアップロードするサービス"
-            select
-            inputProps={props}
-          >
-            {Object.entries(providers).map(([label, value]) => (
-              <MenuItem key={value} value={value}>
-                {label}
-              </MenuItem>
-            ))}
-          </TextField>
-        )}
-      />
+        inputProps={register("provider")}
+      >
+        {Object.entries(providers).map(([label, value]) => (
+          <MenuItem key={value} value={value}>
+            {label}
+          </MenuItem>
+        ))}
+      </TextField>
       <Button variant="contained" color="primary" type="submit">
         インポート
       </Button>

--- a/components/organisms/SubtitleUploadDialog.tsx
+++ b/components/organisms/SubtitleUploadDialog.tsx
@@ -4,7 +4,7 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
 import MenuItem from "@material-ui/core/MenuItem";
 import makeStyles from "@material-ui/core/styles/makeStyles";
-import { useForm, Controller } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import TextField from "$atoms/TextField";
 import useCardStyles from "$styles/card";
 import { VideoTrackProps } from "$server/models/videoTrack";
@@ -37,7 +37,7 @@ export default function SubtitleUploadDialog(props: Props) {
     language: Object.getOwnPropertyNames(languages)[0],
     content: "",
   };
-  const { handleSubmit, register, control } = useForm<
+  const { handleSubmit, register } = useForm<
     VideoTrackProps & { contentFile?: FileList }
   >({
     defaultValues,
@@ -51,32 +51,29 @@ export default function SubtitleUploadDialog(props: Props) {
         component: "form",
         onSubmit: handleSubmit(({ contentFile, ...values }) => {
           const content = contentFile?.[0] ?? defaultValues.content;
-          onSubmit({ ...defaultValues, ...values, content });
+          onSubmit({ ...values, content });
         }),
       }}
     >
       <DialogTitle>字幕のアップロード</DialogTitle>
       <DialogContent className={classes.margin}>
         <TextField
-          name="contentFile"
           label="字幕ファイル"
           type="file"
-          inputRef={register}
+          inputProps={register("contentFile")}
         />
-        <Controller
-          name="language"
-          control={control}
+        <TextField
+          label="言語"
+          select
           defaultValue={defaultValues.language}
-          render={(props) => (
-            <TextField label="言語" select inputProps={props}>
-              {Object.entries(languages).map(([value, label]) => (
-                <MenuItem key={value} value={value}>
-                  {label}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
-        />
+          inputProps={register("language")}
+        >
+          {Object.entries(languages).map(([value, label]) => (
+            <MenuItem key={value} value={value}>
+              {label}
+            </MenuItem>
+          ))}
+        </TextField>
         <Button variant="contained" color="primary" type="submit">
           アップロード
         </Button>

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -9,7 +9,7 @@ import Link from "@material-ui/core/Link";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import { useForm, Controller } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { useDebouncedCallback } from "use-debounce";
 import clsx from "clsx";
 import TextField from "$atoms/TextField";
@@ -105,7 +105,7 @@ export default function TopicForm(props: Props) {
     language: topic?.language ?? Object.getOwnPropertyNames(languages)[0],
     timeRequired: topic?.timeRequired,
   };
-  const { handleSubmit, register, control, getValues, setValue } = useForm<
+  const { handleSubmit, register, getValues, setValue } = useForm<
     Omit<TopicProps, "resource">
   >({
     defaultValues,
@@ -126,16 +126,15 @@ export default function TopicForm(props: Props) {
         className={clsx(classes.margin, className)}
         component="form"
         onSubmit={handleSubmit((values) => {
+          const resource = videoResource ?? { url: "" };
           onSubmit({
-            ...defaultValues,
             ...values,
-            resource: videoResource ?? { url: "" },
+            resource,
           });
         })}
       >
         <TextField
-          name="name"
-          inputRef={register}
+          inputProps={register("name")}
           label={
             <>
               タイトル
@@ -148,7 +147,6 @@ export default function TopicForm(props: Props) {
               </Typography>
             </>
           }
-          defaultValue={defaultValues.name}
           required
           fullWidth
         />
@@ -159,7 +157,7 @@ export default function TopicForm(props: Props) {
           <Checkbox
             id="shared"
             name="shared"
-            inputRef={register}
+            onChange={(_, checked) => setValue("shared", checked)}
             defaultChecked={defaultValues.shared}
             color="primary"
           />
@@ -199,29 +197,23 @@ export default function TopicForm(props: Props) {
         {videoResource && (
           <Video {...videoResource} onDurationChange={handleDurationChange} />
         )}
-        <Controller
-          name="language"
-          control={control}
-          defaultValue={defaultValues.language}
-          render={(props) => (
-            <TextField label="教材の主要な言語" select inputProps={props}>
-              {Object.entries(languages).map(([value, label]) => (
-                <MenuItem key={value} value={value}>
-                  {label}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
-        />
         <TextField
-          name="timeRequired"
+          label="教材の主要な言語"
+          select
+          defaultValue={defaultValues.language}
+          inputProps={register("language")}
+        >
+          {Object.entries(languages).map(([value, label]) => (
+            <MenuItem key={value} value={value}>
+              {label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
           label="学習時間 (秒)"
           type="number"
           inputProps={{
-            ref: register({
-              setValueAs: (value) => (value === "" ? null : +value),
-              min: 0,
-            }),
+            ...register("timeRequired", { valueAsNumber: true }),
             min: 0,
           }}
         />
@@ -266,8 +258,7 @@ export default function TopicForm(props: Props) {
           }
           fullWidth
           multiline
-          name="description"
-          inputRef={register}
+          inputProps={register("description")}
         />
         <Divider className={classes.divider} />
         <Button variant="contained" color="primary" type="submit">

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react": "^17.0.1",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^17.0.1",
-    "react-hook-form": "^6.15.4",
+    "react-hook-form": "^7.12.2",
     "react-infinite-scroll-hook": "^3.0.0",
     "react-intersection-observer": "^8.32.0",
     "react-markdown": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11956,10 +11956,10 @@ react-helmet-async@^1.0.7:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^6.15.4:
-  version "6.15.4"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.4.tgz#328003e1ccc096cd158899ffe7e3b33735a9b024"
-  integrity sha512-K+Sw33DtTMengs8OdqFJI3glzNl1wBzSefD/ksQw/hJf9CnOHQAU6qy82eOrh0IRNt2G53sjr7qnnw1JDjvx1w==
+react-hook-form@^7.12.2:
+  version "7.12.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.12.2.tgz#2660afbf03c4ef360a9314ebf46ce3d972296c77"
+  integrity sha512-cpxocjrgpMAJCMJQR51BQhMoEx80/EQqePNihMTgoTYTqCRbd2GExi+N4GJIr+cFqrmbwNj9wxk5oLWYQsUefg==
 
 react-infinite-scroll-hook@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
React Hook Form v7 へのバージョンアップしました。
Checkboxに関しては対応していないためsetValueを使うことで回避しました。
フォームを操作して問題なさそうなことを確認しました。

参考文献:

- [react\-hook\-form/CHANGELOG\.md at v7\.12\.0 · react\-hook\-form/react\-hook\-form](https://github.com/react-hook-form/react-hook-form/blob/v7.12.2/CHANGELOG.md)
- [Migrate From V6 to V7 \| React Hook Form \- Simple React forms validation](https://react-hook-form.com/migrate-v6-to-v7)
