### PR TITLE
fix: LTI v1.3 ログインエンドポイントにおいてHTTP GETリクエストのクエリ文字列﻿の参照に失敗していたため修正

### DIFF
--- a/server/config/routes/lti.ts
+++ b/server/config/routes/lti.ts
@@ -21,7 +21,7 @@ export async function login(fastify: FastifyInstance) {
   const { method, get, post } = ltiLoginService;
 
   fastify.get<{
-    Params: ltiLoginService.Props;
+    Querystring: ltiLoginService.Props;
   }>(path, { schema: method.get }, handler(get));
 
   fastify.post<{

--- a/server/services/ltiLogin.ts
+++ b/server/services/ltiLogin.ts
@@ -48,8 +48,8 @@ async function baseAction(req: FastifyRequest, props: Props) {
   };
 }
 
-export async function get(req: FastifyRequest<{ Params: Props }>) {
-  return await baseAction(req, req.params);
+export async function get(req: FastifyRequest<{ Querystring: Props }>) {
+  return await baseAction(req, req.query);
 }
 
 export async function post(req: FastifyRequest<{ Body: Props }>) {


### PR DESCRIPTION
LTI v1.3 ログインエンドポイントにおいてHTTP GETリクエストのクエリ文字列﻿の参照に失敗していたため修正
