### PR TITLE
feat(ContentPrevie): ライセンスの表示

### DIFF
--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -12,6 +12,7 @@ import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
 import EditButton from "$atoms/EditButton";
 import DescriptionList from "$atoms/DescriptionList";
+import License from "$atoms/License";
 import SharedIndicator from "$atoms/SharedIndicator";
 import CourseChip from "$atoms/CourseChip";
 import LinkSwitch from "$atoms/LinkSwitch";
@@ -207,6 +208,14 @@ export default function ContentPreview({
             value: getLocaleDateString(content.updatedAt, "ja"),
           },
           ...authors(content),
+          ...(content.license
+            ? [
+                {
+                  key: "ライセンス",
+                  value: <License license={content.license} />,
+                },
+              ]
+            : []),
           ...(content.type === "book" && content.ltiResourceLinks.length > 0
             ? [
                 {

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -10,6 +10,7 @@ import CardMedia from "@mui/material/CardMedia";
 import Checkbox from "@mui/material/Checkbox";
 import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
+import { grey } from "@mui/material/colors";
 import EditButton from "$atoms/EditButton";
 import DescriptionList from "$atoms/DescriptionList";
 import License from "$atoms/License";
@@ -19,7 +20,7 @@ import LinkSwitch from "$atoms/LinkSwitch";
 import type { ContentSchema } from "$server/models/content";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 import type { KeywordSchema } from "$server/models/keyword";
-import { primary, gray } from "$theme/colors";
+import { primary } from "$theme/colors";
 import useLineClampStyles from "$styles/lineClamp";
 import { getSectionsOutline } from "$utils/outline";
 import getLocaleDateString from "$utils/getLocaleDateString";
@@ -87,12 +88,12 @@ const Header = styled(
 }));
 
 const Description = styled("p")({
-  color: gray[700],
+  color: grey[700],
   margin: 0,
 });
 
 const Preview = styled(Card)(({ theme }) => ({
-  border: `1px solid ${gray[400]}`,
+  border: `1px solid ${grey[300]}`,
   borderRadius: 12,
   boxShadow: "none",
   ".shared": {

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -199,6 +199,8 @@ export default function ContentPreview({
           <License
             sx={{
               position: "absolute",
+              px: 2,
+              py: 1,
               bottom: 0,
               right: 0,
             }}

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -86,10 +86,6 @@ const Header = styled(
   },
 }));
 
-const LinkArea = styled("div")({
-  position: "relative",
-});
-
 const Description = styled("p")({
   color: gray[700],
   margin: 0,
@@ -185,8 +181,8 @@ export default function ContentPreview({
           alt="サムネイル"
         />
       </CardActionArea>
-      {linked !== undefined && onContentLinkClick && (
-        <LinkArea>
+      <Box position="relative">
+        {linked !== undefined && onContentLinkClick && (
           <LinkSwitch
             sx={{
               position: "absolute",
@@ -197,8 +193,18 @@ export default function ContentPreview({
             checked={linked}
             onChange={handleContentLinkClick}
           />
-        </LinkArea>
-      )}
+        )}
+        {content.license && (
+          <License
+            sx={{
+              position: "absolute",
+              bottom: 0,
+              right: 0,
+            }}
+            license={content.license}
+          />
+        )}
+      </Box>
       <DescriptionList
         nowrap
         sx={{ mx: 2, my: 1 }}
@@ -208,14 +214,6 @@ export default function ContentPreview({
             value: getLocaleDateString(content.updatedAt, "ja"),
           },
           ...authors(content),
-          ...(content.license
-            ? [
-                {
-                  key: "ライセンス",
-                  value: <License license={content.license} />,
-                },
-              ]
-            : []),
           ...(content.type === "book" && content.ltiResourceLinks.length > 0
             ? [
                 {


### PR DESCRIPTION
関連 #627

表示例

![image](https://user-images.githubusercontent.com/9744580/150075538-6a3b539b-6140-4f64-961a-caa887a5b30d.png)

疑問

ライセンスをクリックするとライセンスの要約文のページが開かれるが、クリックしたらクリックしたライセンスで絞り込まれる挙動に変更すべきかどうか