### PR TITLE
fix: ビデオエリアの上部が下にずれる

### DIFF
--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
   },
   hidden: {
     width: 0,
+    margin: 0,
     "& *": {
       visibility: "hidden",
     },


### PR DESCRIPTION
#504 への対応です

動画プレイヤーにmargin-bottomを持たせている分が画面上に反映されたりされなかったりしていたので、非表示時はmarginを持たせないようにしました