### PR TITLE
fix: 開発用データの外部化

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,14 +2,15 @@
 version: "3"
 services:
   mariadb:
-    image: "mariadb:10.8.3-jammy"
+    image: "mariadb:10.9.4-jammy"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: bitnami_moodle
-    # volumes:
-    #   - ./db.sql:/docker-entrypoint-initdb.d/db.sql # NOTE: SQLファイルによる投入例
+    volumes:
+      - mariadb_data_v10:/var/lib/mysql
   moodle:
-    image: "bitnami/moodle:4.0.2-debian-11-r7"
+    image: ghcr.io/npocccties/chibichilo-moodle
+    build: moodle
     ports: ["8081:8080"]
     environment:
       MOODLE_USERNAME: user
@@ -18,14 +19,19 @@ services:
       MOODLE_DATABASE_USER: root
       BITNAMI_DEBUG: "true"
     depends_on: [mariadb]
+    volumes:
+      - moodle_data_v4:/bitnami/moodle
+      - moodledata_data_v4:/bitnami/moodledata
   db:
-    image: "postgres:14.4-alpine3.16"
+    image: "postgres:15.1-alpine3.16"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports: ["5432:5432"]
+    volumes:
+      - postgres_data_v15:/var/lib/postgresql/data
   app:
-    image: "node:18.12-alpine3.16"
+    image: "node:18.12.1-alpine3.16"
     environment:
       FRONTEND_ORIGIN: "http://localhost:3000"
       SESSION_SECRET: super_secret_characters_for_session
@@ -40,3 +46,8 @@ services:
       - "5555:5555"
       - "8080:8080"
     depends_on: [moodle, db]
+volumes:
+  mariadb_data_v10:
+  moodle_data_v4:
+  moodledata_data_v4:
+  postgres_data_v15:

--- a/moodle/Dockerfile
+++ b/moodle/Dockerfile
@@ -1,0 +1,3 @@
+FROM bitnami/moodle:4.0.2-debian-11-r7
+# NOTE: Fixed AH00023 for macOS with Apple silicon
+RUN echo 'Mutex posixsem' >> /opt/bitnami/apache2/conf/httpd.conf


### PR DESCRIPTION
fixed https://github.com/npocccties/chibichilo/issues/820

この変更でvolumesに永続化されるのでdocker compose down && docker compose up -dしても元の環境に復帰できるようになります。
(もし初期化したい場合は適宜 docker volume rm コマンドを使用するようにしてください) 

volumes
  - mariadb_data_v10: mariadb サービスの /var/lib/mysql の volume
  - moodle_data_v4: moodle サービスの /bitnami/moodle の volume
  - moodledata_data_v4: moodle サービスの /bitnami/moodledata の volume
  - postgres_data_v15: db サービスの /var/lib/postgresql/data の voume

加えて https://github.com/npocccties/chibichilo/issues/797 の AH00023問題に関する修正を moodle/Dockerfile にて含めています。