### PR TITLE
fix: video.jsのiframeを要するソースでiframeが生成されない場合がある

### DIFF
--- a/utils/video/getVideoHolder.ts
+++ b/utils/video/getVideoHolder.ts
@@ -1,0 +1,17 @@
+/**
+ * 動画プレイヤーインスタンス生成時に生成するHTML要素を
+ * 格納するHTML要素の生成
+ * See https://github.com/npocccties/chibichilo/issues/497#issuecomment-907995610
+ * @returns DOMに含まれるが非表示なHTML要素
+ */
+function getVideoHolder() {
+  const videoHolder = document.getElementById("video-holder");
+  if (videoHolder) return videoHolder;
+  const element = document.createElement("div");
+  element.id = "video-holder";
+  element.style.display = "none";
+  document.body.appendChild(element);
+  return element;
+}
+
+export default getVideoHolder;

--- a/utils/video/getVideoJsPlayer.ts
+++ b/utils/video/getVideoJsPlayer.ts
@@ -26,6 +26,7 @@ function getVideoJsPlayer(options: VideoJsPlayerOptions) {
     hlsjsPlugin.registerSourceHandler(videojs);
   }
   const element = document.createElement("video-js");
+  document.body.appendChild(element);
   element.classList.add("vjs-big-play-centered");
   const player = videojs(element, { ...defaultOptions, ...options });
   // @ts-expect-error: @types/video.js@^7.3.11 Unsupported

--- a/utils/video/getVideoJsPlayer.ts
+++ b/utils/video/getVideoJsPlayer.ts
@@ -4,6 +4,7 @@ import hlsjsPlugin from "@meikidd/videojs-hlsjs-plugin/lib/videojs-hlsjs-plugin.
 import ja from "video.js/dist/lang/ja.json";
 import "videojs-youtube";
 import "videojs-seek-buttons";
+import getVideoHolder from "./getVideoHolder";
 
 const defaultOptions: VideoJsPlayerOptions = {
   controls: true,
@@ -26,7 +27,7 @@ function getVideoJsPlayer(options: VideoJsPlayerOptions) {
     hlsjsPlugin.registerSourceHandler(videojs);
   }
   const element = document.createElement("video-js");
-  document.body.appendChild(element);
+  getVideoHolder().appendChild(element);
   element.classList.add("vjs-big-play-centered");
   const player = videojs(element, { ...defaultOptions, ...options });
   // @ts-expect-error: @types/video.js@^7.3.11 Unsupported

--- a/utils/video/getVimeoPlayer.ts
+++ b/utils/video/getVimeoPlayer.ts
@@ -1,5 +1,6 @@
 import Player from "@vimeo/player";
 import type { Options } from "@vimeo/player";
+import getVideoHolder from "./getVideoHolder";
 
 const defaultOptions: Options = {
   responsive: true,
@@ -7,7 +8,7 @@ const defaultOptions: Options = {
 
 function getVimeoPlayer(options: Options) {
   const element = document.createElement("div");
-  document.body.appendChild(element);
+  getVideoHolder().appendChild(element);
   const player = new Player(element, { ...defaultOptions, ...options });
   return { element, player };
 }

--- a/utils/video/getVimeoPlayer.ts
+++ b/utils/video/getVimeoPlayer.ts
@@ -7,6 +7,7 @@ const defaultOptions: Options = {
 
 function getVimeoPlayer(options: Options) {
   const element = document.createElement("div");
+  document.body.appendChild(element);
   const player = new Player(element, { ...defaultOptions, ...options });
   return { element, player };
 }


### PR DESCRIPTION
`VIDEOJS: WARN: The element supplied is not included in the DOM` への対処です

#497 への対応でもあります