### PR TITLE
fix: 自動コミットに失敗する問題の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"


### PR DESCRIPTION
pull_request イベントで実行されるワークフローのときgit pushのタイミングでdetached HEADエラーになる。それを防ぐためのパッチです。
(7951be1b00c10bd4ae2a8562ffd88a5b71410b95 でエンバグ)

次のようなエラーが出ていた:

```
Run if git -c "user.name=bot" -c "user.email=bot@example" commit -am "bot: format"; then
[detached HEAD 539264a] bot: format
 2 files changed, 6 insertions(+), 2 deletions(-)
error: The destination you provided is not a full refname (i.e.,
starting with "refs/"). We tried to guess what you meant by:

- Looking for a ref that matches 'HEAD' on the remote side.
- Checking if the <src> being pushed ('HEAD')
  is a ref in "refs/{heads,tags}/". If so we add a corresponding
  refs/{heads,tags}/ prefix on the remote side.

Neither worked, so we gave up. You must fully qualify the ref.
hint: The <src> part of the refspec is a commit object.
hint: Did you mean to create a new branch by pushing to
hint: 'HEAD:refs/heads/HEAD'?
error: failed to push some refs to 'https://github.com/npocccties/chibichilo'
```

https://github.com/npocccties/chibichilo/actions/runs/3139849186/jobs/5100642961 より

確認した内容:

- 実際に https://github.com/npocccties/chibichilo/actions/runs/3140179960/jobs/5101317618 を実行して、エラー無くパスしたこと
- 551ca3f のコミットが問題なく行われること
