### PR TITLE
fix: 意図しないネガティブマージンの適用

### DIFF
--- a/components/atoms/Markdown.tsx
+++ b/components/atoms/Markdown.tsx
@@ -3,6 +3,7 @@ import type { NormalComponents } from "react-markdown/lib/complex-types";
 import gfm from "remark-gfm";
 import breaks from "remark-breaks";
 import Link from "@mui/material/Link";
+import { css } from "@emotion/css";
 
 // NOTE: 型に差異があるので変換
 const MarkdownLink: NormalComponents["a"] = ({
@@ -24,11 +25,24 @@ const components = {
   a: MarkdownLink,
 } as const;
 
+const root = css({
+  "> :first-child": {
+    marginTop: 0,
+  },
+  "> :last-child": {
+    marginBottom: 0,
+  },
+});
+
 type Props = Pick<Parameters<typeof ReactMarkdown>[0], "children">;
 
 export default function Markdown({ children }: Props) {
   return (
-    <ReactMarkdown remarkPlugins={[gfm, breaks]} components={components}>
+    <ReactMarkdown
+      className={root}
+      remarkPlugins={[gfm, breaks]}
+      components={components}
+    >
       {children}
     </ReactMarkdown>
   );

--- a/components/organisms/BookInfo.tsx
+++ b/components/organisms/BookInfo.tsx
@@ -20,6 +20,7 @@ export default function BookInfo({ className, id, book }: Props) {
     <Card className={className} classes={cardClasses} id={id}>
       <DescriptionList
         color={grey[900]}
+        sx={{ mb: 0.5 }}
         value={[
           {
             key: "学習時間",

--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -112,15 +112,7 @@ export default function TopicViewerContent({ topic, onEnded, offset }: Props) {
           ...authors(topic),
         ]}
       />
-      <Box
-        component="article"
-        sx={{
-          "> :first-child": {
-            mt: 0,
-          },
-          "> :last-child": { mb: 0 },
-        }}
-      >
+      <Box component="article">
         <Markdown>{topic.description}</Markdown>
       </Box>
     </>

--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -114,7 +114,12 @@ export default function TopicViewerContent({ topic, onEnded, offset }: Props) {
       />
       <Box
         component="article"
-        sx={{ "> :first-child, > :last-child": { my: 0 } }}
+        sx={{
+          "> :first-child": {
+            mt: 0,
+          },
+          "> :last-child": { mb: 0 },
+        }}
       >
         <Markdown>{topic.description}</Markdown>
       </Box>

--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -2,7 +2,6 @@ import clsx from "clsx";
 import type { TopicSchema } from "$server/models/topic";
 import Typography from "@mui/material/Typography";
 import Chip from "@mui/material/Chip";
-import Box from "@mui/material/Box";
 import { useTheme } from "@mui/material/styles";
 import Video from "$organisms/Video";
 import VideoPlayer from "$organisms/Video/VideoPlayer";
@@ -112,9 +111,9 @@ export default function TopicViewerContent({ topic, onEnded, offset }: Props) {
           ...authors(topic),
         ]}
       />
-      <Box component="article">
+      <article>
         <Markdown>{topic.description}</Markdown>
-      </Box>
+      </article>
     </>
   );
 }

--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -112,7 +112,7 @@ export default function TopicViewerContent({ topic, onEnded, offset }: Props) {
           ...authors(topic),
         ]}
       />
-      <Box component="article" sx={{ my: -1.5 }}>
+      <Box component="article" sx={{ ":not(:empty)": { my: -1.5 } }}>
         <Markdown>{topic.description}</Markdown>
       </Box>
     </>

--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -112,7 +112,10 @@ export default function TopicViewerContent({ topic, onEnded, offset }: Props) {
           ...authors(topic),
         ]}
       />
-      <Box component="article" sx={{ ":not(:empty)": { my: -1.5 } }}>
+      <Box
+        component="article"
+        sx={{ "> :first-child, > :last-child": { my: 0 } }}
+      >
         <Markdown>{topic.description}</Markdown>
       </Box>
     </>


### PR DESCRIPTION
解説が空の場合にもネガティブマージンが適用されており
必要以上に縦幅が縮められている

変更前
![image](https://user-images.githubusercontent.com/9744580/145942492-9332c025-623b-4d17-8387-938fba0d5e5a.png)

変更後
![image](https://user-images.githubusercontent.com/9744580/145942452-de91085e-ed66-4a05-9dda-ffd7715f41e0.png)

