### PR TITLE
feat: 検索欄での検索実行のタイミングを入力時から手動にする

### DIFF
--- a/components/atoms/SearchClearButton.tsx
+++ b/components/atoms/SearchClearButton.tsx
@@ -6,8 +6,8 @@ type Props = Omit<Parameters<typeof IconButton>[0], "tooltipProps">;
 export default function SearchClearButton({ ...other }: Props) {
   return (
     <IconButton
-      color="primary"
       size="small"
+      color="secondary"
       {...other}
       tooltipProps={{ title: `検索を解除` }}
     >

--- a/components/atoms/SearchTextField.tsx
+++ b/components/atoms/SearchTextField.tsx
@@ -1,111 +1,105 @@
-import type { ComponentProps, FormEvent } from "react";
-import { useCallback } from "react";
-import clsx from "clsx";
+import { useState, useEffect, useCallback } from "react";
+import { useDebouncedCallback } from "use-debounce";
 import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
-import makeStyles from "@mui/styles/makeStyles";
+import { outlinedInputClasses } from "@mui/material/OutlinedInput";
+import { inputLabelClasses } from "@mui/material/InputLabel";
+import { styled } from "@mui/material/styles";
 import SearchIcon from "@mui/icons-material/Search";
-import SearchClearButton from "./SearchClearButton";
-import Divider from "@mui/material/Divider";
-import { grey } from "@mui/material/colors";
+import SearchClearButton from "$atoms/SearchClearButton";
+import { grey, common } from "@mui/material/colors";
+import IconButton from "$atoms/IconButton";
 
-const useOutlinedInputStyles = makeStyles((theme) => ({
-  root: {
-    backgroundColor: "#fff",
+type Props = Omit<Parameters<typeof TextField>[0], "variant" | "value"> & {
+  value: string;
+  onSearchInput: (value: string) => void;
+  onSearchInputReset: () => void;
+  onSearchSubmit: (value: string) => void;
+};
+
+const SearchTextField = styled(
+  ({
+    value,
+    onSearchInput,
+    onSearchInputReset,
+    onSearchSubmit,
+    InputProps,
+    ...other
+  }: Props) => {
+    const [valueState, setValueState] = useState(value);
+    useEffect(() => {
+      setValueState(value);
+    }, [setValueState, value]);
+    const debouncedSearchInput = useDebouncedCallback(onSearchInput, 500);
+    const handleSearchInput = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValueState(event.target.value);
+        debouncedSearchInput(event.target.value);
+      },
+      [setValueState, debouncedSearchInput]
+    );
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+      if (event.key === "Enter") {
+        handleSearchSubmit();
+      }
+    };
+    const handleSearchSubmit = () => onSearchSubmit(valueState);
+    return (
+      <TextField
+        value={valueState}
+        onChange={handleSearchInput}
+        onKeyDown={handleKeyDown}
+        variant="outlined"
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <SearchClearButton onClick={onSearchInputReset} />
+              <IconButton
+                onClick={handleSearchSubmit}
+                size="small"
+                color="primary"
+                tooltipProps={{ title: "検索" }}
+              >
+                <SearchIcon />
+              </IconButton>
+            </InputAdornment>
+          ),
+          ...InputProps,
+        }}
+        {...other}
+      />
+    );
+  }
+)(({ theme }) => ({
+  [`.${outlinedInputClasses.root}`]: {
+    backgroundColor: common.white,
     borderRadius: "1.25rem",
-    paddingRight: theme.spacing(2),
-    "&:hover $notchedOutline": {
+    paddingRight: theme.spacing(1),
+    [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
       borderColor: grey[300],
       borderWidth: "1px",
     },
-    "@media (hover: none)": {
-      "&:hover $notchedOutline": {
-        borderColor: grey[300],
+    [`&.${outlinedInputClasses.focused} .${outlinedInputClasses.notchedOutline}`]:
+      {
+        borderColor: theme.palette.primary.main,
+        borderWidth: "1px",
       },
-    },
-    "&$focused $notchedOutline": {
-      borderColor: theme.palette.primary.main,
-      borderWidth: "1px",
-    },
   },
-  input: {
+  [`.${outlinedInputClasses.notchedOutline}`]: {
+    borderColor: grey[300],
+    transition: theme.transitions.create(["border-color"]),
+  },
+  [`.${outlinedInputClasses.input}`]: {
     height: "1.25rem",
     padding: theme.spacing(1, 2),
     paddingRight: 0,
   },
-  focused: {},
-  notchedOutline: {
-    borderColor: grey[300],
-    transition: theme.transitions.create(["border-color"]),
-  },
-}));
-
-const useInputLabelStyles = makeStyles((theme) => ({
-  outlined: {
+  [`.${inputLabelClasses.outlined}`]: {
     transform: `translate(${theme.spacing(2)}, 6px)`,
-    "&$shrink": {
+    [`&.${inputLabelClasses.shrink}`]: {
       transform: "translate(14px, -9px) scale(0.75)",
     },
   },
-  shrink: {},
 }));
 
-const useStyles = makeStyles(() => ({
-  hide: {
-    visibility: "hidden",
-  },
-  divider: { height: 28, margin: 4 },
-}));
-type Props = {
-  value: string;
-  onSearchInput: (input: string) => void;
-  onSearchInputReset: () => void;
-} & Omit<ComponentProps<typeof TextField>, "value">;
-
-export default function SearchTextField({
-  onSearchInput,
-  onSearchInputReset,
-  ...props
-}: Props) {
-  const outlinedInputClasses = useOutlinedInputStyles();
-  const inputLabelClasses = useInputLabelStyles();
-  const classes = useStyles();
-  const handleInput = useCallback(
-    (event: FormEvent<HTMLInputElement>) => {
-      onSearchInput?.(event.currentTarget.value);
-    },
-    [onSearchInput]
-  );
-  return (
-    <div>
-      <TextField
-        variant="outlined"
-        inputProps={{
-          onInput: handleInput,
-          ...props.inputProps,
-        }}
-        InputProps={{
-          classes: outlinedInputClasses,
-          endAdornment: (
-            <InputAdornment position="end">
-              <SearchClearButton
-                onClick={onSearchInputReset}
-                className={clsx({
-                  [classes.hide]: !props.value,
-                })}
-              />
-              <Divider orientation="vertical" className={classes.divider} />
-              <SearchIcon style={{ color: grey[700] }} />
-            </InputAdornment>
-          ),
-          ...props.InputProps,
-        }}
-        InputLabelProps={{
-          classes: inputLabelClasses,
-          ...props.InputLabelProps,
-        }}
-        {...props}
-      />
-    </div>
-  );
-}
+export default SearchTextField;

--- a/components/organisms/AuthorsInput.tsx
+++ b/components/organisms/AuthorsInput.tsx
@@ -1,6 +1,7 @@
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
+import InputAdornment from "@mui/material/InputAdornment";
 import type { SelectChangeEvent } from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
 import { grey } from "@mui/material/colors";
@@ -131,9 +132,13 @@ export default function AuthorsInput({
           value={value}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
-          startAdornment={<EmailOutlinedIcon />}
+          startAdornment={
+            <InputAdornment position="start">
+              <EmailOutlinedIcon />
+            </InputAdornment>
+          }
           endAdornment={
-            <>
+            <InputAdornment position="end">
               <IconButton
                 onClick={handleReset}
                 color="secondary"
@@ -148,7 +153,7 @@ export default function AuthorsInput({
               >
                 <PersonAddIcon />
               </IconButton>
-            </>
+            </InputAdornment>
           }
         />
         <FormHelperText>{helperText}</FormHelperText>

--- a/components/organisms/KeywordsInput.tsx
+++ b/components/organisms/KeywordsInput.tsx
@@ -5,6 +5,7 @@ import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import Chip from "@mui/material/Chip";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
+import InputAdornment from "@mui/material/InputAdornment";
 import IconButton from "$atoms/IconButton";
 import Input from "$atoms/Input";
 import InputLabel from "$atoms/InputLabel";
@@ -76,9 +77,13 @@ export default function KeywordsInput({
           value={value}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
-          startAdornment={<LabelOutlinedIcon />}
+          startAdornment={
+            <InputAdornment position="start">
+              <LabelOutlinedIcon />
+            </InputAdornment>
+          }
           endAdornment={
-            <>
+            <InputAdornment position="end">
               <IconButton
                 onClick={handleReset}
                 color="secondary"
@@ -93,7 +98,7 @@ export default function KeywordsInput({
               >
                 <AddIcon />
               </IconButton>
-            </>
+            </InputAdornment>
           }
         />
         <FormHelperText>{helperText}</FormHelperText>

--- a/components/templates/BookImport.tsx
+++ b/components/templates/BookImport.tsx
@@ -143,9 +143,10 @@ export default function BookImport(props: Props) {
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="ブック・トピック検索"
-              value={searchProps.query.q}
+              value={searchProps.input}
               onSearchInput={searchProps.onSearchInput}
               onSearchInputReset={searchProps.onSearchInputReset}
+              onSearchSubmit={searchProps.onSearchSubmit}
             />
           </>
         }

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -93,9 +93,10 @@ export default function Books(props: Props) {
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="ブック・トピック検索"
-              value={searchProps.query.q}
+              value={searchProps.input}
               onSearchInput={searchProps.onSearchInput}
               onSearchInputReset={searchProps.onSearchInputReset}
+              onSearchSubmit={searchProps.onSearchSubmit}
             />
           </>
         }

--- a/components/templates/TopicImport.tsx
+++ b/components/templates/TopicImport.tsx
@@ -93,9 +93,10 @@ export default function TopicImport(props: Props) {
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="トピック検索"
-              value={searchProps.query.q}
+              value={searchProps.input}
               onSearchInput={searchProps.onSearchInput}
               onSearchInputReset={searchProps.onSearchInputReset}
+              onSearchSubmit={searchProps.onSearchSubmit}
             />
           </>
         }

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -163,9 +163,10 @@ export default function Topics(props: Props) {
             <AuthorFilter onFilterChange={searchProps.onFilterChange} />
             <SearchTextField
               label="トピック検索"
-              value={searchProps.query.q}
+              value={searchProps.input}
               onSearchInput={searchProps.onSearchInput}
               onSearchInputReset={searchProps.onSearchInputReset}
+              onSearchSubmit={searchProps.onSearchSubmit}
             />
           </>
         }

--- a/store/search.ts
+++ b/store/search.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { atom, useAtom } from "jotai";
 import clsx from "clsx";
 import stringify from "$utils/search/stringify";
@@ -23,8 +23,12 @@ const queryAtom = atom<{
   page: 0,
 });
 
+const inputAtom = atom<string>("");
+
 export function useSearchAtom() {
   const [query, updateQuery] = useAtom(queryAtom);
+  const [input, updateInput] = useAtom(inputAtom);
+  useEffect(() => updateInput(query.q), [updateInput, query]);
   const setType: (type: "book" | "topic") => void = useCallback(
     (type) =>
       updateQuery({
@@ -42,6 +46,10 @@ export function useSearchAtom() {
     [updateQuery]
   );
   const onSearchInput: (q: string) => void = useCallback(
+    (q) => updateInput(q),
+    [updateInput]
+  );
+  const onSearchSubmit: (q: string) => void = useCallback(
     (q) => updateQuery((query) => ({ ...query, q, page: 0 })),
     [updateQuery]
   );
@@ -80,10 +88,12 @@ export function useSearchAtom() {
 
   return {
     query,
+    input,
     setType,
     setPage,
     onSearchInput,
     onSearchInputReset,
+    onSearchSubmit,
     onFilterChange,
     onSortChange,
     onLtiContextClick,


### PR DESCRIPTION
#560 への対応です

- refactor: InputAdornmentが使用可能な場所への導入
- feat(SearchTextField): 検索ボタンの追加
    - 検索実行のハンドラーの追加
    - 再描画を抑制するdebouce、useStateの導入
    - styled形式へのスタイルの移行
    - 入力欄の文字列の状態管理の追加

![image](https://user-images.githubusercontent.com/9744580/145033465-8e39af05-27dd-4dd1-b60b-3f5e278839ea.png)
