### PR TITLE
fix: 「ライセンス:未設定」が機能しない問題の修正

### DIFF
--- a/server/utils/search/parser.test.ts
+++ b/server/utils/search/parser.test.ts
@@ -1,5 +1,16 @@
 import { parse, stringify } from "./parser";
 
+const emptyQuery = {
+  text: [],
+  name: [],
+  description: [],
+  author: [],
+  keyword: [],
+  license: [],
+  shared: [],
+  link: [],
+};
+
 describe("parse()", function () {
   test("検索クエリー文字列をパースできる", function () {
     expect(
@@ -16,6 +27,14 @@ describe("parse()", function () {
       shared: [true],
       link: [{ consumerId: "hoge", contextId: "piyo" }],
     });
+  });
+
+  test("`license:none` は空文字列が得られる", function () {
+    expect(parse(`license:none`).license).toEqual([""]);
+  });
+
+  test("`license:` の無効値の場合は何も得られない", function () {
+    expect(parse("license:")).toEqual(emptyQuery);
   });
 
   test("`link:` 以降にいくつかキーワードが含まれる文字列をパースできる", function () {
@@ -36,43 +55,36 @@ describe("parse()", function () {
   });
 
   test("`link:` キーワードに区切り文字 `:` が含まない無効値の場合は何も得られない", function () {
-    expect(parse("link:foo")).toEqual({
-      text: [],
-      name: [],
-      description: [],
-      author: [],
-      keyword: [],
-      license: [],
-      shared: [],
-      link: [],
-    });
+    expect(parse("link:foo")).toEqual(emptyQuery);
   });
 });
 
 describe("stringify()", function () {
   test("検索クエリー文字列に変換", () => {
     const query = {
+      ...emptyQuery,
       text: ["a", "b"],
-      name: [],
-      description: [],
-      author: [],
       keyword: ["foo", "bar"],
-      license: [],
-      shared: [],
-      link: [],
     };
     expect(stringify(query)).toBe("a b keyword:foo,bar");
   });
 
+  test("空の検索クエリーは空文字列に変換", () => {
+    const query = emptyQuery;
+    expect(stringify(query)).toBe("");
+  });
+
+  test("ライセンス:未設定の検索クエリー文字列に変換", () => {
+    const query = {
+      ...emptyQuery,
+      license: [""],
+    };
+    expect(stringify(query)).toBe("license:none");
+  });
+
   test("LTI Contextを検索クエリー文字列に変換", () => {
     const query = {
-      text: [],
-      name: [],
-      description: [],
-      author: [],
-      keyword: [],
-      license: [],
-      shared: [],
+      ...emptyQuery,
       link: [{ consumerId: "foo", contextId: "bar" }],
     };
     expect(stringify(query)).toBe("link:foo:bar");
@@ -80,13 +92,7 @@ describe("stringify()", function () {
 
   test("いくつかのLTI Contextを検索クエリー文字列に変換", () => {
     const query = {
-      text: [],
-      name: [],
-      description: [],
-      author: [],
-      keyword: [],
-      license: [],
-      shared: [],
+      ...emptyQuery,
       link: [
         { consumerId: "foo", contextId: "bar" },
         { consumerId: "hoge", contextId: "piyo" },
@@ -97,13 +103,7 @@ describe("stringify()", function () {
 
   test("`:` や `,` や空白が含まれるLTI Contextを検索クエリー文字列に変換", () => {
     const query = {
-      text: [],
-      name: [],
-      description: [],
-      author: [],
-      keyword: [],
-      license: [],
-      shared: [],
+      ...emptyQuery,
       link: [{ consumerId: "te:s,t", contextId: "fo o" }],
     };
     expect(stringify(query)).toBe("link:te%3As%2Ct:fo%20o");
@@ -111,14 +111,8 @@ describe("stringify()", function () {
 
   test("共有可否を検索クエリー文字列に変換", () => {
     const query = {
-      text: [],
-      name: [],
-      description: [],
-      author: [],
-      keyword: [],
-      license: [],
+      ...emptyQuery,
       shared: [true],
-      link: [],
     };
     expect(stringify(query)).toBe("shared:true");
   });

--- a/server/utils/search/parser.ts
+++ b/server/utils/search/parser.ts
@@ -37,6 +37,20 @@ function parseBoolean(input: string): boolean[] {
 }
 
 /**
+ * 検索クエリー文字列 `license:` キーワードのパース
+ * @param input `license:` 以降の文字列
+ * @return 一致するライセンス
+ */
+function parseLicense(input: string): string[] {
+  switch (input) {
+    case "none":
+      return [""];
+    default:
+      return [input];
+  }
+}
+
+/**
  * 検索クエリー文字列 `link:` キーワードのパース
  * @param input `link:` 以降の文字列
  * @return LtiResourceLink に関する情報
@@ -58,10 +72,24 @@ export function parse(query: string): SearchQueryBase {
     description: res.description ?? [],
     author: res.author ?? [],
     keyword: res.keyword ?? [],
-    license: res.license ?? [],
+    license: res.license?.flatMap(parseLicense) ?? [],
     shared: res.shared?.flatMap(parseBoolean) ?? [],
     link: res.link?.flatMap(parseLink) ?? [],
   };
+}
+
+/**
+ * ライセンスを検索クエリー文字列に変換
+ * @param license ライセンス
+ * @return 検索クエリー文字列
+ */
+function stringifyLicense(license: string): string {
+  switch (license) {
+    case "":
+      return "none";
+    default:
+      return license;
+  }
 }
 
 /**
@@ -79,8 +107,9 @@ function stringifyLink(
 }
 
 export function stringify(query: SearchQueryBase): string {
-  const { shared, link, ...rest } = query;
+  const { license, shared, link, ...rest } = query;
   const token = {
+    license: license.map(stringifyLicense).join(),
     shared: shared.map(String).join(),
     link: link.map(stringifyLink).join(),
   };

--- a/store/search.ts
+++ b/store/search.ts
@@ -116,7 +116,6 @@ export function useSearchAtom() {
       const values = {
         [filter]: [filter],
         all: [],
-        none: [""],
       };
       updateSearchQuery((searchQuery) => ({
         ...searchQuery,


### PR DESCRIPTION
関連: https://github.com/npocccties/chibichilo/issues/628

> ﻿「ライセンス：未設定」の場合，設定済みのトピックも表示されてしまいます．

この問題の修正です。

原因: `license:` の場合 search-query-parser のパース結果のオブジェクトのプロパティが追加されず、誤ってライセンスの指定のためのクエリー文字列が含まれないものとして解釈されていた
対処: `license:` は無効値なので使わず、代わりに `license:none` を使う