### PR TITLE
fix: 現在使用されていないignoreDevErrorsオプションの削除/ignoreDuringBuilds オプション有効化

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
-  // NOTE: ESLintによって型検査を実施しないならば取り除いて型検査を有効化してください
-  typescript: { ignoreDevErrors: true, ignoreBuildErrors: true },
+  // NOTE: ESLintによる型検査を外部で実施しないならば取り除いて型検査を有効化してください
+  //       https://nextjs.org/docs/api-reference/next.config.js/ignoring-typescript-errors
+  typescript: { ignoreBuildErrors: true },
+  // NOTE: ESLintによる静的コード解析を外部で実施しないならば取り除いて有効化してください
+  //       https://nextjs.org/docs/api-reference/next.config.js/ignoring-eslint
+  eslint: { ignoreDuringBuilds: true },
 };


### PR DESCRIPTION
参考文献:

- https://nextjs.org/docs/api-reference/next.config.js/ignoring-typescript-errors
- https://nextjs.org/docs/api-reference/next.config.js/ignoring-eslint﻿
