### PR TITLE
fix: プリロードする際に動画プレイヤーオブジェクトがすでに存在する場合インスタンスを生成しないように修正

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -55,13 +55,13 @@ function isValidPlaybackEnd({
 }
 
 export default function Video({ className, sx, topic, onEnded }: Props) {
-  const { video, updateVideo } = useVideoAtom();
+  const { video, preloadVideo } = useVideoAtom();
   const { book, itemIndex, itemExists } = useBookAtom();
   useEffect(() => {
     if (!book) return;
     // バックグラウンドで動画プレイヤーオブジェクトプールに読み込む
-    updateVideo(book.sections);
-  }, [book, video, updateVideo]);
+    preloadVideo(book.sections);
+  }, [book, preloadVideo]);
   const oembed = useOembed(topic.resource.id);
   const prevItemIndex = usePrevious(itemIndex);
   useEffect(() => {

--- a/store/video.ts
+++ b/store/video.ts
@@ -1,19 +1,19 @@
 import { useUnmount } from "react-use";
-import { atom, useAtom } from "jotai";
-import { RESET, atomWithReset, useUpdateAtom } from "jotai/utils";
+import { atom, useAtomValue } from "jotai";
+import { useUpdateAtom } from "jotai/utils";
 import type { SectionSchema } from "$server/models/book/section";
 import type { VideoInstance } from "$types/videoInstance";
 import { isVideoResource } from "$utils/videoResource";
 import getVideoInstance from "$utils/video/getVideoInstance";
 
 /** 動画プレイヤーオブジェクトプール (トピックID(10進数文字列)または動画URLをキーとして使用) */
-const videoAtom = atomWithReset<{
+const videoAtom = atom<{
   video: Map<string, VideoInstance>;
 }>({
   video: new Map(),
 });
 
-const updateVideoAtom = atom(
+const preloadVideoAtom = atom(
   null,
   (get, set, sections: Pick<SectionSchema, "topics">[]) => {
     const { video } = get(videoAtom);
@@ -22,18 +22,17 @@ const updateVideoAtom = atom(
         video.delete(String(topic.id));
         continue;
       }
-      video.set(String(topic.id), getVideoInstance(topic.resource));
+      if (!video.has(String(topic.id))) {
+        video.set(String(topic.id), getVideoInstance(topic.resource));
+      }
     }
     set(videoAtom, { video });
   }
 );
 
 export function useVideoAtom() {
-  const [state, reset] = useAtom(videoAtom);
-  const updateVideo = useUpdateAtom(updateVideoAtom);
-  useUnmount(() => {
-    state.video.forEach(({ player }) => player.pause());
-    reset(RESET);
-  });
-  return { ...state, updateVideo };
+  const state = useAtomValue(videoAtom);
+  const preloadVideo = useUpdateAtom(preloadVideoAtom);
+  useUnmount(() => state.video.clear());
+  return { ...state, preloadVideo };
 }


### PR DESCRIPTION
ref #808

- fix: プリロードする際に動画プレイヤーオブジェクトがすでに存在する場合インスタンスを生成しない
- fix: 自動再生プロセスの修正


プリロードする際に動画プレイヤーオブジェクトが存在しているかどうかに関わらず複数登録される問題の修正
アンマウント時に動画プレイヤーオブジェクトプールを初期化されるようにして次回マウント時には新しいインスタンスを生成する処理に変更
関数名を `updateVideo` → `preloadVideo` に変更
今後もMapへの副作用をstoreで扱うのが妥当かどうかは分からないがひとまずそのまま

また #835 の影響でonEnded, onDurationChange, onTimeUpdate の変更のタイミングで誤って自動再生が行われる問題があった

その修正