### PR TITLE
fix: 画面遷移直後も視聴したブックが保持されている

### DIFF
--- a/components/organisms/BookPreviewDialog.tsx
+++ b/components/organisms/BookPreviewDialog.tsx
@@ -59,7 +59,7 @@ export default function BookPreviewDialog(props: Props) {
   const { session } = useSessionAtom();
   useEffect(() => {
     updateBook(book);
-    return updateBook(undefined);
+    return () => updateBook(undefined);
   }, [book, updateBook]);
   return (
     <Dialog

--- a/components/organisms/BookPreviewDialog.tsx
+++ b/components/organisms/BookPreviewDialog.tsx
@@ -59,6 +59,7 @@ export default function BookPreviewDialog(props: Props) {
   const { session } = useSessionAtom();
   useEffect(() => {
     updateBook(book);
+    return updateBook(undefined);
   }, [book, updateBook]);
   return (
     <Dialog

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -31,6 +31,7 @@ function Show(query: Query) {
     useBookAtom();
   useEffect(() => {
     if (book) updateBook(book);
+    return updateBook(undefined);
   }, [book, updateBook]);
   useActivityTracking();
   const { video } = useVideoAtom();

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -31,7 +31,7 @@ function Show(query: Query) {
     useBookAtom();
   useEffect(() => {
     if (book) updateBook(book);
-    return updateBook(undefined);
+    return () => updateBook(undefined);
   }, [book, updateBook]);
   useActivityTracking();
   const { video } = useVideoAtom();

--- a/store/book.ts
+++ b/store/book.ts
@@ -28,14 +28,14 @@ const nextItemIndexAtom = atom((get) => {
   return itemIndex;
 });
 
-const updateBookAtom = atom<undefined, BookSchema>(
+const updateBookAtom = atom<undefined, BookState["book"]>(
   () => undefined,
   (_, set, book) => {
     set(bookAtom, {
       book,
       itemIndex: [0, 0],
       itemExists: ([sectionIndex, topicIndex]) =>
-        book.sections[sectionIndex]?.topics[topicIndex],
+        book?.sections[sectionIndex]?.topics[topicIndex],
     });
   }
 );


### PR DESCRIPTION
関連: #553 

コンポーネントがアンマウントされるとき明示的にブックを破棄することで対処

確認したこと

- ブック視聴画面からの遷移でトピックプレビューが表示されること
    1. http://localhost:3000/book?bookId=1 にアクセスし再読み込みする
    2. http://localhost:3000/topics に遷移しスクロールせずブック1に含まれないトピックをクリックする
- ブック一覧画面からの遷移でトピックプレビューが表示されること
    1. http://localhost:3000/books にアクセスし再読み込みする
    2. ブック1をクリックし表示する
    3. http://localhost:3000/topics に遷移しスクロールせずブック1に含まれないトピックをクリックする
