### PR TITLE
fix: コンソールにMUI: the styled("img")(...args) API requires...が表示される

### DIFF
--- a/components/atoms/License.tsx
+++ b/components/atoms/License.tsx
@@ -10,7 +10,7 @@ const Text = styled("span")({
   fontSize: 12,
 });
 
-const Image = styled("img")();
+const Image = styled("img")({});
 
 type Props = {
   license: ContentSchema["license"];


### PR DESCRIPTION
styledに対して必要な引数を渡していないことが原因