### PR TITLE
fix: ページ表示後すぐに音量を変更すると音量が変更前に戻る問題の修正

### DIFF
--- a/utils/useVolume.ts
+++ b/utils/useVolume.ts
@@ -80,9 +80,11 @@ function useVolume(player: Player) {
   const onChange = useDebouncedCallback(update, wait);
   useEffect(() => {
     if (data) setVolume(player, data);
-    if (data && ready) player.on("volumechange", onChange);
+  }, [player, data]);
+  useEffect(() => {
+    if (ready) player.on("volumechange", onChange);
     return () => player.off("volumechange", onChange);
-  }, [player, ready, data, onChange]);
+  }, [player, ready, onChange]);
 }
 
 export default useVolume;


### PR DESCRIPTION
ready の変化のタイミングで余計な player.volume() を呼ばないようにプロセスを変更

関連: https://github.com/npocccties/chibichilo/issues/514
