### PR TITLE
feat: コンテンツごとの提供中のコースが省略されず表示されるように

### DIFF
--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from "react";
 import clsx from "clsx";
 import Markdown from "react-markdown";
 import gfm from "remark-gfm";
@@ -207,35 +206,42 @@ export default function ContentPreview({
       </Box>
       <DescriptionList
         nowrap
-        sx={{ mx: 2, my: 1 }}
+        sx={{ mx: 2, mt: 1 }}
         value={[
           {
             key: "更新日",
             value: getLocaleDateString(content.updatedAt, "ja"),
           },
           ...authors(content),
-          ...(content.type === "book" && content.ltiResourceLinks.length > 0
-            ? [
-                {
-                  key: "コース",
-                  value: (
-                    <Fragment>
-                      {content.ltiResourceLinks.map(
-                        (ltiResourceLink, index) => (
-                          <CourseChip
-                            key={index}
-                            ltiResourceLink={ltiResourceLink}
-                            onLtiResourceLinkClick={onLtiContextClick}
-                          />
-                        )
-                      )}
-                    </Fragment>
-                  ),
-                },
-              ]
-            : []),
         ]}
       />
+      {content.type === "book" && content.ltiResourceLinks.length > 0 && (
+        <DescriptionList
+          sx={{
+            mx: 2,
+            mb: 1,
+            dt: { flexShrink: 0 },
+            dd: { overflow: "hidden" },
+          }}
+          value={[
+            {
+              key: "コース",
+              value: (
+                <>
+                  {content.ltiResourceLinks.map((ltiResourceLink, index) => (
+                    <CourseChip
+                      sx={{ mr: 0.5, my: 0.125 }}
+                      key={index}
+                      ltiResourceLink={ltiResourceLink}
+                      onLtiResourceLinkClick={onLtiContextClick}
+                    />
+                  ))}
+                </>
+              ),
+            },
+          ]}
+        />
+      )}
       <Box sx={{ mx: 2, my: 1 }}>
         {content.keywords.map((keyword) => (
           <KeywordChip

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -220,6 +220,7 @@ export default function ContentPreview({
           sx={{
             mx: 2,
             mb: 1,
+            // TODO: 深い階層に対するスタイルの上書きが不要なコンポーネントの整理
             dt: { flexShrink: 0 },
             dd: { overflow: "hidden" },
           }}


### PR DESCRIPTION
現状だと提供中のコースが表示領域に収まらなければ省略されアクセス不可能となる。
省略せず折り返して表示することですべての提供されているコースに対してアクセス可能にする変更

変更前
![image](https://user-images.githubusercontent.com/9744580/151751341-e7a4d208-bd81-41c7-80f8-9f39df78f3c4.png)

変更後
![image](https://user-images.githubusercontent.com/9744580/151751284-49d88447-7cc7-44f2-b894-12657210ea4a.png)
