### PR TITLE
feat: コンテンツの種類の表示を強調する

### DIFF
--- a/components/atoms/ContentTypeIndicator.tsx
+++ b/components/atoms/ContentTypeIndicator.tsx
@@ -34,9 +34,8 @@ export default function ContentTypeIndicator({ type }: Props) {
       <Box
         sx={{
           display: "flex",
-          py: 0.25,
           alignItems: "center",
-          "& > p": { m: 0 },
+          "& > p": { m: 0, fontSize: "1.25rem", fontWeight: "bold" },
         }}
       >
         {icon}


### PR DESCRIPTION
#555 への対応です

コンテンツの種類の表示部分の文字を太字にし、大きさを1.25倍にすることで強調しました

![image](https://user-images.githubusercontent.com/9744580/144821112-e56af6fd-868f-4cca-b5d3-4787e2a4d499.png)

