### PR TITLE
fix: GitHub Markdown へのリファレンスのリンクが機能していない問題の修正

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -148,29 +148,26 @@ export default function BookForm({
       </TextField>
       <KeywordsInput {...keywordsInputProps} />
       <TextField
-        label={
-          <>
-            解説
-            <Typography
-              className={classes.labelDescription}
-              variant="caption"
-              component="span"
-            >
-              <Link
-                href="https://github.github.com/gfm/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                GitHub Flavored Markdown
-              </Link>
-              に一部準拠しています
-            </Typography>
-          </>
-        }
+        label="解説"
         fullWidth
         multiline
         inputProps={register("description")}
       />
+      <Typography
+        className={classes.labelDescription}
+        variant="caption"
+        component="span"
+      >
+        <Link
+          href="https://github.github.com/gfm/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub Flavored Markdown
+        </Link>
+        {` `}
+        に一部準拠しています
+      </Typography>
       <Divider className={classes.divider} />
       {!linked && (
         <div>

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -38,8 +38,8 @@ import useKeywordsInput from "$utils/useKeywordsInput";
 
 const useStyles = makeStyles((theme) => ({
   margin: {
-    "& > :not(:last-child)": {
-      marginBottom: theme.spacing(2.5),
+    "& > :not(:first-child)": {
+      marginTop: theme.spacing(2.5),
     },
   },
   labelDescription: {
@@ -273,29 +273,26 @@ export default function TopicForm(props: Props) {
           </Button>
         </div>
         <TextField
-          label={
-            <>
-              解説
-              <Typography
-                className={classes.labelDescription}
-                variant="caption"
-                component="span"
-              >
-                <Link
-                  href="https://github.github.com/gfm/"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  GitHub Flavored Markdown
-                </Link>
-                に一部準拠しています
-              </Typography>
-            </>
-          }
+          label="解説"
           fullWidth
           multiline
           inputProps={register("description")}
         />
+        <Typography
+          className={classes.labelDescription}
+          variant="caption"
+          component="span"
+        >
+          <Link
+            href="https://github.github.com/gfm/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            GitHub Flavored Markdown
+          </Link>
+          {` `}
+          に一部準拠しています
+        </Typography>
         <Divider className={classes.divider} />
         <Button variant="contained" color="primary" type="submit">
           {label[variant]}


### PR DESCRIPTION
関連: https://github.com/npocccties/chibichilo/issues/641

トピック・ブックのそれぞれ解説の入力欄のラベル中のリンクがクリックしても反応しないので、その構造と見た目の変更を行いました。

![image](https://user-images.githubusercontent.com/1730234/155464319-953cf1de-b67a-4474-9b3b-039f98846e3f.png)
