### PR TITLE
fix: Bufferのサイズ制限を回避するためにStreamを使う

### DIFF
--- a/server/tests/wowzaUploadTest.ts
+++ b/server/tests/wowzaUploadTest.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs/promises";
+import childProcess from "node:child_process";
+import util from "node:util";
+import { WowzaUpload } from "$server/utils/wowza/upload";
+
+const exec = util.promisify(childProcess.exec);
+
+/** WowzaUpload 大きいサイズのアップロードのテスト (環境変数での設定必須) */
+async function wowzaUploadTest() {
+  const root = await fs.mkdtemp("/tmp/wowza-upload-");
+  await exec(`fallocate -l 10GB ${root}/dummy`);
+  const wowzaUpload = new WowzaUpload(root, "dummy");
+  await wowzaUpload.upload();
+  await exec(`rm -r ${root}`);
+  console.log("pass");
+}
+
+void wowzaUploadTest();

--- a/server/utils/zoom/import.ts
+++ b/server/utils/zoom/import.ts
@@ -1,5 +1,6 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
+import stream from "node:stream/promises";
 import got from "got";
 import format from "date-fns/format";
 import utcToZoneTime from "date-fns-tz/utcToZonedTime";
@@ -199,10 +200,10 @@ class ZoomImport {
       const startTime = new Date(meeting.start_time);
       const timezone = meeting.timezone || "Asia/Tokyo";
       const file = path.join(this.tmpdir, `${fileId}.mp4`);
-      const responsePromise = got(
-        `${downloadUrl}?access_token=${zoomRequestToken()}`
-      );
-      await fs.promises.writeFile(file, await responsePromise.buffer());
+      const fileStream = got
+        .stream(`${downloadUrl}?access_token=${zoomRequestToken()}`)
+        .pipe(fs.createWriteStream(file));
+      await stream.finished(fileStream);
 
       const video = {
         create: {


### PR DESCRIPTION
ref #798

確認したこと:

- 大きいファイルの書き込みにBufferを使用してる箇所をStreamに
- WOWZA_SCP_* 環境変数を設定して `node -r esbuild-register server/tests/wowzaUploadTest.ts`
    - SSHでの転送時のサイズ制限に関しては問題無いことを確認
