### PR TITLE
feat: コンテンツの種類は重要な情報なので一番左に配置する

### DIFF
--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -88,8 +88,8 @@ export default function Books(props: Props) {
         }
         action={
           <>
-            <SortSelect onSortChange={searchProps.onSortChange} />
             <ContentTypeIndicator type="book" />
+            <SortSelect onSortChange={searchProps.onSortChange} />
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="ブック・トピック検索"

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -142,6 +142,7 @@ export default function Topics(props: Props) {
         }
         action={
           <>
+            <ContentTypeIndicator type="topic" />
             <Badge
               className={classes.fieldset}
               badgeContent={selected.size}
@@ -159,7 +160,6 @@ export default function Topics(props: Props) {
               />
             </Badge>
             <SortSelect onSortChange={searchProps.onSortChange} />
-            <ContentTypeIndicator type="topic" />
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="トピック検索"


### PR DESCRIPTION
以下への対応です

> > 「コンテンツの種類・ブック」という文字列を，並び順のソートの前にもってくるのは難しいのでしょうか？
> 
> 画面上の左上から目につきやすいという特性を考えれば、おっしゃるように一番左に配置するのは一定の理があるとおもいます。
> 
> なやましかった背景として、並べ替えという操作も一番左に配置されることが多く、そのような「見慣れたレイアウト」であることを優先するのか、このアプリケーション特有のコンテキストを優先するのか、という判断をおこなう必要がありました。
> 
> 結果的に私は「見慣れたレイアウト」であることを #607 の時点では優先したわけですが、今からその並びをかえることは理解できる判断であると思いました。
> 
> _Originally posted by @knokmki612 in https://github.com/npocccties/chibichilo/issues/555#issuecomment-986609709_

![image](https://user-images.githubusercontent.com/9744580/144825477-4ab86b3a-29ec-480d-9125-0a57d3d7b56e.png)