### PR TITLE
fix: ブック作成時に「以下のトピックを追加します」と意図しない通知が表示される問題の修正

### DIFF
--- a/pages/book/new.tsx
+++ b/pages/book/new.tsx
@@ -2,7 +2,10 @@ import { useRouter } from "next/router";
 import BookNew from "$templates/BookNew";
 import useBookNewHandlers from "$utils/useBookNewHandlers";
 
-export type Query = { context?: "books" | "topics"; topics?: number[] };
+export type Query = {
+  context?: "books" | "topics";
+  topics?: number | number[];
+};
 
 function New({ context, topics }: Query) {
   const handlers = useBookNewHandlers(context);
@@ -17,7 +20,8 @@ function Router() {
   return <New context={context} topics={topics} />;
 }
 
-function getTopicsIdArray(topics: unknown) {
+function getTopicsIdArray(topics: Query["topics"]): undefined | number[] {
+  if (topics == null) return undefined;
   if (Array.isArray(topics)) return topics;
   return [Number(topics)];
 }


### PR DESCRIPTION
ブック作成時にトピックを追加する旨の空の通知が意図せず表示される問題への修正です。
関連: https://github.com/npocccties/chibichilo/pull/534
