### PR TITLE
fix: キーワードが削除されない不具合の修正

### DIFF
--- a/server/utils/book/updateBook.ts
+++ b/server/utils/book/updateBook.ts
@@ -34,8 +34,8 @@ async function updateBook(
   }
 
   const timeRequired = sections && (await aggregateTimeRequired({ sections }));
-  const keywords = await prisma.keyword.findMany({
-    where: { books: { every: { id } } },
+  const keywordsBeforeUpdate = await prisma.keyword.findMany({
+    where: { books: { some: { id } } },
   });
   const update = prisma.book.update({
     where: { id },
@@ -44,7 +44,7 @@ async function updateBook(
       ...(timeRequired && { timeRequired }),
       keywords: {
         ...keywordsConnectOrCreateInput(book.keywords ?? []),
-        ...keywordsDisconnectInput(keywords, book.keywords ?? []),
+        ...keywordsDisconnectInput(keywordsBeforeUpdate, book.keywords ?? []),
       },
       updatedAt: new Date(),
     },

--- a/server/utils/topic/upsertTopic.ts
+++ b/server/utils/topic/upsertTopic.ts
@@ -30,14 +30,14 @@ async function upsertTopic(
   { id, ...topic }: TopicProps & Pick<Topic, "id">,
   ip: string
 ): Promise<TopicSchema | undefined> {
-  const keywords = await prisma.keyword.findMany({
-    where: { topics: { every: { id } } },
+  const keywordsBeforeUpdate = await prisma.keyword.findMany({
+    where: { topics: { some: { id } } },
   });
   const created = await prisma.topic.upsert({
     ...topicsWithResourcesArg,
     where: { id },
     create: topicCreateInput(authorId, topic),
-    update: topicUpdateInput(topic, keywords),
+    update: topicUpdateInput(topic, keywordsBeforeUpdate),
   });
 
   if (!created) return;


### PR DESCRIPTION
ref #673
複数のトピックや複数のブックに同じキーワードが設定されているとき更新前のキーワードの取得処理が機能せず期待通り削除されない不具合があった。更新前のキーワードの取得処理を修正しキーワードを削除できるように修正します。
