### PR TITLE
feat: トピックAPIのライセンス対応

### DIFF
--- a/openapi/models/InlineObject6.ts
+++ b/openapi/models/InlineObject6.ts
@@ -59,6 +59,12 @@ export interface InlineObject6 {
      * @type {string}
      * @memberof InlineObject6
      */
+    license?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject6
+     */
     description?: string;
     /**
      * 
@@ -88,6 +94,7 @@ export function InlineObject6FromJSONTyped(json: any, ignoreDiscriminator: boole
         'language': !exists(json, 'language') ? undefined : json['language'],
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'resource': !exists(json, 'resource') ? undefined : ApiV2TopicTopicIdResourceFromJSON(json['resource']),
         'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
@@ -107,6 +114,7 @@ export function InlineObject6ToJSON(value?: InlineObject6 | null): any {
         'language': value.language,
         'timeRequired': value.timeRequired,
         'shared': value.shared,
+        'license': value.license,
         'description': value.description,
         'resource': ApiV2TopicTopicIdResourceToJSON(value.resource),
         'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),

--- a/openapi/models/InlineObject7.ts
+++ b/openapi/models/InlineObject7.ts
@@ -59,6 +59,12 @@ export interface InlineObject7 {
      * @type {string}
      * @memberof InlineObject7
      */
+    license?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject7
+     */
     description?: string;
     /**
      * 
@@ -88,6 +94,7 @@ export function InlineObject7FromJSONTyped(json: any, ignoreDiscriminator: boole
         'language': !exists(json, 'language') ? undefined : json['language'],
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'resource': !exists(json, 'resource') ? undefined : ApiV2TopicTopicIdResourceFromJSON(json['resource']),
         'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
@@ -107,6 +114,7 @@ export function InlineObject7ToJSON(value?: InlineObject7 | null): any {
         'language': value.language,
         'timeRequired': value.timeRequired,
         'shared': value.shared,
+        'license': value.license,
         'description': value.description,
         'resource': ApiV2TopicTopicIdResourceToJSON(value.resource),
         'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),

--- a/openapi/models/InlineResponse2001Contents.ts
+++ b/openapi/models/InlineResponse2001Contents.ts
@@ -83,6 +83,12 @@ export interface InlineResponse2001Contents {
      * @type {string}
      * @memberof InlineResponse2001Contents
      */
+    license?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2001Contents
+     */
     description?: string;
     /**
      * 
@@ -156,6 +162,7 @@ export function InlineResponse2001ContentsFromJSONTyped(json: any, ignoreDiscrim
         'language': !exists(json, 'language') ? undefined : json['language'],
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
         'updatedAt': !exists(json, 'updatedAt') ? undefined : (new Date(json['updatedAt'])),
@@ -184,6 +191,7 @@ export function InlineResponse2001ContentsToJSON(value?: InlineResponse2001Conte
         'language': value.language,
         'timeRequired': value.timeRequired,
         'shared': value.shared,
+        'license': value.license,
         'description': value.description,
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),
         'updatedAt': value.updatedAt === undefined ? undefined : (value.updatedAt.toISOString()),

--- a/openapi/models/InlineResponse2001Topics.ts
+++ b/openapi/models/InlineResponse2001Topics.ts
@@ -69,6 +69,12 @@ export interface InlineResponse2001Topics {
      * @type {string}
      * @memberof InlineResponse2001Topics
      */
+    license?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2001Topics
+     */
     description?: string;
     /**
      * 
@@ -123,6 +129,7 @@ export function InlineResponse2001TopicsFromJSONTyped(json: any, ignoreDiscrimin
         'language': !exists(json, 'language') ? undefined : json['language'],
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
         'updatedAt': !exists(json, 'updatedAt') ? undefined : (new Date(json['updatedAt'])),
@@ -147,6 +154,7 @@ export function InlineResponse2001TopicsToJSON(value?: InlineResponse2001Topics 
         'language': value.language,
         'timeRequired': value.timeRequired,
         'shared': value.shared,
+        'license': value.license,
         'description': value.description,
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),
         'updatedAt': value.updatedAt === undefined ? undefined : (value.updatedAt.toISOString()),

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -6,7 +6,7 @@ import { KeywordPropSchema, KeywordSchema } from "./keyword";
 
 export type TopicProps = Pick<
   Prisma.TopicCreateInput,
-  "name" | "language" | "timeRequired" | "shared" | "description"
+  "name" | "language" | "timeRequired" | "shared" | "license" | "description"
 > & {
   resource: ResourceProps;
   keywords?: KeywordPropSchema[];
@@ -25,6 +25,7 @@ export const topicPropsSchema = {
     language: { type: "string", nullable: true },
     timeRequired: { type: "integer" },
     shared: { type: "boolean", nullable: true },
+    license: { type: "string" },
     description: { type: "string" },
     resource: resourcePropsSchema,
     keywords: {
@@ -42,6 +43,7 @@ export const topicSchema = {
     language: { type: "string" },
     timeRequired: { type: "integer" },
     shared: { type: "boolean" },
+    license: { type: "string" },
     description: { type: "string" },
     createdAt: { type: "string", format: "date-time" },
     updatedAt: { type: "string", format: "date-time" },


### PR DESCRIPTION
resolved #552
確認したこと:
開発用サーバー起動後 http://localhost:8080/api/v2/swagger/static/index.html#/default/put_api_v2_topic__topic_id_ にてライセンスフィールドを更新可能なこと
