### PR TITLE
fix: 特定のケースでトピックプレビューが表示されない問題の修正 事前読み込みされる動画の除去プロセスの修正

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -43,11 +43,9 @@ export default function Video({ className, sx, resource, onEnded }: Props) {
   const { book, itemIndex, itemExists } = useBookAtom();
   const prevItemIndex = usePrevious(itemIndex);
   useEffect(() => {
-    if (!book) {
-      video.clear();
-      return;
-    }
+    if (!book) return;
     updateVideo(book.sections);
+    return () => video.clear();
   }, [book, video, updateVideo]);
   useEffect(() => {
     if (prevItemIndex?.some((v, i) => v !== itemIndex[i])) {


### PR DESCRIPTION
関連: #553
確認したこと:
手元の開発用サーバーにて報告のあった手順で問題が再現しないことを確認
