### PR TITLE
feat:ブック・トピック・LTIリンク・コースのタイトルから検索する

### DIFF
--- a/components/molecules/CourseSearchTextField.tsx
+++ b/components/molecules/CourseSearchTextField.tsx
@@ -19,10 +19,15 @@ const options: ReadonlyArray<{
 type Props = Omit<TextFieldProps, "variant" | "value"> & {
   target: LinkSearchTarget;
   onSearchSubmit(value: string): void;
-  onSearchTargetChange: (target: LinkSearchTarget) =>void;
+  onSearchTargetChange: (target: LinkSearchTarget) => void;
 };
 
-function CourseSearchTextField({ target, onSearchSubmit,onSearchTargetChange, ...props }: Props) {
+function CourseSearchTextField({
+  target,
+  onSearchSubmit,
+  onSearchTargetChange,
+  ...props
+}: Props) {
   const [value, setValue] = useState("");
   const reset = useCallback(() => {
     setValue("");
@@ -44,12 +49,7 @@ function CourseSearchTextField({ target, onSearchSubmit,onSearchTargetChange, ..
         onSearchInputReset={reset}
         onSearchSubmit={onSearchSubmit}
       />
-      <RadioGroup
-        id="search-type"
-        value={target}
-        onChange={handleChange}
-        row
-      >
+      <RadioGroup id="search-type" value={target} onChange={handleChange} row>
         {options.map(({ value, label }) => (
           <FormControlLabel
             key={value}

--- a/components/molecules/CourseSearchTextField.tsx
+++ b/components/molecules/CourseSearchTextField.tsx
@@ -1,26 +1,65 @@
 import { useState, useCallback } from "react";
 import type { TextFieldProps } from "@mui/material/TextField";
 import SearchTextField from "$atoms/SearchTextField";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Radio from "@mui/material/Radio";
+import type { LinkSearchTarget } from "$types/linkSearchTarget";
+
+const options: ReadonlyArray<{
+  value: LinkSearchTarget;
+  label: string;
+}> = [
+  { value: "all", label: "すべて" },
+  { value: "linkTitle", label: "リンク" },
+  { value: "bookName", label: "ブック" },
+  { value: "topicName", label: "トピック" },
+];
 
 type Props = Omit<TextFieldProps, "variant" | "value"> & {
+  target: LinkSearchTarget;
   onSearchSubmit(value: string): void;
+  onSearchTargetChange: (target: LinkSearchTarget) =>void;
 };
 
-function CourseSearchTextField({ onSearchSubmit, ...props }: Props) {
+function CourseSearchTextField({ target, onSearchSubmit,onSearchTargetChange, ...props }: Props) {
   const [value, setValue] = useState("");
   const reset = useCallback(() => {
     setValue("");
     onSearchSubmit("");
   }, [setValue, onSearchSubmit]);
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onSearchTargetChange(event.target.value as LinkSearchTarget);
+    },
+    [onSearchTargetChange]
+  );
 
   return (
-    <SearchTextField
-      {...props}
-      value={value}
-      onSearchInput={setValue}
-      onSearchInputReset={reset}
-      onSearchSubmit={onSearchSubmit}
-    />
+    <div>
+      <SearchTextField
+        {...props}
+        value={value}
+        onSearchInput={setValue}
+        onSearchInputReset={reset}
+        onSearchSubmit={onSearchSubmit}
+      />
+      <RadioGroup
+        id="search-type"
+        value={target}
+        onChange={handleChange}
+        row
+      >
+        {options.map(({ value, label }) => (
+          <FormControlLabel
+            key={value}
+            value={value}
+            control={<Radio color="primary" size="small" />}
+            label={label}
+          />
+        ))}
+      </RadioGroup>
+    </div>
   );
 }
 

--- a/components/templates/Courses.tsx
+++ b/components/templates/Courses.tsx
@@ -91,7 +91,9 @@ export default function Courses({
         />
         <CourseSearchTextField
           label="検索"
+          target={linkSearchProps.target}
           onSearchSubmit={linkSearchProps.onSearchSubmit}
+          onSearchTargetChange={linkSearchProps.onSearchTargetChange}
         />
       </ActionHeader>
       <CourseFilterColumn sx={{ gridArea: "side" }} clientIds={clientIds} />

--- a/components/templates/Courses.tsx
+++ b/components/templates/Courses.tsx
@@ -90,7 +90,7 @@ export default function Courses({
           ]}
         />
         <CourseSearchTextField
-          label="コース名検索"
+          label="検索"
           onSearchSubmit={linkSearchProps.onSearchSubmit}
         />
       </ActionHeader>

--- a/server/models/link/searchQuery.ts
+++ b/server/models/link/searchQuery.ts
@@ -5,4 +5,10 @@ export type LinkSearchQuery = {
   text: string[];
   /** 配信されているLMS */
   oauthClientId: string[];
+  /** リンク（リンク名）*/
+  link: string[];
+  /** ブック（ブック名）*/
+  book: string[];
+  /** トピック（トピック名）*/
+  topic: string[];
 };

--- a/server/models/link/searchQuery.ts
+++ b/server/models/link/searchQuery.ts
@@ -5,10 +5,10 @@ export type LinkSearchQuery = {
   text: string[];
   /** 配信されているLMS */
   oauthClientId: string[];
-  /** リンク（リンク名）*/
-  link: string[];
-  /** ブック（ブック名）*/
-  book: string[];
-  /** トピック（トピック名）*/
-  topic: string[];
+  /** LTIリンクタイトル */
+  linkTitle: string[];
+  /** ブック名 */
+  bookName: string[];
+  /** トピック名 */
+  topicName: string[];
 };

--- a/server/utils/linkSearch/linkSearch.ts
+++ b/server/utils/linkSearch/linkSearch.ts
@@ -83,11 +83,42 @@ async function linkSearch(
   const where: Prisma.LtiResourceLinkWhereInput = {
     AND: [
       createLinkScope(filter, course),
-      // NOTE: text - 検索文字列 (コース名)
+      // NOTE: text - 検索文字列 (コース名、LTIリンク名、ブック名、トピック名)
       ...query.text.map((t) => ({
-        context: {
-          title: { contains: t, ...insensitiveMode },
-        },
+        OR: [
+          {
+            context: {
+              title: { contains: t, ...insensitiveMode },
+            },
+          },
+          {
+            context: {
+              resourceLinks: {
+                some: {
+                  title: { contains: t, ...insensitiveMode },
+                },
+              },
+            },
+          },
+          {
+            book: {
+              name: { contains: t, ...insensitiveMode },
+            },
+          },
+          {
+            book: {
+              sections: {
+                some: {
+                  topicSections: {
+                    some: {
+                      topic: { name: { contains: t, ...insensitiveMode } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
       })),
       // NOTE: oauthClientId - 配信されているLMS
       ...query.oauthClientId.map((consumerId) => ({ consumerId })),

--- a/server/utils/linkSearch/linkSearch.ts
+++ b/server/utils/linkSearch/linkSearch.ts
@@ -122,6 +122,36 @@ async function linkSearch(
       })),
       // NOTE: oauthClientId - 配信されているLMS
       ...query.oauthClientId.map((consumerId) => ({ consumerId })),
+      // NOTE: link - リンクのタイトル
+      ...query.link.map((l) => ({
+        context: {
+          resourceLinks: {
+            some: {
+              title: { contains: l, ...insensitiveMode },
+            },
+          },
+        },
+      })),
+      // NOTE: book - ブックのタイトル
+      ...query.book.map((t) => ({
+        book: {
+          name: { contains: t, ...insensitiveMode },
+        },
+      })),
+      // NOTE: topic - トピックのタイトル
+      ...query.topic.map((t) => ({
+        book: {
+          sections: {
+            some: {
+              topicSections: {
+                some: {
+                  topic: { name: { contains: t, ...insensitiveMode } },
+                },
+              },
+            },
+          },
+        },
+      })),
     ],
   };
 

--- a/server/utils/linkSearch/parser.test.ts
+++ b/server/utils/linkSearch/parser.test.ts
@@ -12,6 +12,7 @@ const emptyQuery = {
 describe("parse()", function () {
   test("検索クエリー文字列をパースできる", function () {
     expect(parse(`link:hoge foo bar baz`)).toEqual({
+      ...emptyQuery,
       type: "link",
       text: ["foo", "bar", "baz"],
       oauthClientId: ["hoge"],
@@ -28,6 +29,16 @@ describe("parse()", function () {
       "hoge",
       "te:s,t",
     ]);
+  });
+
+  test("`linkTitle:` が含まれる文字列をパースできる", function () {
+    expect(parse("link:foo bar linkTitle:hoge")).toEqual({
+      ...emptyQuery,
+      type: "link",
+      text: ["bar"],
+      linkTitle: ["hoge"],
+      oauthClientId: ["foo"],
+    });
   });
 });
 

--- a/server/utils/linkSearch/parser.test.ts
+++ b/server/utils/linkSearch/parser.test.ts
@@ -4,6 +4,9 @@ const emptyQuery = {
   type: "link" as const,
   text: [],
   oauthClientId: [],
+  linkTitle: [],
+  bookName: [],
+  topicName: [],
 };
 
 describe("parse()", function () {

--- a/server/utils/linkSearch/parser.ts
+++ b/server/utils/linkSearch/parser.ts
@@ -18,6 +18,9 @@ export function parse(query: string): LinkSearchQuery {
     type: "link",
     text: res.text ?? [],
     oauthClientId: res.link?.map(decodeURIComponent) ?? [],
+    linkTitle: res.linkTitle ?? [],
+    bookName: res.bookName ?? [],
+    topicName: res.topicName ?? []
   };
 }
 

--- a/server/utils/linkSearch/parser.ts
+++ b/server/utils/linkSearch/parser.ts
@@ -2,12 +2,20 @@ import * as base from "search-query-parser";
 import type { LinkSearchQuery } from "$server/models/link/searchQuery";
 
 const options = {
-  keywords: ["link" as const],
+  keywords: [
+    "link" as const,
+    "linkTitle" as const,
+    "bookName" as const,
+    "topicName" as const,
+  ],
   alwaysArray: true,
   tokenize: true,
 };
 
 type SearchParserResult = base.SearchParserResult & {
+  // NOTE: keywords and `{ alwaysArray: true }`
+  [K in typeof options["keywords"][number]]?: string[];
+} & {
   // NOTE: `{ tokenize: true }`
   text?: string[];
 };
@@ -20,7 +28,7 @@ export function parse(query: string): LinkSearchQuery {
     oauthClientId: res.link?.map(decodeURIComponent) ?? [],
     linkTitle: res.linkTitle ?? [],
     bookName: res.bookName ?? [],
-    topicName: res.topicName ?? []
+    topicName: res.topicName ?? [],
   };
 }
 

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -82,10 +82,11 @@ export function useLinkSearchAtom() {
   );
   // const onLtiClientClick = useUpdateAtom(oauthClientIdAtom);
   const onLtiClientClick: (value: string) => void = useCallback(
-    (value:string) =>  updateSearchQuery((searchQuery) => ({
-      ...searchQuery,
-      oauthClientId: [value],
-    })),
+    (value: string) =>
+      updateSearchQuery((searchQuery) => ({
+        ...searchQuery,
+        oauthClientId: [value],
+      })),
     [updateSearchQuery]
   );
 

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -7,9 +7,9 @@ type SortOrder = "created" | "reverse-created";
 
 const inputAtom = atomWithReset<string>("");
 const oauthClientIdAtom = atomWithReset<string>(""); // "": すべてのLMS
-const linkAtom = atomWithReset<string>(""); // "": すべてのリンク
-const bookAtom = atomWithReset<string>(""); // "": すべてのブック
-const topicAtom = atomWithReset<string>(""); // "": すべてのトピック
+const linkTitleAtom = atomWithReset<string>(""); // "": すべてのリンク
+const bookNameAtom = atomWithReset<string>(""); // "": すべてのブック
+const topicNameAtom = atomWithReset<string>(""); // "": すべてのトピック
 const sortAtom = atomWithReset<SortOrder>("created");
 const queryAtom = atom<{
   type: "link";
@@ -23,9 +23,9 @@ const queryAtom = atom<{
     type: "link",
     text: [get(inputAtom)],
     oauthClientId: [get(oauthClientIdAtom) || []].flat(),
-    link: [get(linkAtom) || []].flat(),
-    book: [get(bookAtom) || []].flat(),
-    topic: [get(topicAtom) || []].flat(),
+    linkTitle: [get(linkTitleAtom) || []].flat(),
+    bookName: [get(bookNameAtom) || []].flat(),
+    topicName: [get(topicNameAtom) || []].flat(),
   }),
   sort: get(sortAtom),
   perPage: Number.MAX_SAFE_INTEGER,
@@ -36,6 +36,9 @@ const resetAtom = atom<undefined, undefined>(
   (_, set) => {
     set(inputAtom, RESET);
     set(oauthClientIdAtom, RESET);
+    set(linkTitleAtom, RESET);
+    set(bookNameAtom, RESET);
+    set(topicNameAtom, RESET);
     set(sortAtom, RESET);
   }
 );

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -10,7 +10,6 @@ import type { LinkSearchQuery } from "$server/models/link/searchQuery";
 type SortOrder = "created" | "reverse-created";
 
 const inputAtom = atomWithReset<string>("");
-const oauthClientIdAtom = atomWithReset<string>(""); // "": すべてのLMS
 const targetAtom = atomWithReset<LinkSearchTarget>("all");
 const queryAtom = atom<{
   type: "link";
@@ -39,7 +38,6 @@ const resetAtom = atom<undefined, undefined>(
   () => undefined,
   (_, set) => {
     set(inputAtom, RESET);
-    set(oauthClientIdAtom, RESET);
     set(targetAtom, RESET);
   }
 );

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -57,7 +57,7 @@ const getInputQuery = (input: string, target: LinkSearchTarget) => {
 export function useLinkSearchAtom() {
   const [query, updateQuery] = useAtom(queryAtom);
   const [target, updateTarget] = useAtom(targetAtom);
-  const searchQuery = useAtomValue(searchQueryAtom);
+  const [searchQuery, updateSearchQuery] = useAtom(searchQueryAtom);
   const input = useAtomValue(inputAtom);
   const reset = useUpdateAtom(resetAtom);
 
@@ -80,7 +80,14 @@ export function useLinkSearchAtom() {
     (sort) => updateQuery((query) => ({ ...query, sort, page: 0 })),
     [updateQuery]
   );
-  const onLtiClientClick = useUpdateAtom(oauthClientIdAtom);
+  // const onLtiClientClick = useUpdateAtom(oauthClientIdAtom);
+  const onLtiClientClick: (value: string) => void = useCallback(
+    (value:string) =>  updateSearchQuery((searchQuery) => ({
+      ...searchQuery,
+      oauthClientId: [value],
+    })),
+    [updateSearchQuery]
+  );
 
   useEffect(() => {
     reset();

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -78,7 +78,6 @@ export function useLinkSearchAtom() {
     (sort) => updateQuery((query) => ({ ...query, sort, page: 0 })),
     [updateQuery]
   );
-  // const onLtiClientClick = useUpdateAtom(oauthClientIdAtom);
   const onLtiClientClick: (value: string) => void = useCallback(
     (value: string) =>
       updateSearchQuery((searchQuery) => ({

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -27,7 +27,7 @@ const queryAtom = atom<{
     type: "link",
     text: [get(inputAtom)],
     oauthClientId: [get(oauthClientIdAtom) || []].flat(),
-    linkTitle: [get(inputAtom) || []].flat(),
+    linkTitle: [get(linkTitleAtom) || []].flat(),
     bookName: [get(bookNameAtom) || []].flat(),
     topicName: [get(topicNameAtom) || []].flat(),
   }),
@@ -44,6 +44,7 @@ const resetAtom = atom<undefined, undefined>(
     set(linkTitleAtom, RESET);
     set(bookNameAtom, RESET);
     set(topicNameAtom, RESET);
+    set(targetAtom, RESET);
     set(sortAtom, RESET);
   }
 );
@@ -51,14 +52,32 @@ const resetAtom = atom<undefined, undefined>(
 export function useLinkSearchAtom() {
   const query = useAtomValue(queryAtom);
   const reset = useUpdateAtom(resetAtom);
+
+  // 入力
+  const input = useAtomValue(inputAtom);
   const onSearchSubmit = useUpdateAtom(inputAtom);
-  const onLtiClientClick = useUpdateAtom(oauthClientIdAtom);
-  const onSortChange = useUpdateAtom(sortAtom);
+
+  // フィルター
+  const updateLinkTile = useUpdateAtom(linkTitleAtom);
+  const updateBookName = useUpdateAtom(bookNameAtom);
+  const updateTopicName = useUpdateAtom(topicNameAtom);
   const [target, updateTarget] = useAtom(targetAtom);
   const onSearchTargetChange: (target: LinkSearchTarget) => void = useCallback(
     (target) => updateTarget(target),
     [updateTarget]
   );
+  useEffect(() => {
+    if (target === "linkTitle") {
+      updateLinkTile(input);
+    } else if (target === "bookName") {
+      updateBookName(input);
+    } else if (target === "topicName") {
+      updateTopicName(input);
+    }
+  }, [target, input, updateLinkTile, updateBookName, updateTopicName]);
+
+  const onLtiClientClick = useUpdateAtom(oauthClientIdAtom);
+  const onSortChange = useUpdateAtom(sortAtom);
 
   useEffect(() => {
     reset();

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -7,6 +7,9 @@ type SortOrder = "created" | "reverse-created";
 
 const inputAtom = atomWithReset<string>("");
 const oauthClientIdAtom = atomWithReset<string>(""); // "": すべてのLMS
+const linkAtom = atomWithReset<string>(""); // "": すべてのリンク
+const bookAtom = atomWithReset<string>(""); // "": すべてのブック
+const topicAtom = atomWithReset<string>(""); // "": すべてのトピック
 const sortAtom = atomWithReset<SortOrder>("created");
 const queryAtom = atom<{
   type: "link";
@@ -20,6 +23,9 @@ const queryAtom = atom<{
     type: "link",
     text: [get(inputAtom)],
     oauthClientId: [get(oauthClientIdAtom) || []].flat(),
+    link: [get(linkAtom) || []].flat(),
+    book: [get(bookAtom) || []].flat(),
+    topic: [get(topicAtom) || []].flat(),
   }),
   sort: get(sortAtom),
   perPage: Number.MAX_SAFE_INTEGER,

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -69,10 +69,20 @@ export function useLinkSearchAtom() {
   useEffect(() => {
     if (target === "linkTitle") {
       updateLinkTile(input);
+      updateBookName("");
+      updateTopicName("");
     } else if (target === "bookName") {
       updateBookName(input);
+      updateLinkTile("");
+      updateTopicName("");
     } else if (target === "topicName") {
       updateTopicName(input);
+      updateLinkTile("");
+      updateBookName("");
+    } else {
+      updateTopicName("");
+      updateLinkTile("");
+      updateBookName("");
     }
   }, [target, input, updateLinkTile, updateBookName, updateTopicName]);
 

--- a/types/linkSearchTarget.ts
+++ b/types/linkSearchTarget.ts
@@ -1,0 +1,1 @@
+export type LinkSearchTarget = "all" | "linkTitle" | "bookName" | "topicName";


### PR DESCRIPTION
ref:[#788](https://github.com/npocccties/chibichilo/issues/788)

UIは以下のようにブック検索などと揃えました。
![スクリーンショット 2022-11-13 22 28 13](https://user-images.githubusercontent.com/47715432/201524308-79af2d83-c90d-439a-9b6e-2bdc634ba27d.png)

以下の項目で検索できる
- コース名
- リンクのタイトル
- ブック名
- トピック名

以下の絞り込み検索ができる
- リンクタイトル
- ブック
- トピック
