### PR TITLE
feat: 文言統一「リンク」→「コース」

### DIFF
--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -217,7 +217,7 @@ export default function ContentPreview({
           ...(content.type === "book" && content.ltiResourceLinks.length > 0
             ? [
                 {
-                  key: "リンク",
+                  key: "コース",
                   value: (
                     <Fragment>
                       {content.ltiResourceLinks.map(


### PR DESCRIPTION
関連: #647

例
![image](https://user-images.githubusercontent.com/9744580/151741596-a981cf96-74da-4051-b0c9-e43832842274.png)