### PR TITLE
fix: コース名やキーワードが長いとはみ出る箇所がある, etc.

### DIFF
--- a/components/atoms/CourseChip.tsx
+++ b/components/atoms/CourseChip.tsx
@@ -2,15 +2,13 @@ import type { MouseEvent } from "react";
 import { useCallback, useState } from "react";
 import type { SxProps } from "@mui/system";
 import Chip from "@mui/material/Chip";
-import Popover from "@mui/material/Popover";
-import makeStyles from "@mui/styles/makeStyles";
+import { styled } from "@mui/material/styles";
+import MuiPopover, { popoverClasses } from "@mui/material/Popover";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 
-const useStyles = makeStyles((theme) => ({
-  popover: {
-    pointerEvents: "none",
-  },
-  paper: {
+const Popover = styled(MuiPopover)(({ theme }) => ({
+  pointerEvents: "none",
+  [`.${popoverClasses.paper}`]: {
     padding: theme.spacing(1),
     marginTop: theme.spacing(1),
   },
@@ -29,7 +27,6 @@ export default function CourseChip({
   sx,
   onDelete,
 }: Props) {
-  const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
   const handlePopoverOpen = useCallback(
@@ -64,8 +61,6 @@ export default function CourseChip({
         onMouseLeave={handlePopoverClose}
       />
       <Popover
-        className={classes.popover}
-        classes={{ paper: classes.paper }}
         open={open}
         onClose={handlePopoverClose}
         anchorEl={anchorEl}

--- a/components/atoms/CourseChip.tsx
+++ b/components/atoms/CourseChip.tsx
@@ -1,10 +1,14 @@
 import type { MouseEvent } from "react";
 import { useCallback, useState } from "react";
 import type { SxProps } from "@mui/system";
-import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
+import MuiChip from "@mui/material/Chip";
 import MuiPopover, { popoverClasses } from "@mui/material/Popover";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
+
+const Chip = styled(MuiChip)({
+  maxWidth: "100%",
+});
 
 const Popover = styled(MuiPopover)(({ theme }) => ({
   pointerEvents: "none",

--- a/components/atoms/KeywordChip.stories.tsx
+++ b/components/atoms/KeywordChip.stories.tsx
@@ -1,0 +1,14 @@
+import type { Story } from "@storybook/react";
+import KeywordChip from "./KeywordChip";
+
+export default { title: "atoms/KeywordChip", component: KeywordChip };
+
+const Template: Story<Parameters<typeof KeywordChip>[0]> = (args) => (
+  <KeywordChip {...args} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = {
+  keyword: { name: "キーワード" },
+};

--- a/components/atoms/KeywordChip.tsx
+++ b/components/atoms/KeywordChip.tsx
@@ -1,0 +1,35 @@
+import { styled } from "@mui/material/styles";
+import MuiChip from "@mui/material/Chip";
+import type { SxProps } from "@mui/system";
+import type { KeywordPropSchema } from "$server/models/keyword";
+
+type Props = {
+  keyword: KeywordPropSchema;
+  onKeywordClick?(keyword: KeywordPropSchema): void;
+  sx?: SxProps;
+  onDelete?: () => void;
+};
+
+const Chip = styled(MuiChip)({
+  borderRadius: 4,
+});
+
+export default function KeywordChip({
+  keyword,
+  onKeywordClick,
+  sx,
+  onDelete,
+}: Props) {
+  const handleClick = () => onKeywordClick?.(keyword);
+  return (
+    <Chip
+      sx={sx}
+      variant="outlined"
+      size="small"
+      color="primary"
+      label={keyword.name}
+      onClick={onKeywordClick && handleClick}
+      onDelete={onDelete}
+    />
+  );
+}

--- a/components/atoms/KeywordChip.tsx
+++ b/components/atoms/KeywordChip.tsx
@@ -12,6 +12,7 @@ type Props = {
 
 const Chip = styled(MuiChip)({
   borderRadius: 4,
+  maxWidth: "100%",
 });
 
 export default function KeywordChip({

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -8,7 +8,6 @@ import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import CardMedia from "@mui/material/CardMedia";
 import Checkbox from "@mui/material/Checkbox";
-import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
 import { grey } from "@mui/material/colors";
 import EditButton from "$atoms/EditButton";
@@ -16,6 +15,7 @@ import DescriptionList from "$atoms/DescriptionList";
 import License from "$atoms/License";
 import SharedIndicator from "$atoms/SharedIndicator";
 import CourseChip from "$atoms/CourseChip";
+import KeywordChip from "$atoms/KeywordChip";
 import LinkSwitch from "$atoms/LinkSwitch";
 import type { ContentSchema } from "$server/models/content";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
@@ -149,8 +149,6 @@ export default function ContentPreview({
       : content.sections[0]?.topics[0]?.resource.id
   );
   const handleContentLinkClick = () => onContentLinkClick?.(content);
-  const handleKeywordClick = (keyword: Pick<KeywordSchema, "name">) => () =>
-    onKeywordClick(keyword);
   return (
     <Preview className={clsx({ selected: checked })}>
       <Header
@@ -240,15 +238,11 @@ export default function ContentPreview({
       />
       <Box sx={{ mx: 2, my: 1 }}>
         {content.keywords.map((keyword) => (
-          <Chip
+          <KeywordChip
             key={keyword.id}
-            onClick={handleKeywordClick(keyword)}
-            clickable
-            variant="outlined"
-            color="primary"
-            label={keyword.name}
-            size="small"
-            sx={{ mr: 0.5, borderRadius: 1 }}
+            keyword={keyword}
+            onKeywordClick={onKeywordClick}
+            sx={{ mr: 0.5 }}
           />
         ))}
       </Box>

--- a/components/organisms/FilterColumn.tsx
+++ b/components/organisms/FilterColumn.tsx
@@ -1,6 +1,5 @@
 import type { SxProps } from "@mui/system";
 import Box from "@mui/material/Box";
-import Chip from "@mui/material/Chip";
 import FormLabel from "@mui/material/FormLabel";
 import FormControl from "@mui/material/FormControl";
 import MenuItem from "@mui/material/MenuItem";
@@ -8,6 +7,7 @@ import Typography from "@mui/material/Typography";
 import AuthorFilter from "$atoms/AuthorFilter";
 import SharedFilter from "$atoms/SharedFilter";
 import CourseChip from "$atoms/CourseChip";
+import KeywordChip from "$atoms/KeywordChip";
 import TextField from "$atoms/TextField";
 import licenses from "$utils/licenses";
 import { useSearchAtom } from "$store/search";
@@ -89,13 +89,10 @@ export default function FilterColumn({ sx, variant }: Props) {
           <Typography>なし</Typography>
         )}
         {searchQuery.keyword?.map((keyword) => (
-          <Chip
+          <KeywordChip
             key={keyword}
-            variant="outlined"
-            color="primary"
-            label={keyword}
-            size="small"
-            sx={{ mr: 0.5, borderRadius: 1 }}
+            keyword={{ name: keyword }}
+            sx={{ mr: 0.5 }}
             onDelete={() => onKeywordDelete(keyword)}
           />
         ))}

--- a/components/organisms/KeywordsInput.tsx
+++ b/components/organisms/KeywordsInput.tsx
@@ -2,10 +2,10 @@ import { styled } from "@mui/material/styles";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
-import Chip from "@mui/material/Chip";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
 import InputAdornment from "@mui/material/InputAdornment";
+import KeywordChip from "$atoms/KeywordChip";
 import IconButton from "$atoms/IconButton";
 import Input from "$atoms/Input";
 import InputLabel from "$atoms/InputLabel";
@@ -60,13 +60,10 @@ export default function KeywordsInput({
       </InputLabel>
       <Keywords>
         {keywords.map((keyword) => (
-          <Chip
+          <KeywordChip
             key={keyword.name}
-            variant="outlined"
-            color="primary"
-            label={keyword.name}
-            size="small"
-            sx={{ mr: 0.5, borderRadius: 1 }}
+            keyword={keyword}
+            sx={{ mr: 0.5 }}
             onDelete={handleKeywordRemove(keyword)}
           />
         ))}


### PR DESCRIPTION
関連: #629

- refactor: KeywordChipとして外部化
- refactor(CourseChip): styledへの移行
- fix: コース名やキーワードが長いとはみ出る箇所がある

before
![image](https://user-images.githubusercontent.com/8957521/146323298-aaedd0ea-aa7a-47fe-98f6-4bd01e7ca378.png)

![image](https://user-images.githubusercontent.com/9005132/150906745-4b8f0d8d-eb6b-4063-9538-1b75a18f4699.png)

after
![image](https://user-images.githubusercontent.com/9744580/151732430-b5c40565-222f-41f2-b66b-1b34b500a1bc.png)

![image](https://user-images.githubusercontent.com/9744580/151732843-877b2c33-7bbd-4146-959f-efbf9e8ac6da.png)

