### PR TITLE
fix: 検索欄の入力途中にキーワードをクリックすると検索欄の入力内容が失われる

### DIFF
--- a/store/search.ts
+++ b/store/search.ts
@@ -71,19 +71,19 @@ export function useSearchAtom() {
     (link) =>
       updateQuery((query) => ({
         ...query,
-        q: clsx(query.q, stringify({ link: [link] })),
+        q: clsx(input, stringify({ link: [link] })),
         page: 0,
       })),
-    [updateQuery]
+    [updateQuery, input]
   );
   const onKeywordClick: (keyword: KeywordSchema) => void = useCallback(
     (keyword) =>
       updateQuery((query) => ({
         ...query,
-        q: clsx(query.q, stringify({ keyword: [keyword.name] })),
+        q: clsx(input, stringify({ keyword: [keyword.name] })),
         page: 0,
       })),
-    [updateQuery]
+    [updateQuery, input]
   );
 
   return {


### PR DESCRIPTION
関連: #560

以下のような問題、変更内容への対応

> 
> > SearchTextField 外で query.q が更新される場合に、それを反映する
> 
> お粗末ながら現時点でもこの点について実現できておらず、次のような変更が必要ですね
> 
> ```diff
> diff --git a/store/search.ts b/store/search.ts
> index 745bdbb..ccfdca9 100644
> --- a/store/search.ts
> +++ b/store/search.ts
> @@ -71,19 +71,19 @@ export function useSearchAtom() {
>      (link) =>
>        updateQuery((query) => ({
>          ...query,
> -        q: clsx(query.q, stringify({ link: [link] })),
> +        q: clsx(input, stringify({ link: [link] })),
>          page: 0,
>        })),
> -    [updateQuery]
> +    [updateQuery, input]
>    );
>    const onKeywordClick: (keyword: KeywordSchema) => void = useCallback(
>      (keyword) =>
>        updateQuery((query) => ({
>          ...query,
> -        q: clsx(query.q, stringify({ keyword: [keyword.name] })),
> +        q: clsx(input, stringify({ keyword: [keyword.name] })),
>          page: 0,
>        })),
> -    [updateQuery]
> +    [updateQuery, input]
>    );
> ```
> 
> _Originally posted by @knokmki612 in https://github.com/npocccties/chibichilo/pull/611#discussion_r764508362_