### PR TITLE
fix: プレイヤーオブジェクト生成時の自動再生プロセスの修正

### DIFF
--- a/components/organisms/Video/VideoPlayer.tsx
+++ b/components/organisms/Video/VideoPlayer.tsx
@@ -12,6 +12,7 @@ type Props = {
   sx?: SxProps;
   className?: string;
   videoInstance: VideoInstance;
+  autoplay?: boolean;
   onEnded?: () => void;
   onDurationChange?: (duration: number) => void;
   onTimeUpdate?: (currentTime: number) => void;
@@ -19,6 +20,7 @@ type Props = {
 
 export default function VideoPlayer({
   videoInstance,
+  autoplay = false,
   onEnded,
   onDurationChange,
   onTimeUpdate,
@@ -42,15 +44,29 @@ export default function VideoPlayer({
     player.on("ended", handleEnded);
     player.on("durationchange", handleDurationChange);
     player.on("timeupdate", handleTimeUpdate);
-    if (videoInstance.type != "vimeo") {
+    if (videoInstance.type !== "vimeo") {
       videoJsDurationChangeShims(videoInstance.player, handleDurationChange);
+    }
+    if (autoplay) {
+      const play = async () => {
+        try {
+          await player.play();
+        } catch {
+          // nop
+        }
+      };
+      if (videoInstance.type === "vimeo") {
+        void videoInstance.player.ready().then(play);
+      } else {
+        void videoInstance.player.ready(play);
+      }
     }
     return () => {
       player.off("ended", handleEnded);
       player.off("durationchange", handleDurationChange);
       player.off("timeupdate", handleTimeUpdate);
     };
-  }, [videoInstance, onEnded, onDurationChange, onTimeUpdate]);
+  }, [videoInstance, autoplay, onEnded, onDurationChange, onTimeUpdate]);
 
   return (
     <Box {...other}>

--- a/components/organisms/Video/VideoResource.tsx
+++ b/components/organisms/Video/VideoResource.tsx
@@ -24,7 +24,7 @@ export default function VideoResource({
   providerUrl,
   url,
   accessToken,
-  tracks: resourceTracks,
+  tracks,
   identifier,
   autoplay = false,
   thumbnailUrl,
@@ -32,17 +32,17 @@ export default function VideoResource({
 }: Props) {
   const videoInstance = useMemo(() => {
     return getVideoInstance(
-      { providerUrl, url, accessToken, tracks: resourceTracks },
-      autoplay,
+      { providerUrl, url, accessToken, tracks },
       thumbnailUrl
     );
-  }, [providerUrl, url, accessToken, resourceTracks, autoplay, thumbnailUrl]);
+  }, [providerUrl, url, accessToken, tracks, thumbnailUrl]);
 
   const { video } = useVideoAtom();
   useEffect(() => {
     video.set(identifier, videoInstance);
-    return () => void videoInstance.player.pause();
   }, [video, identifier, videoInstance]);
 
-  return <VideoPlayer videoInstance={videoInstance} {...other} />;
+  return (
+    <VideoPlayer videoInstance={videoInstance} autoplay={autoplay} {...other} />
+  );
 }

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -61,7 +61,6 @@ export default function Video({ className, sx, topic, onEnded }: Props) {
     if (!book) return;
     // バックグラウンドで動画プレイヤーオブジェクトプールに読み込む
     updateVideo(book.sections);
-    return () => video.forEach((v) => v.player.pause());
   }, [book, video, updateVideo]);
   const oembed = useOembed(topic.resource.id);
   const prevItemIndex = usePrevious(itemIndex);
@@ -88,9 +87,6 @@ export default function Video({ className, sx, topic, onEnded }: Props) {
         }
       });
       void videoInstance.player.setCurrentTime(startTime || 0);
-      videoInstance.player.play().catch(() => {
-        // nop
-      });
     } else {
       const handleEnded = () => {
         videoInstance.stopTimeOver = true;
@@ -127,9 +123,6 @@ export default function Video({ className, sx, topic, onEnded }: Props) {
         }
         videoInstance.player.on("timeupdate", handleTimeUpdate);
         videoInstance.player.on("seeked", handleSeeked);
-        videoInstance.player.play()?.catch(() => {
-          // nop
-        });
       };
 
       videoInstance.player.on("ended", handleEnded);
@@ -151,6 +144,7 @@ export default function Video({ className, sx, topic, onEnded }: Props) {
             })}
             sx={{ ...videoStyle, ...sx }}
             videoInstance={videoInstance}
+            autoplay={String(topic.id) === id}
           />
         ))}
       </>

--- a/utils/video/getVideoInstance.ts
+++ b/utils/video/getVideoInstance.ts
@@ -8,7 +8,6 @@ import getVimeoPlayer from "./getVimeoPlayer";
 /**
  * 動画プレイヤーのインスタンスを生成
  * @param resource VideoResourceSchema
- * @param autoplay インスタンス生成時に自動再生するか否か
  * @returns プレイヤーのHTML要素、インスタンス、video.jsであれば字幕トラック
  */
 function getVideoInstance(
@@ -16,7 +15,6 @@ function getVideoInstance(
     VideoResourceSchema,
     "providerUrl" | "url" | "accessToken" | "tracks"
   >,
-  autoplay = false,
   thumbnailUrl?: OembedSchema["thumbnail_url"]
 ): VideoInstance {
   switch (resource.providerUrl) {
@@ -32,7 +30,6 @@ function getVideoInstance(
               src: resource.url,
             },
           ],
-          autoplay,
         }),
         tracks: buildTracks(resource.tracks),
         stopTimeOver: false,
@@ -41,7 +38,7 @@ function getVideoInstance(
       return {
         type: "vimeo",
         url: resource.url,
-        ...getVimeoPlayer({ url: resource.url, autoplay }),
+        ...getVimeoPlayer({ url: resource.url }),
       };
     default: {
       const url = `${resource.url}?accessToken=${resource.accessToken}`;
@@ -50,7 +47,6 @@ function getVideoInstance(
         url,
         ...getVideoJsPlayer({
           sources: [{ type: "application/vnd.apple.mpegurl", src: url }],
-          autoplay,
           poster: thumbnailUrl,
         }),
         tracks: buildTracks(resource.tracks),


### PR DESCRIPTION
ref #808
誤ってバックグラウドで再生されうる問題を防ぐ目的でインスタンス生成時の自動再生オプションを無効化しVideoPlayerコンポーネントで一貫して管理する
