### PR TITLE
fix: ブックやトピック削除時にキーワード削除は行わない

### DIFF
--- a/server/utils/book/destroyBook.ts
+++ b/server/utils/book/destroyBook.ts
@@ -10,7 +10,6 @@ async function destroyBook(id: Book["id"]) {
       prisma.authorship.deleteMany({ where: { bookId: id } }),
       prisma.publicBook.deleteMany({ where: { bookId: id } }),
       prisma.book.deleteMany({ where: { id } }),
-      prisma.keyword.deleteMany({ where: { books: { every: { id } } } }),
     ]);
   } catch {
     return;

--- a/server/utils/topic/destroyTopic.ts
+++ b/server/utils/topic/destroyTopic.ts
@@ -34,9 +34,6 @@ async function destroyTopic(id: Topic["id"]) {
       prisma.resource.deleteMany({
         where: { topics: { every: { id } } },
       }),
-      prisma.keyword.deleteMany({
-        where: { topics: { every: { id } } },
-      }),
     ]);
   } catch {
     return;


### PR DESCRIPTION
#767 #768 の対応．
この対応では，何にも紐付かないキーワードがDB内に残り続けることになるが，どうあるべきかは別途考える．