### PR TITLE
feat: 一部のツールチップを非対話的な挙動にする

### DIFF
--- a/components/atoms/CourseChip.tsx
+++ b/components/atoms/CourseChip.tsx
@@ -32,7 +32,7 @@ export default function CourseChip({
   );
 
   return (
-    <Tooltip title={ltiResourceLink.contextTitle}>
+    <Tooltip title={ltiResourceLink.contextTitle} disableInteractive>
       <Chip
         sx={sx}
         aria-haspopup="true"

--- a/components/atoms/KeywordChip.tsx
+++ b/components/atoms/KeywordChip.tsx
@@ -24,7 +24,7 @@ export default function KeywordChip({
 }: Props) {
   const handleClick = () => onKeywordClick?.(keyword);
   return (
-    <Tooltip title={keyword.name}>
+    <Tooltip title={keyword.name} disableInteractive>
       <Chip
         sx={sx}
         variant="outlined"


### PR DESCRIPTION
たくさんのツールチップが含まれた表示系が並んでいると、
ツールチップに被った表示系への操作が阻害される。
操作を阻害させないための変更
一部WCAG AA基準をパスしないことになる点に留意

See: https://mui.com/components/tooltips/#interactive
See: https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus