### PR TITLE
perf: 検索時のリクエストの遅延の解消

### DIFF
--- a/utils/useContents.ts
+++ b/utils/useContents.ts
@@ -1,5 +1,4 @@
 import useSWR, { mutate } from "swr";
-import { useDebounce } from "use-debounce";
 import type {
   ApiV2SearchGetFilterEnum,
   ApiV2SearchGetSortEnum,
@@ -13,9 +12,6 @@ import { revalidateBook } from "./book";
 import { revalidateTopic } from "./topic";
 
 const key = "/api/v2/search";
-
-/** リクエストを間引くための間隔 (ms) */
-const wait = 500;
 
 async function fetchContents(
   _: typeof key,
@@ -62,11 +58,8 @@ function useContents({
   perPage: number;
   page: number;
 }) {
-  const [debouncedQuery] = useDebounce(q, wait);
   const { data, isValidating } = useSWR(
-    type === "none"
-      ? null
-      : [key, type, debouncedQuery, filter, sort, perPage, page],
+    type === "none" ? null : [key, type, q, filter, sort, perPage, page],
     fetchContents
   );
   const totalCount = data?.totalCount ?? 0;


### PR DESCRIPTION
検索のための操作後リクエストを間引くために遅延させていましたが、更新頻度の高い入力操作は input として分離され、リクエストを間引く重要性が低くなったため、その遅延処理を取り除きました。
