### PR TITLE
chore: PRの変更に含まれないファイルのLintエラーもチェックする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
             git push origin HEAD
           fi
       - uses: ataylorme/eslint-annotate-action@v2
-        with: { repo-token: "${{ github.token }}" }
+        with:
+          repo-token: "${{ github.token }}"
+          only-pr-files: false
       - name: format
         run: yarn format
       - name: "commit format"


### PR DESCRIPTION
見逃す恐れがあるためすべてチェックする

PR https://github.com/npocccties/chibichilo/pull/813 を見ていてCIの自動チェックからPRの変更に含まれないファイルが漏れていたのでそれを含めます。

参考文献: https://github.com/marketplace/actions/eslint-annotate-from-report-json
