### PR TITLE
feat: 動画プレイヤーの再生速度の設定を引き継がせる

### DIFF
--- a/components/organisms/Video/VideoPlayer.tsx
+++ b/components/organisms/Video/VideoPlayer.tsx
@@ -3,6 +3,7 @@ import type { SxProps } from "@mui/system";
 import type { VideoInstance } from "$types/videoInstance";
 import Box from "@mui/material/Box";
 import useVolume from "$utils/useVolume";
+import { usePlaybackRate } from "$utils/playbackRate";
 import Vimeo from "./Vimeo";
 import VideoJs from "./VideoJs";
 import videoJsDurationChangeShims from "$utils/videoJsDurationChangeShims";
@@ -24,6 +25,7 @@ export default function VideoPlayer({
   ...other
 }: Props) {
   useVolume(videoInstance.player);
+  usePlaybackRate(videoInstance.player);
   useEffect(() => {
     const { player } = videoInstance;
     const handleEnded = () => onEnded?.();

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -1,6 +1,7 @@
 import type { EventType } from "$server/models/event";
 import { api } from "$utils/api";
 import type { PlayerEvent, PlayerEvents, PlayerTracker } from "./playerTracker";
+import { load as loadPlaybackRate } from "$utils/playbackRate";
 import { load } from "./loggerSessionPersister";
 import getFilePath from "./getFilePath";
 
@@ -73,7 +74,10 @@ function logger(tracker: PlayerTracker) {
   }
 
   tracker.on("playbackratechange", function (event) {
-    void send("ratechange", event, event.playbackRate.toString());
+    const persistentRate = loadPlaybackRate();
+    if (persistentRate !== event.playbackRate) {
+      void send("ratechange", event, event.playbackRate.toString());
+    }
   });
 
   tracker.on("nextvideo", function (event) {

--- a/utils/playbackRate.ts
+++ b/utils/playbackRate.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect } from "react";
+import useSWRImmutable from "swr/immutable";
+import type { VideoJsPlayer } from "video.js";
+import VimeoPlayer from "@vimeo/player";
+
+type Player = VideoJsPlayer | VimeoPlayer;
+
+/** 再生速度 */
+type PlaybackRate = number;
+
+/** VideoJsPlayer.readyState() 監視間隔 (ms) */
+const interval = 1_000;
+/** Storage に永続化するための識別子 */
+const key = "playbackRatePersister";
+/** デフォルト値 */
+const defaultValues: PlaybackRate = 1;
+
+/** Storage への再生速度の保存処理 */
+function save(data: PlaybackRate) {
+  localStorage.setItem(key, data.toString());
+}
+
+/** Storage からの再生速度の読み込み処理 */
+export function load(): PlaybackRate {
+  const data = localStorage.getItem(key);
+  if (data == null) return defaultValues;
+  return Number(data);
+}
+
+/** 動画プレイヤーへの再生速度の設定処理 */
+function setPlaybackRate(player: Player, data: PlaybackRate): void {
+  if (player instanceof VimeoPlayer) {
+    void player.setPlaybackRate(data);
+  } else {
+    player.playbackRate(data);
+  }
+}
+
+/** 動画プレイヤーからの再生速度の取得処理 */
+async function getPlaybackRate(player: Player): Promise<PlaybackRate> {
+  const data = await (player instanceof VimeoPlayer
+    ? player.getPlaybackRate()
+    : player.playbackRate());
+  return data;
+}
+
+/** 再生速度の設定の保存と反映のためのカスタムフック */
+export function usePlaybackRate(player: Player) {
+  const { data: ready } = useSWRImmutable<boolean>(
+    [key, player],
+    () =>
+      ready ||
+      player instanceof VimeoPlayer ||
+      // NOTE: videojs-youtube はバッファリングが行われるまで誤った値が得られうるため待機
+      player.readyState() === 4 /* HaveEnoughData */,
+    { refreshInterval: interval }
+  );
+  const { data, mutate } = useSWRImmutable<PlaybackRate>(key, load);
+  const onChange = useCallback(async () => {
+    save(await getPlaybackRate(player));
+    await mutate();
+  }, [player, mutate]);
+  useEffect(() => {
+    if (data) setPlaybackRate(player, data);
+  }, [player, data]);
+  useEffect(() => {
+    if (ready) player.on("ratechange", onChange);
+    return () => player.off("ratechange", onChange);
+  }, [player, ready, onChange]);
+}


### PR DESCRIPTION
ref #672

利用者によって手動で変更された場合と区別する目的で、再生速度がデフォルト値またはlocalStorageに記録されているものと一致しない場合は ratechange イベントが発報されないように変更しました。
この変更の副作用として、従来動画読み込み直後に発報されていた ratechange イベントについても発報されなくなりますので、確認してもらえればと思います。