### PR TITLE
fix: TypeScript 3.6.2 で削除された GlobalFetch の削除

### DIFF
--- a/openapi/runtime.ts
+++ b/openapi/runtime.ts
@@ -125,7 +125,7 @@ export const COLLECTION_FORMATS = {
     pipes: "|",
 };
 
-export type FetchAPI = GlobalFetch['fetch'];
+export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,16 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "4.3.1"
+    "version": "4.3.1",
+    "generators": {
+      "v2": {
+        "generatorName": "typescript-fetch",
+        "output": "openapi",
+        "inputSpec": "http://localhost:8080/api/v2/swagger/json",
+        "additionalProperties": {
+          "typescriptThreePlus": true
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "build:next": "next build",
     "build:export": "next export -o server/dist/public",
     "build:server": "yarn --cwd server build:app",
-    "build:openapi": "openapi-generator-cli generate -i http://localhost:8080/api/v2/swagger/json -g typescript-fetch -o openapi",
+    "build:openapi": "openapi-generator-cli generate",
     "zoom:import": "yarn --cwd server zoom:import",
     "start": "yarn --cwd server start",
     "vercel-build": "run-s compile build:static build:server && rm -rf public/api/v2/swagger && mkdir -p public/api/v2/swagger && cp -a server/dist/static public/api/v2/swagger/static",

--- a/types/globalFetch.d.ts
+++ b/types/globalFetch.d.ts
@@ -1,2 +1,0 @@
-// NOTE: openapi/runtime.ts にて TypeScript 3.6.2 で削除された GlobalFetch が参照されているため宣言
-declare type GlobalFetch = WindowOrWorkerGlobalScope;


### PR DESCRIPTION
TypeScript 3.6.2 で削除された GlobalFetch が openapi-generator によってデフォルトで生成されていたため、型宣言ファイルで上書きしていましたが、typescriptThreePlus オプションを使うことで対応可能なので削除しました。
https://openapi-generator.tech/docs/generators/typescript-fetch/#:~:text=false-,typescriptThreePlus,-Setting%20this%20property
﻿
