### PR TITLE
feat: トピック作成/編集のライセンス対応

### DIFF
--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -240,7 +240,7 @@ export default function TopicForm(props: Props) {
           label="ライセンス"
           select
           defaultValue={defaultValues.license}
-          inputProps={register("license")}
+          inputProps={{ displayEmpty: true, ...register("license") }}
         >
           <MenuItem value="">未設定</MenuItem>
           {Object.entries(licenses).map(([value, { name }]) => (

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -242,9 +242,7 @@ export default function TopicForm(props: Props) {
           defaultValue={defaultValues.license}
           inputProps={register("license")}
         >
-          <MenuItem value="">
-            未設定
-          </MenuItem>
+          <MenuItem value="">未設定</MenuItem>
           {Object.entries(licenses).map(([value, { name }]) => (
             <MenuItem key={value} value={value}>
               {name}

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -27,6 +27,7 @@ import type {
   VideoTrackSchema,
 } from "$server/models/videoTrack";
 import languages from "$utils/languages";
+import licenses from "$utils/licenses";
 import providers from "$utils/providers";
 import useVideoResourceProps from "$utils/useVideoResourceProps";
 import type { AuthorSchema } from "$server/models/author";
@@ -114,6 +115,7 @@ export default function TopicForm(props: Props) {
     description: topic?.description ?? "",
     shared: Boolean(topic?.shared),
     language: topic?.language ?? Object.getOwnPropertyNames(languages)[0],
+    license: topic?.license,
     timeRequired: topic?.timeRequired,
   };
   const { handleSubmit, register, getValues, setValue } = useForm<
@@ -234,6 +236,21 @@ export default function TopicForm(props: Props) {
             min: 1,
           }}
         />
+        <TextField
+          label="ライセンス"
+          select
+          defaultValue={defaultValues.license}
+          inputProps={register("license")}
+        >
+          <MenuItem key="unselect" value="">
+            未設定
+          </MenuItem>
+          {Object.entries(licenses).map(([value, { name }]) => (
+            <MenuItem key={value} value={value}>
+              {name}
+            </MenuItem>
+          ))}
+        </TextField>
         <KeywordsInput {...keywordsInputProps} />
         <div>
           <InputLabel>字幕</InputLabel>

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -242,7 +242,7 @@ export default function TopicForm(props: Props) {
           defaultValue={defaultValues.license}
           inputProps={register("license")}
         >
-          <MenuItem key="unselect" value="">
+          <MenuItem value="">
             未設定
           </MenuItem>
           {Object.entries(licenses).map(([value, { name }]) => (


### PR DESCRIPTION
関連: #551 

以下のようなライセンスのセレクターを追加しました

![image](https://user-images.githubusercontent.com/9744580/144365144-a46b0876-f2c7-470f-8184-10226b6f864c.png)

確認したこと

- 開発環境でトピック作成/編集によるライセンスの設定/設定解除ができること

差分を見やすくするためベースブランチを #593 にしています
