### PR TITLE
feat: 一覧画面でのコンテンツの種類の表示, etc.

### DIFF
--- a/components/atoms/AuthorFilter.tsx
+++ b/components/atoms/AuthorFilter.tsx
@@ -3,7 +3,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import makeStyles from "@mui/styles/makeStyles";
-import { gray } from "$theme/colors";
+import { grey } from "@mui/material/colors";
 import type { AuthorFilterType } from "$server/models/authorFilter";
 
 const useStyles = makeStyles((theme) => ({
@@ -13,13 +13,13 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(0),
     backgroundColor: "white",
     border: "1px solid",
-    borderColor: gray[500],
+    borderColor: grey[300],
     borderRadius: 8,
   },
   legend: {
     marginLeft: theme.spacing(1),
     marginBottom: theme.spacing(-1),
-    color: gray[700],
+    color: grey[700],
     fontSize: "0.75rem",
   },
   group: {
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
 
 const useFormControlLabelStyles = makeStyles((theme) => ({
   label: {
-    color: gray[800],
+    color: grey[800],
     fontSize: "0.875rem",
     marginLeft: theme.spacing(-0.5),
   },

--- a/components/atoms/ContentTypeIndicator.stories.tsx
+++ b/components/atoms/ContentTypeIndicator.stories.tsx
@@ -1,0 +1,16 @@
+import type { Story } from "@storybook/react";
+import ContentTypeIndicator from "./ContentTypeIndicator";
+
+export default {
+  title: "atoms/ContentTypeIndicator",
+  component: ContentTypeIndicator,
+};
+
+const Template: Story<Parameters<typeof ContentTypeIndicator>[0]> = (args) => (
+  <ContentTypeIndicator {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  type: "book",
+};

--- a/components/atoms/ContentTypeIndicator.tsx
+++ b/components/atoms/ContentTypeIndicator.tsx
@@ -1,0 +1,47 @@
+import Box from "@mui/material/Box";
+import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
+import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
+import { styled } from "@mui/material/styles";
+import { grey } from "@mui/material/colors";
+import type { ContentSchema } from "$server/models/content";
+
+const Heading = styled("h6")({
+  color: grey[700],
+  fontSize: "0.75rem",
+  fontWeight: "normal",
+});
+
+const value = {
+  book: {
+    icon: <MenuBookOutlinedIcon sx={{ mr: 0.5 }} />,
+    name: "ブック",
+  },
+  topic: {
+    icon: <LibraryBooksOutlinedIcon sx={{ mr: 0.5 }} />,
+    name: "トピック",
+  },
+} as const;
+
+type Props = {
+  type: ContentSchema["type"];
+};
+
+export default function ContentTypeIndicator({ type }: Props) {
+  const { icon, name } = value[type];
+  return (
+    <section>
+      <Heading sx={{ m: 0, mt: -1 }}>コンテンツの種類</Heading>
+      <Box
+        sx={{
+          display: "flex",
+          py: 0.25,
+          alignItems: "center",
+          "& > p": { m: 0 },
+        }}
+      >
+        {icon}
+        <p>{name}</p>
+      </Box>
+    </section>
+  );
+}

--- a/components/atoms/SearchTextField.tsx
+++ b/components/atoms/SearchTextField.tsx
@@ -7,7 +7,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import SearchIcon from "@mui/icons-material/Search";
 import SearchClearButton from "./SearchClearButton";
 import Divider from "@mui/material/Divider";
-import gray from "$theme/colors/gray";
+import { grey } from "@mui/material/colors";
 
 const useOutlinedInputStyles = makeStyles((theme) => ({
   root: {
@@ -15,12 +15,12 @@ const useOutlinedInputStyles = makeStyles((theme) => ({
     borderRadius: "1.25rem",
     paddingRight: theme.spacing(2),
     "&:hover $notchedOutline": {
-      borderColor: gray[500],
+      borderColor: grey[300],
       borderWidth: "1px",
     },
     "@media (hover: none)": {
       "&:hover $notchedOutline": {
-        borderColor: gray[500],
+        borderColor: grey[300],
       },
     },
     "&$focused $notchedOutline": {
@@ -35,7 +35,7 @@ const useOutlinedInputStyles = makeStyles((theme) => ({
   },
   focused: {},
   notchedOutline: {
-    borderColor: gray[500],
+    borderColor: grey[300],
     transition: theme.transitions.create(["border-color"]),
   },
 }));
@@ -95,7 +95,7 @@ export default function SearchTextField({
                 })}
               />
               <Divider orientation="vertical" className={classes.divider} />
-              <SearchIcon style={{ color: gray[700] }} />
+              <SearchIcon style={{ color: grey[700] }} />
             </InputAdornment>
           ),
           ...props.InputProps,

--- a/components/atoms/Select.tsx
+++ b/components/atoms/Select.tsx
@@ -1,7 +1,14 @@
 import MuiSelect from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
+import { outlinedInputClasses } from "@mui/material/OutlinedInput";
+import { grey } from "@mui/material/colors";
 import select from "$styles/select";
 
-const Select = styled(MuiSelect)(({ theme }) => select(theme));
+const Select = styled(MuiSelect)(({ theme }) => ({
+  [`.${outlinedInputClasses.notchedOutline}`]: {
+    borderColor: grey[300],
+  },
+  ...select(theme),
+}));
 
 export default Select;

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -5,6 +5,7 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import AddIcon from "@mui/icons-material/Add";
 import ActionHeader from "$organisms/ActionHeader";
+import ContentTypeIndicator from "$atoms/ContentTypeIndicator";
 import ContentPreview from "$organisms/ContentPreview";
 import LinkInfo from "$organisms/LinkInfo";
 import SearchPagination from "$organisms/SearchPagination";
@@ -88,6 +89,7 @@ export default function Books(props: Props) {
         action={
           <>
             <SortSelect onSortChange={searchProps.onSortChange} />
+            <ContentTypeIndicator type="book" />
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="ブック・トピック検索"

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -10,6 +10,7 @@ import Container from "@mui/material/Container";
 import AddIcon from "@mui/icons-material/Add";
 import ActionHeader from "$organisms/ActionHeader";
 import ActionFooter from "$organisms/ActionFooter";
+import ContentTypeIndicator from "$atoms/ContentTypeIndicator";
 import ContentPreview from "$organisms/ContentPreview";
 import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
 import SearchPagination from "$organisms/SearchPagination";
@@ -158,6 +159,7 @@ export default function Topics(props: Props) {
               />
             </Badge>
             <SortSelect onSortChange={searchProps.onSortChange} />
+            <ContentTypeIndicator type="topic" />
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="トピック検索"

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -18,7 +18,7 @@ import AuthorFilter from "$atoms/AuthorFilter";
 import SearchTextField from "$atoms/SearchTextField";
 import type { ContentSchema } from "$server/models/content";
 import type { TopicSchema } from "$server/models/topic";
-import { gray } from "$theme/colors";
+import { grey } from "@mui/material/colors";
 import useContainerStyles from "$styles/container";
 import useDialogProps from "$utils/useDialogProps";
 import { useSearchAtom } from "$store/search";
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(0),
     backgroundColor: "white",
     border: "1px solid",
-    borderColor: gray[500],
+    borderColor: grey[300],
     borderRadius: 8,
   },
   checkbox: {},

--- a/styles/outlinedInput.ts
+++ b/styles/outlinedInput.ts
@@ -1,12 +1,12 @@
 import type { Theme } from "@mui/material/styles";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 import { inputBaseClasses } from "@mui/material/InputBase";
-import gray from "theme/colors/gray";
+import { grey } from "@mui/material/colors";
 
 const outlinedInput = (theme: Theme) => ({
   [`.${outlinedInputClasses.root}`]: {
     backgroundColor: theme.palette.common.white,
-    border: `1px solid ${gray[500]}`,
+    border: `1px solid ${grey[300]}`,
     borderRadius: "6px",
     fontSize: "1rem",
     transition: theme.transitions.create(["border-color"]),


### PR DESCRIPTION
#555 への対応です

スクロール時追従する領域で、コンテンツの種類が分かるようにしました

ブック

![image](https://user-images.githubusercontent.com/9744580/144809889-f25a5c51-5c33-4825-807c-407213b0e799.png)

トピック

![image](https://user-images.githubusercontent.com/9744580/144809843-00602340-c6af-4b0f-9d8f-b0bf3e039475.png)
