### PR TITLE
fix: videojs-hlsjs-pluginが重複して登録される

### DIFF
--- a/utils/video/getVideoJsPlayer.ts
+++ b/utils/video/getVideoJsPlayer.ts
@@ -18,8 +18,13 @@ const defaultOptions: VideoJsPlayerOptions = {
 };
 
 function getVideoJsPlayer(options: VideoJsPlayerOptions) {
-  hlsjsPlugin.registerConfigPlugin(videojs);
-  hlsjsPlugin.registerSourceHandler(videojs);
+  if (!videojs.getPlugin("streamrootHls")) {
+    hlsjsPlugin.registerConfigPlugin(videojs);
+  }
+  // @ts-expect-error @types/video.js Unsupported
+  if (!videojs.Html5Hlsjs) {
+    hlsjsPlugin.registerSourceHandler(videojs);
+  }
   const element = document.createElement("video-js");
   element.classList.add("vjs-big-play-centered");
   const player = videojs(element, { ...defaultOptions, ...options });


### PR DESCRIPTION
`VIDEOJS: WARN: A plugin named "streamrootHls" already exists. You may want to avoid re-registering plugins!`

というメッセージがコンソールで表示される点への対処 https://github.com/npocccties/chibichilo/pull/499#issuecomment-903382446