### PR TITLE
chore(eslint): --cacheオプションの無効化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
           cache: yarn
       - name: install
         run: yarn
-      - uses: actions/cache@v2
-        with:
-          path: .eslintcache
-          key: "${{ runner.os }}-eslint"
       - name: lint
         run: yarn lint:fix:report
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "vercel-build": "run-s compile build:static build:server && rm -rf public/api/v2/swagger && mkdir -p public/api/v2/swagger && cp -a server/dist/static public/api/v2/swagger/static",
     "format": "prettier --write .",
     "lint": "run-s compile 'lint:eslint {@}' --",
-    "lint:eslint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
+    "lint:eslint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
     "lint:fix:report": "yarn lint:fix --output-file eslint_report.json --format json",
     "storybook": "start-storybook -s ./public"


### PR DESCRIPTION
関連: #539 

> > `/.eslintcache` を消すとエラーが表示されました。やはり(私の環境では)キャッシュ周りでリントをすり抜けたりあやまったエラーの検知がなされたりしている気がします
> 
> パフォーマンスとのトレードオフなのでそのあたりの問題は仕方ないという気もしますが、ESlintのキャッシュの構造としてもおそらくタイムスタンプとサイズのメタデータを管理しているだけの単純なものなので確かに脆弱すぎるかもしれないですね。yarnとyarn.lockに比べればeslintのパフォーマンスの影響は比較的小さいので--cache をデフォルトに含めずとも私はよいと思います。

CI上は適切にLint結果を返せているように思うので、ひとまずはアドホックに自分の環境で怪しく感じたらキャッシュを消すことでお茶を濁そうかなと思いました

_Originally posted by @knokmki612 in https://github.com/npocccties/chibichilo-qleap/issues/91#issuecomment-970084628_

`--cache-strategy (metadata|content)` のいずれにしても
依存しているファイルに変更があるが自身に変更がないファイルは
リントされてほしいにもかかわらずがスキップされるという問題があるため