### PR TITLE
feat: ライセンスの表示

### DIFF
--- a/components/atoms/License.stories.tsx
+++ b/components/atoms/License.stories.tsx
@@ -1,0 +1,13 @@
+import type { Story } from "@storybook/react";
+import License from "./License";
+
+export default { title: "atoms/License", component: License };
+
+const Template: Story<Parameters<typeof License>[0]> = (args) => (
+  <License {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  license: "CC-BY-4.0",
+};

--- a/components/atoms/License.tsx
+++ b/components/atoms/License.tsx
@@ -15,19 +15,7 @@ type Props = {
 
 export default function License({ license }: Props) {
   if (!Object.keys(licenses).includes(license))
-    return (
-      <Text>
-        この作品は
-        <Link
-          target="_blank"
-          rel="license noreferrer"
-          href={`https://spdx.org/licenses/${license}.html`}
-        >
-          {license} ライセンス
-        </Link>
-        の下に提供されています
-      </Text>
-    );
+    return <Text>この作品は{license} ライセンスの下に提供されています</Text>;
   const { button, url, name } = licenses[license];
   return (
     <>

--- a/components/atoms/License.tsx
+++ b/components/atoms/License.tsx
@@ -1,0 +1,51 @@
+import { styled } from "@mui/material/styles";
+import { grey } from "@mui/material/colors";
+import Link from "@mui/material/Link";
+import type { ContentSchema } from "$server/models/content";
+import licenses from "$utils/licenses";
+
+const Text = styled("p")({
+  color: grey[700],
+  fontSize: 12,
+});
+
+type Props = {
+  license: ContentSchema["license"];
+};
+
+export default function License({ license }: Props) {
+  if (!Object.keys(licenses).includes(license))
+    return (
+      <Text>
+        この作品は
+        <Link
+          target="_blank"
+          rel="license noreferrer"
+          href={`https://spdx.org/licenses/${license}.html`}
+        >
+          {license} ライセンス
+        </Link>
+        の下に提供されています
+      </Text>
+    );
+  const { button, url, name } = licenses[license];
+  return (
+    <>
+      <Link
+        sx={{ display: "block" }}
+        target="_blank"
+        rel="license noreferrer"
+        href={url}
+      >
+        <img alt={license} src={button} />
+      </Link>
+      <Text sx={{ mt: 0 }}>
+        この作品は
+        <Link target="_blank" rel="license noreferrer" href={url}>
+          {name}
+        </Link>
+        の下に提供されています
+      </Text>
+    </>
+  );
+}

--- a/components/atoms/License.tsx
+++ b/components/atoms/License.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export default function License({ license }: Props) {
   if (!Object.keys(licenses).includes(license))
-    return <Text>この作品は{license} ライセンスの下に提供されています</Text>;
+    return <Text>この作品は {license} ライセンスの下に提供されています</Text>;
   const { button, url, name } = licenses[license];
   return (
     <>

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -27,6 +27,7 @@ import type {
   VideoTrackSchema,
 } from "$server/models/videoTrack";
 import languages from "$utils/languages";
+import licenses from "$utils/licenses";
 import providers from "$utils/providers";
 import useVideoResourceProps from "$utils/useVideoResourceProps";
 import type { AuthorSchema } from "$server/models/author";
@@ -114,6 +115,7 @@ export default function TopicForm(props: Props) {
     description: topic?.description ?? "",
     shared: Boolean(topic?.shared),
     language: topic?.language ?? Object.getOwnPropertyNames(languages)[0],
+    license: topic?.license,
     timeRequired: topic?.timeRequired,
   };
   const { handleSubmit, register, getValues, setValue } = useForm<
@@ -234,6 +236,19 @@ export default function TopicForm(props: Props) {
             min: 1,
           }}
         />
+        <TextField
+          label="ライセンス"
+          select
+          defaultValue={defaultValues.license}
+          inputProps={{ displayEmpty: true, ...register("license") }}
+        >
+          <MenuItem value="">未設定</MenuItem>
+          {Object.entries(licenses).map(([value, { name }]) => (
+            <MenuItem key={value} value={value}>
+              {name}
+            </MenuItem>
+          ))}
+        </TextField>
         <KeywordsInput {...keywordsInputProps} />
         <div>
           <InputLabel>字幕</InputLabel>

--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -7,6 +7,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import Video from "$organisms/Video";
 import VideoPlayer from "$organisms/Video/VideoPlayer";
 import DescriptionList from "$atoms/DescriptionList";
+import License from "$atoms/License";
 import Markdown from "$atoms/Markdown";
 import useSticky from "$utils/useSticky";
 import getLocaleDateString from "$utils/getLocaleDateString";
@@ -109,6 +110,7 @@ export default function TopicViewerContent({ topic, onEnded, offset }: Props) {
           ...authors(topic),
         ]}
       />
+      {topic.license && <License license={topic.license} />}
       <article className={classes.description}>
         <Markdown>{topic.description}</Markdown>
       </article>

--- a/utils/licenses.ts
+++ b/utils/licenses.ts
@@ -1,0 +1,36 @@
+const licenses: {
+  [key: string]: { button: string; url: string; name: string };
+} = {
+  "CC-BY-4.0": {
+    button: "https://i.creativecommons.org/l/by/4.0/88x31.png",
+    url: "https://creativecommons.org/licenses/by/4.0/",
+    name: "クリエイティブ・コモンズ 表示 4.0 国際 ライセンス",
+  },
+  "CC-BY-NC-4.0": {
+    button: "https://i.creativecommons.org/l/by-nc/4.0/88x31.png",
+    url: "https://creativecommons.org/licenses/by-nc/4.0/",
+    name: "クリエイティブ・コモンズ 表示 - 非営利 4.0 国際 ライセンス",
+  },
+  "CC-BY-NC-ND-4.0": {
+    button: "https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png",
+    url: "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+    name: "クリエイティブ・コモンズ 表示 - 非営利 - 改変禁止 4.0 国際 ライセンス",
+  },
+  "CC-BY-NC-SA-4.0": {
+    button: "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+    url: "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+    name: "クリエイティブ・コモンズ 表示 - 非営利 - 継承 4.0 国際 ライセンス",
+  },
+  "CC-BY-ND-4.0": {
+    button: "https://i.creativecommons.org/l/by-nd/4.0/88x31.png",
+    url: "https://creativecommons.org/licenses/by-nd/4.0/",
+    name: "クリエイティブ・コモンズ 表示 - 改変禁止 4.0 国際 ライセンス",
+  },
+  "CC-BY-SA-4.0": {
+    button: "https://i.creativecommons.org/l/by-sa/4.0/88x31.png",
+    url: "https://creativecommons.org/licenses/by-sa/4.0/",
+    name: "クリエイティブ・コモンズ 表示 - 継承 4.0 国際 ライセンス",
+  },
+} as const;
+
+export default licenses;


### PR DESCRIPTION
関連: #558 

- CC-BY-*-4.0 について https://creativecommons.org/choose/ で生成される埋め込みコードに近い見え方
- それ以外は[SPDY Licenses List](https://spdx.org/licenses/)のリンク

で表示されるようにしました

![image](https://user-images.githubusercontent.com/9744580/144362271-85b12ffb-5b3a-4cbc-8da9-175817869cc3.png)