### PR TITLE
feat:(Search): 折りたたみは不要

### DIFF
--- a/components/organisms/Search.tsx
+++ b/components/organisms/Search.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
@@ -26,8 +26,6 @@ export default function Search({
   onSearchTargetChange,
   ...other
 }: Props) {
-  const [expanded, setExpanded] = useState(false);
-  const handleClick = () => setExpanded(!expanded);
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       onSearchTargetChange(event.target.value as SearchTarget);

--- a/components/organisms/Search.tsx
+++ b/components/organisms/Search.tsx
@@ -1,11 +1,8 @@
 import { useState, useCallback } from "react";
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import SearchTextField from "$atoms/SearchTextField";
-import CollapsibleContent from "$organisms/CollapsibleContent";
 import type { SearchTarget } from "$types/searchTarget";
 
 const options: ReadonlyArray<{
@@ -39,30 +36,17 @@ export default function Search({
   );
   return (
     <div>
-      <Box display="flex" alignItems="center" gap={0.5}>
-        <SearchTextField {...other} />
-        <Button
-          variant="text"
-          size="small"
-          aria-expanded={expanded}
-          aria-controls="search-type"
-          onClick={handleClick}
-        >
-          検索対象
-        </Button>
-      </Box>
-      <CollapsibleContent expanded={expanded}>
-        <RadioGroup id="search-type" value={target} onChange={handleChange} row>
-          {options.map(({ value, label }) => (
-            <FormControlLabel
-              key={value}
-              value={value}
-              control={<Radio color="primary" size="small" />}
-              label={label}
-            />
-          ))}
-        </RadioGroup>
-      </CollapsibleContent>
+      <SearchTextField {...other} />
+      <RadioGroup id="search-type" value={target} onChange={handleChange} row>
+        {options.map(({ value, label }) => (
+          <FormControlLabel
+            key={value}
+            value={value}
+            control={<Radio color="primary" size="small" />}
+            label={label}
+          />
+        ))}
+      </RadioGroup>
     </div>
   );
 }


### PR DESCRIPTION
関連: #602

折りたたまれている情報を展開するためのボタンを認識するコスト
折りたたまれている機能にアクセスするための効率性

という観点から取り除くことによる改善が期待される

![image](https://user-images.githubusercontent.com/9744580/150711431-1d22fe7a-3de2-4590-b3cb-4a27088e9ac0.png)
