### PR TITLE
feat: トピック一覧のブックでの絞り込み

### DIFF
--- a/components/atoms/BookChip.stories.tsx
+++ b/components/atoms/BookChip.stories.tsx
@@ -1,0 +1,15 @@
+import type { Story } from "@storybook/react";
+import BookChip from "./BookChip";
+import { relatedBook } from "$samples";
+
+export default {
+  title: "atoms/BookChip",
+  component: BookChip,
+};
+
+const Template: Story<Parameters<typeof BookChip>[0]> = (args) => (
+  <BookChip {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = { relatedBook };

--- a/components/atoms/BookChip.tsx
+++ b/components/atoms/BookChip.tsx
@@ -12,23 +12,31 @@ const Chip = styled(MuiChip)({
 
 type Props = {
   relatedBook: RelatedBook;
-  onRelatedBookClick?(id: number): void;
+  onRelatedBookClick?: (relatedBook: RelatedBook) => void;
+  onRelatedBookDelete?: (relatedBook: RelatedBook) => void;
   sx?: SxProps;
-  onDelete?: () => void;
 };
 
 export default function BookChip({
   relatedBook,
   onRelatedBookClick,
   sx,
-  onDelete,
+  onRelatedBookDelete,
 }: Props) {
   const handleClick = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
       event.stopPropagation();
-      onRelatedBookClick?.(relatedBook.id);
+      onRelatedBookClick?.(relatedBook);
     },
-    [onRelatedBookClick, relatedBook.id]
+    [onRelatedBookClick, relatedBook]
+  );
+
+  const handleDelete = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      onRelatedBookDelete?.(relatedBook);
+    },
+    [onRelatedBookDelete, relatedBook]
   );
 
   return (
@@ -44,7 +52,7 @@ export default function BookChip({
         color="primary"
         label={relatedBook.name}
         onClick={handleClick}
-        onDelete={onDelete}
+        onDelete={onRelatedBookDelete && handleDelete}
       />
     </Tooltip>
   );

--- a/components/atoms/BookChip.tsx
+++ b/components/atoms/BookChip.tsx
@@ -1,0 +1,51 @@
+import type { MouseEvent } from "react";
+import { useCallback } from "react";
+import type { SxProps } from "@mui/system";
+import { styled } from "@mui/material/styles";
+import MuiChip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
+import type { RelatedBook } from "$server/models/topic";
+
+const Chip = styled(MuiChip)({
+  maxWidth: "100%",
+});
+
+type Props = {
+  relatedBook: RelatedBook;
+  onRelatedBookClick?(id: number): void;
+  sx?: SxProps;
+  onDelete?: () => void;
+};
+
+export default function BookChip({
+  relatedBook,
+  onRelatedBookClick,
+  sx,
+  onDelete,
+}: Props) {
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      onRelatedBookClick?.(relatedBook.id);
+    },
+    [onRelatedBookClick, relatedBook.id]
+  );
+
+  return (
+    <Tooltip
+      title={relatedBook.description || relatedBook.name}
+      disableInteractive
+    >
+      <Chip
+        sx={sx}
+        aria-haspopup="true"
+        variant="outlined"
+        size="small"
+        color="primary"
+        label={relatedBook.name}
+        onClick={handleClick}
+        onDelete={onDelete}
+      />
+    </Tooltip>
+  );
+}

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -122,7 +122,7 @@ type Props = Parameters<typeof Checkbox>[0] & {
     ltiResourceLink: Pick<LtiResourceLinkSchema, "consumerId" | "contextId">
   ): void;
   onKeywordClick(keyword: Pick<KeywordSchema, "name">): void;
-  onRelatedBookClick(id: RelatedBook): void;
+  onRelatedBookClick?(id: RelatedBook): void;
   linked?: boolean;
 };
 
@@ -254,9 +254,7 @@ export default function ContentPreview({
                         key={index}
                         sx={{ mr: 0.5, my: 0.125 }}
                         relatedBook={relatedBook}
-                        onRelatedBookClick={() =>
-                          onRelatedBookClick(relatedBook)
-                        }
+                        onRelatedBookClick={onRelatedBookClick}
                       />
                     ))}
                   </>

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -28,6 +28,7 @@ import { authors } from "$utils/descriptionList";
 import useOembed from "$utils/useOembed";
 import { NEXT_PUBLIC_BASE_PATH } from "$utils/env";
 import BookChip from "$atoms/BookChip";
+import type { RelatedBook } from "$server/models/topic";
 
 type HeaderProps = Parameters<typeof Checkbox>[0] & {
   checkable: boolean;
@@ -121,7 +122,7 @@ type Props = Parameters<typeof Checkbox>[0] & {
     ltiResourceLink: Pick<LtiResourceLinkSchema, "consumerId" | "contextId">
   ): void;
   onKeywordClick(keyword: Pick<KeywordSchema, "name">): void;
-  onRelatedBookClick(id: number): void;
+  onRelatedBookClick(id: RelatedBook): void;
   linked?: boolean;
 };
 
@@ -253,7 +254,9 @@ export default function ContentPreview({
                         key={index}
                         sx={{ mr: 0.5, my: 0.125 }}
                         relatedBook={relatedBook}
-                        onRelatedBookClick={onRelatedBookClick}
+                        onRelatedBookClick={() =>
+                          onRelatedBookClick(relatedBook)
+                        }
                       />
                     ))}
                   </>

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -27,6 +27,7 @@ import getLocaleDateString from "$utils/getLocaleDateString";
 import { authors } from "$utils/descriptionList";
 import useOembed from "$utils/useOembed";
 import { NEXT_PUBLIC_BASE_PATH } from "$utils/env";
+import BookChip from "$atoms/BookChip";
 
 type HeaderProps = Parameters<typeof Checkbox>[0] & {
   checkable: boolean;
@@ -120,6 +121,7 @@ type Props = Parameters<typeof Checkbox>[0] & {
     ltiResourceLink: Pick<LtiResourceLinkSchema, "consumerId" | "contextId">
   ): void;
   onKeywordClick(keyword: Pick<KeywordSchema, "name">): void;
+  onRelatedBookClick(id: number): void;
   linked?: boolean;
 };
 
@@ -130,6 +132,7 @@ export default function ContentPreview({
   onContentLinkClick,
   onLtiContextClick,
   onKeywordClick,
+  onRelatedBookClick,
   linked = content.type === "book" ? false : undefined,
   checked,
   ...checkboxProps
@@ -229,6 +232,36 @@ export default function ContentPreview({
           ...authors(content),
         ]}
       />
+      {content.type === "topic" &&
+        content.relatedBooks &&
+        content.relatedBooks?.length > 0 && (
+          <DescriptionList
+            sx={{
+              mx: 2,
+              mb: 1,
+              // TODO: 深い階層に対するスタイルの上書きが不要なコンポーネントの整理
+              dt: { flexShrink: 0 },
+              dd: { overflow: "hidden" },
+            }}
+            value={[
+              {
+                key: "ブック",
+                value: (
+                  <>
+                    {content.relatedBooks?.map((relatedBook, index) => (
+                      <BookChip
+                        key={index}
+                        sx={{ mr: 0.5, my: 0.125 }}
+                        relatedBook={relatedBook}
+                        onRelatedBookClick={onRelatedBookClick}
+                      />
+                    ))}
+                  </>
+                ),
+              },
+            ]}
+          />
+        )}
       {content.type === "book" && content.ltiResourceLinks.length > 0 && (
         <DescriptionList
           sx={{

--- a/components/organisms/FilterColumn.tsx
+++ b/components/organisms/FilterColumn.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { SxProps } from "@mui/system";
 import Box from "@mui/material/Box";
 import FormLabel from "@mui/material/FormLabel";
@@ -13,19 +12,18 @@ import TextField from "$atoms/TextField";
 import licenses from "$utils/licenses";
 import { useSearchAtom } from "$store/search";
 import type { SharedFilterType } from "$types/sharedFilter";
-import type { ContentSchema } from "$server/models/content";
 import BookChip from "$atoms/BookChip";
 
 type Props = {
   sx?: SxProps;
   variant: "book" | "topic";
-  contents: ContentSchema[];
 };
 
-export default function FilterColumn({ sx, variant, contents }: Props) {
+export default function FilterColumn({ sx, variant }: Props) {
   const {
     query,
     searchQuery,
+    relatedBooks,
     onAuthorFilterChange,
     onSharedFilterChange,
     onLicenseFilterChange,
@@ -33,29 +31,6 @@ export default function FilterColumn({ sx, variant, contents }: Props) {
     onKeywordDelete,
     onRelatedBookDelete,
   } = useSearchAtom();
-
-  const relatedBooks = useMemo(() => {
-    const relatedBooks = contents
-      .map((content) => {
-        if (content.type === "topic") {
-          return content.relatedBooks;
-        }
-
-        return [];
-      })
-      .flatMap((relatedBook) =>
-        relatedBook?.filter((relatedBook) => {
-          return searchQuery?.book?.some((id) => id === relatedBook.id);
-        })
-      );
-
-    const uniqueRelatedBooks = Array.from(
-      new Map(
-        relatedBooks.map((relatedBook) => [relatedBook?.id, relatedBook])
-      ).values()
-    );
-    return uniqueRelatedBooks;
-  }, [contents, searchQuery?.book]);
 
   return (
     <Box sx={sx}>
@@ -127,7 +102,7 @@ export default function FilterColumn({ sx, variant, contents }: Props) {
                   sx={{ mr: 0.5 }}
                   key={relatedBook.id}
                   relatedBook={relatedBook}
-                  onDelete={() => onRelatedBookDelete(relatedBook.id)}
+                  onDelete={() => onRelatedBookDelete(relatedBook)}
                 />
               )
             );

--- a/components/organisms/FilterColumn.tsx
+++ b/components/organisms/FilterColumn.tsx
@@ -102,7 +102,7 @@ export default function FilterColumn({ sx, variant }: Props) {
                   sx={{ mr: 0.5 }}
                   key={relatedBook.id}
                   relatedBook={relatedBook}
-                  onDelete={() => onRelatedBookDelete(relatedBook)}
+                  onRelatedBookDelete={onRelatedBookDelete}
                 />
               )
             );

--- a/components/organisms/FilterColumn.tsx
+++ b/components/organisms/FilterColumn.tsx
@@ -31,6 +31,7 @@ export default function FilterColumn({ sx, variant, contents }: Props) {
     onLicenseFilterChange,
     onLtiContextDelete,
     onKeywordDelete,
+    onRelatedBookDelete,
   } = useSearchAtom();
 
   const relatedBooks = useMemo(() => {
@@ -126,7 +127,7 @@ export default function FilterColumn({ sx, variant, contents }: Props) {
                   sx={{ mr: 0.5 }}
                   key={relatedBook.id}
                   relatedBook={relatedBook}
-                  // onDelete={() => onLtiContextDelete(ltiResourceLink)}
+                  onDelete={() => onRelatedBookDelete(relatedBook.id)}
                 />
               )
             );

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -146,7 +146,11 @@ export default function Topics(props: Props) {
           onSearchTargetChange={searchProps.onSearchTargetChange}
         />
       </ActionHeader>
-      <FilterColumn sx={{ gridArea: "side" }} variant="topic" />
+      <FilterColumn
+        sx={{ gridArea: "side" }}
+        variant="topic"
+        contents={contents}
+      />
       <Box
         display="grid"
         gridTemplateColumns="repeat(auto-fill, 296px)"

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -162,6 +162,7 @@ export default function Topics(props: Props) {
             onContentPreviewClick={handlePreviewClick}
             onContentEditClick={onContentEditClick}
             onKeywordClick={searchProps.onKeywordClick}
+            onRelatedBookClick={searchProps.onRelatedBookClick}
           />
         ))}
         {loading &&

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -146,11 +146,7 @@ export default function Topics(props: Props) {
           onSearchTargetChange={searchProps.onSearchTargetChange}
         />
       </ActionHeader>
-      <FilterColumn
-        sx={{ gridArea: "side" }}
-        variant="topic"
-        contents={contents}
-      />
+      <FilterColumn sx={{ gridArea: "side" }} variant="topic" />
       <Box
         display="grid"
         gridTemplateColumns="repeat(auto-fill, 296px)"

--- a/samples/index.ts
+++ b/samples/index.ts
@@ -10,3 +10,4 @@ export { default as book } from "./book";
 export { default as books } from "./books";
 export { default as activity } from "./activity";
 export { default as bookActivity } from "./bookActivity";
+export { default as relatedBook } from "./relatedBook";

--- a/samples/relatedBook.ts
+++ b/samples/relatedBook.ts
@@ -1,0 +1,9 @@
+const relatedBook = {
+  id: 1,
+  name: "さまざまな関数",
+  description: "入門微分積分学入門 第１章",
+  language: "ja",
+  shared: true,
+};
+
+export default relatedBook;

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -18,7 +18,7 @@ const RelatedBook = {
   additionalProperties: false,
 } as const;
 
-type RelatedBook = FromSchema<typeof RelatedBook>;
+export type RelatedBook = FromSchema<typeof RelatedBook>;
 
 export type TopicProps = Pick<
   Prisma.TopicCreateInput,

--- a/store/search.ts
+++ b/store/search.ts
@@ -195,6 +195,16 @@ export function useSearchAtom() {
     [updateSearchQuery]
   );
 
+  const onRelatedBookClick: (id: number) => void = useCallback(
+    (id) => {
+      updateSearchQuery((searchQuery) => ({
+        ...searchQuery,
+        book: [...(searchQuery.book ?? []), id],
+      }));
+    },
+    [updateSearchQuery]
+  );
+
   return {
     query,
     searchQuery,
@@ -214,5 +224,6 @@ export function useSearchAtom() {
     onLtiContextDelete,
     onKeywordClick,
     onKeywordDelete,
+    onRelatedBookClick,
   };
 }

--- a/store/search.ts
+++ b/store/search.ts
@@ -220,7 +220,9 @@ export function useSearchAtom() {
     (relatedBook) => {
       updateSearchQuery((searchQuery) => ({
         ...searchQuery,
-        book: (searchQuery.book ?? []).filter((book) => book !== relatedBook.id),
+        book: (searchQuery.book ?? []).filter(
+          (book) => book !== relatedBook.id
+        ),
       }));
       updateRelatedBooks((prev) =>
         prev.filter((book) => book.id !== relatedBook.id)

--- a/store/search.ts
+++ b/store/search.ts
@@ -201,14 +201,14 @@ export function useSearchAtom() {
 
   const onRelatedBookClick: (relatedBook: RelatedBook) => void = useCallback(
     (relatedBook) => {
+      if (relatedBooks.some((book) => book.id === relatedBook.id)) {
+        return;
+      }
       updateSearchQuery((searchQuery) => ({
         ...searchQuery,
         book: [...(searchQuery.book ?? []), relatedBook.id],
       }));
 
-      if (relatedBooks.some((book) => book.id === relatedBook.id)) {
-        return;
-      }
       updateRelatedBooks((prevRelatedBooks) => [
         ...prevRelatedBooks,
         relatedBook,
@@ -224,8 +224,8 @@ export function useSearchAtom() {
           (book) => book !== relatedBook.id
         ),
       }));
-      updateRelatedBooks((prev) =>
-        prev.filter((book) => book.id !== relatedBook.id)
+      updateRelatedBooks((prevRelatedBooks) =>
+        prevRelatedBooks.filter((book) => book.id !== relatedBook.id)
       );
     },
     [updateRelatedBooks, updateSearchQuery]

--- a/store/search.ts
+++ b/store/search.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+import { useUnmount } from "react-use";
 import { atom, useAtom } from "jotai";
 import { RESET, atomWithReset } from "jotai/utils";
 import yn from "yn";
@@ -230,6 +231,7 @@ export function useSearchAtom() {
     },
     [updateRelatedBooks, updateSearchQuery]
   );
+  useUnmount(() => updateRelatedBooks([]));
 
   return {
     query,

--- a/store/search.ts
+++ b/store/search.ts
@@ -220,7 +220,7 @@ export function useSearchAtom() {
     (relatedBook) => {
       updateSearchQuery((searchQuery) => ({
         ...searchQuery,
-        book: (searchQuery.book ?? []).filter((book) => book != relatedBook.id),
+        book: (searchQuery.book ?? []).filter((book) => book !== relatedBook.id),
       }));
       updateRelatedBooks((prev) =>
         prev.filter((book) => book.id !== relatedBook.id)

--- a/store/search.ts
+++ b/store/search.ts
@@ -204,6 +204,14 @@ export function useSearchAtom() {
     },
     [updateSearchQuery]
   );
+  const onRelatedBookDelete: (id: number) => void = useCallback(
+    (id) =>
+      updateSearchQuery((searchQuery) => ({
+        ...searchQuery,
+        book: (searchQuery.book ?? []).filter((book) => book != id),
+      })),
+    [updateSearchQuery]
+  );
 
   return {
     query,
@@ -225,5 +233,6 @@ export function useSearchAtom() {
     onKeywordClick,
     onKeywordDelete,
     onRelatedBookClick,
+    onRelatedBookDelete,
   };
 }


### PR DESCRIPTION
関連 #779 #766 #806

トピック検索apiのブックでの絞り込みのクライアントの対応です。

- [x] ブックの表示
- [x] クリック時にブックでの絞り込み
- [x] サイドバーに適用中のブックを表示
- [x] サイドバーのDeleteボタンを押すと絞り込み表示解除