### PR TITLE
refactor: 不要なdebounceの除去

### DIFF
--- a/components/atoms/SearchTextField.tsx
+++ b/components/atoms/SearchTextField.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from "react";
-import { useDebouncedCallback } from "use-debounce";
 import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
@@ -30,14 +29,12 @@ const SearchTextField = styled(
     useEffect(() => {
       setValueState(value);
     }, [setValueState, value]);
-    const debouncedSearchInput = useDebouncedCallback(onSearchInput, 500);
-    const handleSearchInput = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        setValueState(event.target.value);
-        debouncedSearchInput(event.target.value);
-      },
-      [setValueState, debouncedSearchInput]
+    const handleChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) =>
+        setValueState(event.target.value),
+      [setValueState]
     );
+    const handleBlur = () => onSearchInput(valueState);
     const handleKeyDown = (event: React.KeyboardEvent) => {
       if (event.key === "Enter") {
         handleSearchSubmit();
@@ -47,7 +44,8 @@ const SearchTextField = styled(
     return (
       <TextField
         value={valueState}
-        onChange={handleSearchInput}
+        onChange={handleChange}
+        onBlur={handleBlur}
         onKeyDown={handleKeyDown}
         variant="outlined"
         InputProps={{


### PR DESCRIPTION
関連: #560

検索欄での入力後入力内容の `store/search` への反映が必要なケースは以下の2つ

1. onSearchSubmit発火時:
   onSearchSubmitの発火時に入力内容が渡される
2. onKeywordClick/onLtiContextClick発火時:
   debouncedなonSearchInputが事前に発火している

このうち2\.について、onKeywordClickないしonLtiContextClickが発火する際は
必ず検索欄からのフォーカスが外れている(onBlurが発火する)との仮定により
onSearchInputの発火タイミングをonChangeからonBlurに変更
debounceは頻繁なイベントの発火を抑制するために使用していたがonBlurでは不要