### PR TITLE
fix: 字幕が複数表示される不具合の修正

### DIFF
--- a/components/organisms/Video/VideoJs.tsx
+++ b/components/organisms/Video/VideoJs.tsx
@@ -52,17 +52,23 @@ function VideoJs({ element, player, tracks }: Props) {
       current.removeChild(element);
     };
   }, [element, player, classes]);
-  const tracksRef = useRef<HTMLTrackElement[]>([]);
   useEffect(() => {
     if (!tracks || tracks.length === 0) return;
+    const trackElements: HTMLTrackElement[] = [];
     player.ready(() => {
-      tracksRef.current.forEach((track) => {
-        player.removeRemoteTextTrack(track);
-      });
-      tracksRef.current = (tracks
-        ?.map((track) => track && player.addRemoteTextTrack(track, false))
-        .filter(Boolean) ?? []) as HTMLTrackElement[];
+      (
+        (tracks ?? [])
+          .map((track) => track && player.addRemoteTextTrack(track, false))
+          .filter(Boolean) as HTMLTrackElement[]
+      ).forEach((track) => trackElements.push(track));
     });
+    return () => {
+      player.ready(() => {
+        trackElements.forEach((track) => {
+          player.removeRemoteTextTrack(track);
+        });
+      });
+    };
   }, [player, tracks]);
   return <div ref={ref} />;
 }


### PR DESCRIPTION
ref #860

Ref オブジェクトが機能しておらず player.removeRemoteTextTrack() が呼び出されていない不具合がありました。Refオブジェクトを廃止し、代わりに通常の変数とReact.useEffect()のクリーンナップ処理を使用することでその不具合を修正します。
