### PR TITLE
feat:LTIリンクのソート項目を増やす

### DIFF
--- a/components/atoms/SortLinkSelect.stories.tsx
+++ b/components/atoms/SortLinkSelect.stories.tsx
@@ -1,0 +1,5 @@
+export default { title: "atoms/SortLinkSelect" };
+
+import SortLinkSelect from "./SortLinkSelect";
+
+export const Default = () => <SortLinkSelect onSortChange={console.log} />;

--- a/components/atoms/SortLinkSelect.tsx
+++ b/components/atoms/SortLinkSelect.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+import MenuItem from "@mui/material/MenuItem";
+import type { SelectChangeEvent } from "@mui/material/Select";
+import Select from "$atoms/Select";
+import type { SortLinkOrder } from "$server/models/sortLinkOrder";
+
+const options: ReadonlyArray<{
+  value: SortLinkOrder;
+  label: string;
+}> = [
+  {
+    value: "updated",
+    label: "更新日順（新しい）",
+  },
+  {
+    value: "reverse-updated",
+    label: "更新日順（古い）",
+  },
+  {
+    value: "created",
+    label: "作成日順（新しい）",
+  },
+  {
+    value: "reverse-created",
+    label: "作成日順（古い）",
+  },
+  {
+    value: "title",
+    label: "名前順（A-Z）",
+  },
+  {
+    value: "reverse-title",
+    label: "名前順（Z-A）",
+  },
+];
+
+type Props<Order extends SortLinkOrder> = Parameters<typeof Select>[0] & {
+  onSortChange?(value: Order): void;
+};
+
+export default function SortLinkSelect<Order extends SortLinkOrder>(
+  props: Props<Order>
+) {
+  const { onSortChange, ...other } = props;
+  const defaultValue = options[0].value;
+  const handleChange = useCallback(
+    (event: SelectChangeEvent<unknown>) => {
+      onSortChange?.(event.target.value as Order);
+    },
+    [onSortChange]
+  );
+  return (
+    <Select
+      defaultValue={defaultValue}
+      disabled={!onSortChange}
+      onChange={handleChange}
+      {...other}
+    >
+      {options.map((option) => (
+        <MenuItem key={option.value} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}

--- a/components/templates/Courses.tsx
+++ b/components/templates/Courses.tsx
@@ -6,7 +6,7 @@ import Button from "@mui/material/Button";
 import groupBy from "just-group-by";
 import ContentTypeIndicator from "$atoms/ContentTypeIndicator";
 import Container from "$atoms/Container";
-import SortSelect from "$atoms/SortSelect";
+import SortLinkSelect from "$atoms/SortLinkSelect";
 import CourseSearchTextField from "$molecules/CourseSearchTextField";
 import ActionHeader from "$organisms/ActionHeader";
 import ActionFooter from "$organisms/ActionFooter";
@@ -76,19 +76,7 @@ export default function Courses({
     <Container twoColumns maxWidth="xl">
       <ActionHeader sx={{ gridArea: "action-header" }}>
         <ContentTypeIndicator type="course" />
-        <SortSelect<"created" | "reverse-created">
-          onSortChange={linkSearchProps.onSortChange}
-          options={[
-            {
-              value: "created",
-              label: "作成日順（新しい）",
-            },
-            {
-              value: "reverse-created",
-              label: "作成日順（古い）",
-            },
-          ]}
-        />
+        <SortLinkSelect onSortChange={linkSearchProps.onSortChange} />
         <CourseSearchTextField
           label="検索"
           target={linkSearchProps.target}

--- a/server/models/sortLinkOrder.ts
+++ b/server/models/sortLinkOrder.ts
@@ -1,0 +1,12 @@
+const sortLinkOrder = [
+  "updated",
+  "reverse-updated",
+  "created",
+  "reverse-created",
+  "title",
+  "reverse-title",
+] as const;
+
+export type SortLinkOrder = typeof sortLinkOrder[number];
+
+export default sortLinkOrder;

--- a/server/utils/linkSearch/linkSearch.ts
+++ b/server/utils/linkSearch/linkSearch.ts
@@ -15,6 +15,7 @@ import { AuthorSchema } from "$server/models/author";
 import prisma from "$server/utils/prisma";
 import createLinkScope from "./createLinkScope";
 import createScopes from "../search/createScopes";
+import makeSortLinkOrderQuery from "../makeSortLinkOrderQuery";
 
 function linkToLinkSchema(
   link: LtiResourceLink & {
@@ -171,9 +172,7 @@ async function linkSearch(
         },
       },
     },
-    orderBy: {
-      createdAt: sort === "reverse-created" ? "asc" : "desc",
-    },
+    orderBy: makeSortLinkOrderQuery(sort),
     skip: page * perPage,
     take: perPage,
   });

--- a/server/utils/makeSortLinkOrderQuery.ts
+++ b/server/utils/makeSortLinkOrderQuery.ts
@@ -1,0 +1,21 @@
+import sortLinkOrder from "$server/models/sortLinkOrder";
+
+function makeSortLinkOrderQuery(sort: string) {
+  switch (sortLinkOrder.find((order) => order === sort)) {
+    default:
+    case "updated":
+      return { updatedAt: "desc" as const };
+    case "reverse-updated":
+      return { updatedAt: "asc" as const };
+    case "created":
+      return { createdAt: "desc" as const };
+    case "reverse-created":
+      return { createdAt: "asc" as const };
+    case "title":
+      return { title: "asc" as const };
+    case "reverse-title":
+      return { title: "desc" as const };
+  }
+}
+
+export default makeSortLinkOrderQuery;

--- a/server/validators/linkSearchProps.ts
+++ b/server/validators/linkSearchProps.ts
@@ -7,7 +7,14 @@ export const LinkSearchProps = {
     q: { type: "string" },
     sort: {
       type: "string",
-      enum: ["created", "reverse-created"],
+      enum: [
+        "created",
+        "reverse-created",
+        "updated",
+        "reverse-updated",
+        "title",
+        "reverse-title",
+      ],
     },
     page: { type: "number" },
     per_page: { type: "number" },

--- a/store/linkSearch.ts
+++ b/store/linkSearch.ts
@@ -6,8 +6,7 @@ import { stringify } from "$utils/linkSearch/parser";
 import type { AuthorFilterType } from "$server/models/authorFilter";
 import type { LinkSearchTarget } from "$types/linkSearchTarget";
 import type { LinkSearchQuery } from "$server/models/link/searchQuery";
-
-type SortOrder = "created" | "reverse-created";
+import type { SortLinkOrder } from "$server/models/sortLinkOrder";
 
 const inputAtom = atomWithReset<string>("");
 const targetAtom = atomWithReset<LinkSearchTarget>("all");
@@ -15,14 +14,14 @@ const queryAtom = atom<{
   type: "link";
   q: string;
   filter: AuthorFilterType;
-  sort: SortOrder;
+  sort: SortLinkOrder;
   perPage: number;
   page: number;
 }>({
   type: "link",
   q: "",
   filter: "self",
-  sort: "created",
+  sort: "updated",
   perPage: Number.MAX_SAFE_INTEGER,
   page: 0,
 });
@@ -74,7 +73,7 @@ export function useLinkSearchAtom() {
     (target) => updateTarget(target),
     [updateTarget]
   );
-  const onSortChange: (sort: SortOrder) => void = useCallback(
+  const onSortChange: (sort: SortLinkOrder) => void = useCallback(
     (sort) => updateQuery((query) => ({ ...query, sort, page: 0 })),
     [updateQuery]
   );

--- a/utils/courses/useLinks.ts
+++ b/utils/courses/useLinks.ts
@@ -3,14 +3,13 @@ import type { ApiV2LtiSearchGetSortEnum } from "$openapi";
 import type { LinkSearchResultSchema } from "$server/models/link/search";
 import { useLinkSearchAtom } from "$store/linkSearch";
 import { api } from "$utils/api";
-
-type SortOrder = "created" | "reverse-created";
+import type { SortLinkOrder } from "$server/models/sortLinkOrder";
 
 const key = "/api/v2/lti/search";
 
 async function fetchLinks(
   _: typeof key,
-  query: { q: string; sort: SortOrder; perPage: number; page: number }
+  query: { q: string; sort: SortLinkOrder; perPage: number; page: number }
 ): Promise<LinkSearchResultSchema> {
   const res: LinkSearchResultSchema = (await api.apiV2LtiSearchGet({
     ...query,
@@ -32,7 +31,7 @@ export default useLinks;
 
 export function revalidateLinks(query: {
   q: string;
-  sort: SortOrder;
+  sort: SortLinkOrder;
   perPage: number;
   page: number;
 }): Promise<LinkSearchResultSchema> {


### PR DESCRIPTION
関連：#789
項目はブックなどと合わせて、以下のように
- 更新日時
- 作成日時
- タイトル
でのソートを追加しました。

![スクリーンショット 2022-11-21 23 19 35](https://user-images.githubusercontent.com/47715432/203078064-7cb365b4-37be-40ba-948a-48b540a076ea.png)
