### PR TITLE
fix: SPDX Licenseに適合するもののみ受け付けるライセンスのバリデーションの対応

### DIFF
--- a/server/config/app.ts
+++ b/server/config/app.ts
@@ -7,6 +7,7 @@ import cookie from "fastify-cookie";
 import auth from "fastify-auth";
 import formbody from "fastify-formbody";
 import pkg from "$server/package.json";
+import { buildValidatorCompiler } from "./validations";
 import routes from "./routes";
 
 export type Options = {
@@ -62,6 +63,8 @@ async function app(fastify: FastifyInstance, options: Options) {
     fastify.register(formbody),
   ]);
 
+  const validatorCompiler = buildValidatorCompiler();
+  fastify.setValidatorCompiler(validatorCompiler);
   await fastify.register(routes, { prefix: basePath });
 }
 

--- a/server/config/validations.ts
+++ b/server/config/validations.ts
@@ -1,0 +1,26 @@
+import type {
+  FastifyRouteSchemaDef,
+  FastifyValidationResult,
+} from "fastify/types/schema";
+import Ajv from "ajv";
+import { isValidLicense } from "$server/validators/license";
+
+export function buildValidatorCompiler() {
+  const ajv = new Ajv({
+    removeAdditional: true,
+    useDefaults: true,
+    coerceTypes: true,
+  }).addFormat("license", {
+    type: "string",
+    validate: isValidLicense,
+  });
+
+  function validatorCompiler<T>({
+    schema,
+  }: FastifyRouteSchemaDef<T>): FastifyValidationResult {
+    // @ts-expect-error TODO: `errors` には `instancePath` が得られるが FastifySchemaValidationError では `dataPath` が必須
+    return ajv.compile(schema);
+  }
+
+  return validatorCompiler;
+}

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -25,7 +25,7 @@ export const topicPropsSchema = {
     language: { type: "string", nullable: true },
     timeRequired: { type: "integer" },
     shared: { type: "boolean", nullable: true },
-    license: { type: "string" },
+    license: { type: "string", format: "license" },
     description: { type: "string" },
     resource: resourcePropsSchema,
     keywords: {

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
     "@types/strict-uri-encode": "^2.0.0",
     "@types/unzipper": "^0.10.4",
     "@vercel/ncc": "^0.30.0",
+    "ajv": "^8.8.2",
     "class-validator": "^0.13.1",
     "class-validator-jsonschema": "^3.1.0",
     "date-fns": "^2.23.0",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -83,7 +83,7 @@ model Topic {
   shared       Boolean        @default(true)
   /// 著作者
   authors      Authorship[]
-  /// ライセンス (https://spdx.org/licenses/ に準拠するものを入力する)
+  /// ライセンス (https://spdx.org/licenses/ に準拠するもの, "" は無効)
   license      String         @default("")
   /// 作成日
   createdAt    DateTime       @default(now()) @map("created_at")
@@ -184,7 +184,7 @@ model Book {
   shared           Boolean           @default(true)
   /// 著作者
   authors          Authorship[]
-  /// ライセンス (https://spdx.org/licenses/ に準拠するものを入力する)
+  /// ライセンス (https://spdx.org/licenses/ に準拠するもの, "" は無効)
   license          String            @default("")
   /// 公開日
   publishedAt      DateTime          @default(now()) @map("published_at")

--- a/server/validators/license.test.ts
+++ b/server/validators/license.test.ts
@@ -1,0 +1,16 @@
+import { isValidLicense } from "./license";
+
+describe("isValidLicense()", () => {
+  test("正しい形式のライセンス", () => {
+    expect(isValidLicense("CC-BY-4.0")).toBe(true);
+  });
+  test("誤った形式のライセンス", () => {
+    expect(isValidLicense("無効なライセンス")).toBe(false);
+  });
+  test("式を含む形式の正しいライセンス", () => {
+    expect(isValidLicense("GPL-2.0 OR MIT")).toBe(true);
+  });
+  test("空文字は無効値として許容", () => {
+    expect(isValidLicense("")).toBe(true);
+  });
+});

--- a/server/validators/license.ts
+++ b/server/validators/license.ts
@@ -1,0 +1,18 @@
+import parse from "spdx-expression-parse";
+
+/**
+ * ライセンス https://spdx.org/licenses/ に準拠しているか否かの判定
+ * @param input ライセンス
+ * @returns 空文字か正しい形式ならば true, そうでなければ false
+ */
+export function isValidLicense(input: unknown): boolean {
+  if (typeof input !== "string") return false;
+  if (input === "") return true;
+
+  try {
+    parse(input);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3942,10 +3942,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.4, ajv
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
-  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
+ajv@^8.0.1, ajv@^8.8.2:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
resolved #589

- JSON Schema custom formats `"license"` を追加
