### PR TITLE
feat: 共有可否フィルターのサポート

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -69,6 +69,7 @@
     "strict-uri-encode": "^2.0.0",
     "ts-jest": "^27.0.5",
     "unzipper": "^0.10.11",
-    "webpack": "^5.51.1"
+    "webpack": "^5.51.1",
+    "yn": "^4.0.0"
   }
 }

--- a/server/utils/search/bookSearch.ts
+++ b/server/utils/search/bookSearch.ts
@@ -18,7 +18,16 @@ import type { BookSearchQuery } from "./query";
  * @return ブック
  */
 async function bookSearch(
-  { text, name, description, author, keyword, license, link }: BookSearchQuery,
+  {
+    text,
+    name,
+    description,
+    author,
+    keyword,
+    license,
+    shared,
+    link,
+  }: BookSearchQuery,
   filter: AuthorFilter,
   sort: string,
   page: number,
@@ -100,6 +109,10 @@ async function bookSearch(
         // NOTE: license - ライセンス
         ...license.map((l) => ({
           license: l,
+        })),
+        // NOTE: shared - 共有可否
+        ...shared.map((s) => ({
+          shared: s,
         })),
         // NOTE: link - 提供されているコース
         ...link.map((l) => ({

--- a/server/utils/search/parser.test.ts
+++ b/server/utils/search/parser.test.ts
@@ -4,7 +4,7 @@ describe("parse()", function () {
   test("検索クエリー文字列をパースできる", function () {
     expect(
       parse(
-        `name:a description:"b b" author:c keyword:d,e license:CC-BY-4.0 link:hoge:piyo foo bar baz`
+        `name:a description:"b b" author:c keyword:d,e license:CC-BY-4.0 shared:true link:hoge:piyo foo bar baz`
       )
     ).toEqual({
       text: ["foo", "bar", "baz"],
@@ -13,6 +13,7 @@ describe("parse()", function () {
       author: ["c"],
       keyword: ["d", "e"],
       license: ["CC-BY-4.0"],
+      shared: [true],
       link: [{ consumerId: "hoge", contextId: "piyo" }],
     });
   });
@@ -42,12 +43,13 @@ describe("parse()", function () {
       author: [],
       keyword: [],
       license: [],
+      shared: [],
       link: [],
     });
   });
 });
 
-describe("query()", function () {
+describe("stringify()", function () {
   test("検索クエリー文字列に変換", () => {
     const query = {
       text: ["a", "b"],
@@ -56,6 +58,7 @@ describe("query()", function () {
       author: [],
       keyword: ["foo", "bar"],
       license: [],
+      shared: [],
       link: [],
     };
     expect(stringify(query)).toBe("a b keyword:foo,bar");
@@ -69,6 +72,7 @@ describe("query()", function () {
       author: [],
       keyword: [],
       license: [],
+      shared: [],
       link: [{ consumerId: "foo", contextId: "bar" }],
     };
     expect(stringify(query)).toBe("link:foo:bar");
@@ -82,6 +86,7 @@ describe("query()", function () {
       author: [],
       keyword: [],
       license: [],
+      shared: [],
       link: [
         { consumerId: "foo", contextId: "bar" },
         { consumerId: "hoge", contextId: "piyo" },
@@ -98,8 +103,23 @@ describe("query()", function () {
       author: [],
       keyword: [],
       license: [],
+      shared: [],
       link: [{ consumerId: "te:s,t", contextId: "fo o" }],
     };
     expect(stringify(query)).toBe("link:te%3As%2Ct:fo%20o");
+  });
+
+  test("共有可否を検索クエリー文字列に変換", () => {
+    const query = {
+      text: [],
+      name: [],
+      description: [],
+      author: [],
+      keyword: [],
+      license: [],
+      shared: [true],
+      link: [],
+    };
+    expect(stringify(query)).toBe("shared:true");
   });
 });

--- a/server/utils/search/query.ts
+++ b/server/utils/search/query.ts
@@ -13,6 +13,8 @@ export type SearchQueryBase = {
   keyword: string[];
   /** ライセンス (SPDX License Identifier) */
   license: string[];
+  /** 共有可否 (true: シェアする, それ以外: シェアしない) */
+  shared: boolean[],
   /** トピックの場合: 無効、ブックの場合: 提供されているコース */
   link: Array<Pick<LtiResourceLinkSchema, "consumerId" | "contextId">>;
 };

--- a/server/utils/search/query.ts
+++ b/server/utils/search/query.ts
@@ -14,7 +14,7 @@ export type SearchQueryBase = {
   /** ライセンス (SPDX License Identifier) */
   license: string[];
   /** 共有可否 (true: シェアする, それ以外: シェアしない) */
-  shared: boolean[],
+  shared: boolean[];
   /** トピックの場合: 無効、ブックの場合: 提供されているコース */
   link: Array<Pick<LtiResourceLinkSchema, "consumerId" | "contextId">>;
 };

--- a/server/utils/search/topicSearch.ts
+++ b/server/utils/search/topicSearch.ts
@@ -18,7 +18,15 @@ import type { TopicSearchQuery } from "./query";
  * @return トピック
  */
 async function topicSearch(
-  { text, name, description, author, keyword, license }: TopicSearchQuery,
+  {
+    text,
+    name,
+    description,
+    author,
+    keyword,
+    license,
+    shared,
+  }: TopicSearchQuery,
   filter: AuthorFilter,
   sort: string,
   page: number,
@@ -55,13 +63,17 @@ async function topicSearch(
         ...author.map((a) => ({
           authors: { some: { user: { name: { contains: a } } } },
         })),
+        // NOTE: keyword - キーワード
+        ...keyword.map((k) => ({
+          keywords: { some: { name: k } },
+        })),
         // NOTE: license - ライセンス
         ...license.map((l) => ({
           license: l,
         })),
-        // NOTE: keyword - キーワード
-        ...keyword.map((k) => ({
-          keywords: { some: { name: k } },
+        // NOTE: shared - 共有可否
+        ...shared.map((s) => ({
+          shared: s,
         })),
       ],
     },

--- a/utils/search/stringify.ts
+++ b/utils/search/stringify.ts
@@ -14,6 +14,7 @@ function stringify(query: Partial<SearchQueryBase>): string {
     author: [],
     keyword: [],
     license: [],
+    shared: [],
     link: [],
     ...query,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15712,6 +15712,11 @@ yargs@^16.0.3, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-4.0.0.tgz#611480051ea43b510da1dfdbe177ed159f00a979"
+  integrity sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"


### PR DESCRIPTION
resolved #550

使い方: (シェアされているものでの絞り込みの場合) 検索欄に `shared:true` と入力して検索
シェアされていないものは`shared:false`と入力して検索
