### PR TITLE
chore: 依存関係の更新 (Node.js v18 対応)

### DIFF
--- a/INSTALL-en.md
+++ b/INSTALL-en.md
@@ -22,16 +22,16 @@ When changing the information of the connection destination of API, .env must be
 
 ### Prerequisites
 
-As of 2021-09-03, confirm the build in the following environment.
+As of 2022-10-27, confirm the build in the following environment.
 
-- Node.js v16.8.0
-- Yarn 1.22.11
+- Node.js v18.12.0
 
 ### Build
 
 Execute the following command.
 
 ```sh
+corepack enable yarn
 yarn && yarn build
 ```
 

--- a/INSTALL-ja.md
+++ b/INSTALL-ja.md
@@ -32,10 +32,9 @@ API の接続先の情報を変更する場合 .env を適宜書き換える必�
 
 ### 前提条件
 
-2021-09-03 現在、以下の環境でビルドを確認。
+2022-10-27 現在、以下の環境でビルドを確認。
 
-- Node.js v16.8.0
-- Yarn 1.22.11
+- Node.js v18.12.0
 
 ### ビルド
 
@@ -44,6 +43,7 @@ API の接続先の情報を変更する場合 .env を適宜書き換える必�
 ```sh
 git clone https://github.com/npocccties/chibichilo.git
 cd chibichilo
+corepack enable yarn
 yarn
 yarn build
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       POSTGRES_PASSWORD: password
     ports: ["5432:5432"]
   app:
-    image: "node:16.16-alpine3.16"
+    image: "node:18.12-alpine3.16"
     environment:
       FRONTEND_ORIGIN: "http://localhost:3000"
       SESSION_SECRET: super_secret_characters_for_session

--- a/package.json
+++ b/package.json
@@ -124,6 +124,6 @@
     "storybook": "start-storybook -s ./public"
   },
   "engines": {
-    "node": ">=12 <17"
+    "node": "^14.15.0 || ^16.13.0 || ^18.12.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -63,7 +63,7 @@
     "node-interval-tree": "^2.0.1",
     "node-schedule": "^2.1.0",
     "npm-run-all": "^4.1.5",
-    "openid-client": "^5.1.8",
+    "openid-client": "^5.2.1",
     "outdent": "^0.8.0",
     "pino-pretty": "^8.1.0",
     "prisma": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9317,10 +9317,10 @@ jest@^28.1.3:
     import-local "^3.0.2"
     jest-cli "^28.1.3"
 
-jose@^4.1.4:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.8.3.tgz#5a754fb4aa5f2806608d083f438e6916b11087da"
-  integrity sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g==
+jose@^4.10.0:
+  version "4.10.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.10.3.tgz#36ffeae395f14624a99961db6ada957476eccb19"
+  integrity sha512-3S4wQnaoJKSAx9uHSoyf8B/lxjs1qCntHWL6wNFszJazo+FtWe+qD0zVfY0BlqJ5HHK4jcnM98k3BQzVLbzE4g==
 
 jotai@^1.7.7:
   version "1.7.7"
@@ -11347,12 +11347,12 @@ openapi3-ts@^2.0.0:
   dependencies:
     yaml "^1.10.0"
 
-openid-client@^5.1.8:
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.1.8.tgz#3a24910288b32c32f548fb6e391f44178ce6370f"
-  integrity sha512-EPxJY6bT7YIYQEXSGxRC5flQ3GUhLy98ufdto6+BVBrFGPmwjUpy4xBcYuU/Wt9nPkO/3EgljBrr6Ezx4lp1RQ==
+openid-client@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.2.1.tgz#dd26298aca237625298ef34ff11ad9276917df28"
+  integrity sha512-KPxqWnxobG/70Cxqyvd43RWfCfHedFnCdHSBpw5f7WnTnuBAeBnvot/BIo+brrcTr0wyAYUlL/qejQSGwWtdIg==
   dependencies:
-    jose "^4.1.4"
+    jose "^4.10.0"
     lru-cache "^6.0.0"
     object-hash "^2.0.1"
     oidc-token-hash "^5.0.1"


### PR DESCRIPTION
- openid-client 5.1.8 → 5.2.1 更新
- `node:18.12-alpine3.16` イメージ へのアップデート
