### PR TITLE
fix: ブックプレビューでトピックを切り替えると自動再生されないことがある問題の修正

### DIFF
--- a/components/organisms/Video/VideoPlayer.tsx
+++ b/components/organisms/Video/VideoPlayer.tsx
@@ -44,7 +44,12 @@ export default function VideoPlayer({
         ? player.ready()
         : new Promise((resolve) => player.ready(() => resolve(undefined)));
     void ready.then(play);
-  }, [videoInstance, autoplay]);
+  }, [
+    videoInstance,
+    autoplay,
+    // NOTE: セクションが切り替わったことを検知する目的でonEndedの変更検知を利用している
+    onEnded,
+  ]);
   useEffect(() => {
     const { player } = videoInstance;
     const handleEnded = () => onEnded?.();

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -61,7 +61,8 @@ export default function Video({ className, sx, topic, onEnded }: Props) {
     if (!book) return;
     // バックグラウンドで動画プレイヤーオブジェクトプールに読み込む
     preloadVideo(book.sections);
-  }, [book, preloadVideo]);
+    return () => video.clear();
+  }, [book, preloadVideo, video]);
   const oembed = useOembed(topic.resource.id);
   const prevItemIndex = usePrevious(itemIndex);
   useEffect(() => {

--- a/store/video.ts
+++ b/store/video.ts
@@ -1,4 +1,3 @@
-import { useUnmount } from "react-use";
 import { atom, useAtomValue } from "jotai";
 import { useUpdateAtom } from "jotai/utils";
 import type { SectionSchema } from "$server/models/book/section";
@@ -33,6 +32,5 @@ const preloadVideoAtom = atom(
 export function useVideoAtom() {
   const state = useAtomValue(videoAtom);
   const preloadVideo = useUpdateAtom(preloadVideoAtom);
-  useUnmount(() => state.video.clear());
   return { ...state, preloadVideo };
 }


### PR DESCRIPTION
ref #840

- セクションが切り替わったことを検知する目的でonEndedの変更検知に応じた自動再生処理の追加
- バックグラウンドで動画プレイヤーオブジェクトプールの初期化プロセスを変更

