### PR TITLE
feat:ブック詳細のデザイン更新

### DIFF
--- a/components/organisms/BookInfo.tsx
+++ b/components/organisms/BookInfo.tsx
@@ -2,8 +2,8 @@ import Card from "@mui/material/Card";
 import Markdown from "$atoms/Markdown";
 import type { BookSchema } from "$server/models/book";
 import KeywordChip from "$atoms/KeywordChip";
-import makeStyles from "@mui/styles/makeStyles";
 import useCardStyle from "$styles/card";
+import { Box } from "@mui/material";
 
 type Props = {
   className?: string;
@@ -11,35 +11,23 @@ type Props = {
   book: BookSchema;
 };
 
-const useStyles = makeStyles((theme) => ({
-  keywords: {
-    display: "flex",
-    listStyle: "none",
-    padding: 0,
-    margin: 0,
-    marginBottom: theme.spacing(0.75),
-    "& > *": {
-      marginRight: theme.spacing(0.5),
-    },
-  },
-}));
-
 export default function BookInfo({ className, id, book }: Props) {
-  const classes = useStyles();
   const cardClasses = useCardStyle();
 
   return (
     <Card className={className} classes={cardClasses} id={id}>
       {book.keywords && (
-        <ul className={classes.keywords}>
+        <Box sx={{ my: 1 }}>
           {book.keywords.map((keyword) => {
             return (
-              <li key={keyword.id}>
-                <KeywordChip keyword={keyword} />
-              </li>
+              <KeywordChip
+                key={keyword.id}
+                keyword={keyword}
+                sx={{ mr: 0.5, maxWidth: "260px" }}
+              />
             );
           })}
-        </ul>
+        </Box>
       )}
       {book.description && <Markdown>{book.description}</Markdown>}
     </Card>

--- a/components/organisms/BookInfo.tsx
+++ b/components/organisms/BookInfo.tsx
@@ -17,7 +17,7 @@ export default function BookInfo({ className, id, book }: Props) {
   return (
     <Card className={className} classes={cardClasses} id={id}>
       {book.keywords && (
-        <Box sx={{ my: 1 }}>
+        <Box sx={{ mb: 1 }}>
           {book.keywords.map((keyword) => {
             return (
               <KeywordChip

--- a/components/organisms/BookInfo.tsx
+++ b/components/organisms/BookInfo.tsx
@@ -1,7 +1,6 @@
 import Card from "@mui/material/Card";
 import Markdown from "$atoms/Markdown";
 import type { BookSchema } from "$server/models/book";
-import React from "react";
 import KeywordChip from "$atoms/KeywordChip";
 import makeStyles from "@mui/styles/makeStyles";
 import useCardStyle from "$styles/card";

--- a/components/organisms/BookInfo.tsx
+++ b/components/organisms/BookInfo.tsx
@@ -1,11 +1,10 @@
 import Card from "@mui/material/Card";
-import { grey } from "@mui/material/colors";
-import DescriptionList from "$atoms/DescriptionList";
 import Markdown from "$atoms/Markdown";
-import useCardStyle from "$styles/card";
-import languages from "$utils/languages";
-import formatInterval from "$utils/formatInterval";
 import type { BookSchema } from "$server/models/book";
+import React from "react";
+import KeywordChip from "$atoms/KeywordChip";
+import makeStyles from "@mui/styles/makeStyles";
+import useCardStyle from "$styles/card";
 
 type Props = {
   className?: string;
@@ -13,25 +12,36 @@ type Props = {
   book: BookSchema;
 };
 
+const useStyles = makeStyles((theme) => ({
+  keywords: {
+    display: "flex",
+    listStyle: "none",
+    padding: 0,
+    margin: 0,
+    marginBottom: theme.spacing(0.75),
+    "& > *": {
+      marginRight: theme.spacing(0.5),
+    },
+  },
+}));
+
 export default function BookInfo({ className, id, book }: Props) {
+  const classes = useStyles();
   const cardClasses = useCardStyle();
 
   return (
     <Card className={className} classes={cardClasses} id={id}>
-      <DescriptionList
-        color={grey[900]}
-        sx={{ mb: 0.5 }}
-        value={[
-          {
-            key: "学習時間",
-            value: formatInterval(0, (book.timeRequired ?? 0) * 1000),
-          },
-          {
-            key: "教材の主要な言語",
-            value: languages[book.language],
-          },
-        ]}
-      />
+      {book.keywords && (
+        <ul className={classes.keywords}>
+          {book.keywords.map((keyword) => {
+            return (
+              <li key={keyword.id}>
+                <KeywordChip keyword={keyword} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
       {book.description && <Markdown>{book.description}</Markdown>}
     </Card>
   );

--- a/components/organisms/Sections.stories.tsx
+++ b/components/organisms/Sections.stories.tsx
@@ -8,6 +8,7 @@ export default { title: "organisms/Sections", component: Sections };
 const activityBySections = sections
   .flatMap(({ topics }) => topics)
   .map((topic) => ({
+    id: topic.id,
     topic,
     learner: user,
     completed: Math.floor(Math.random() * 2) === 0,

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -26,7 +26,6 @@ import type { ButtonProps } from "@mui/material";
 import { Button } from "@mui/material";
 import { learningStatus } from "$theme/colors";
 
-
 const hidden = css({
   m: 0,
   width: 0,

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -27,11 +27,13 @@ import { authors } from "$utils/descriptionList";
 import extractNumberFromPx from "$utils/extractNumberFromPx";
 import sumPixels from "$utils/sumPixels";
 import type { ActivitySchema } from "$server/models/activity";
+import Chip from "@mui/material/Chip";
+import formatInterval from "$utils/formatInterval";
 
 const useStyles = makeStyles((theme) => ({
   header: {
     display: "flex",
-    alignItems: "baseline",
+    alignItems: "center",
     margin: 0,
     width: "100%",
     "& > *": {
@@ -174,6 +176,12 @@ export default function Book(props: Props) {
           >
             {book?.name}
           </Typography>
+          {book?.timeRequired && (
+            <Chip
+              sx={{ mr: 1, mb: 0.5 }}
+              label={`学習時間 ${formatInterval(0, book.timeRequired * 1000)}`}
+            />
+          )}
           {book?.shared && <SharedIndicator />}
           {isInstructor &&
             book &&


### PR DESCRIPTION
ブック詳細/トピック詳細/タイムライン周りのデザイン更新
https://github.com/npocccties/chibichilo/issues/876

のブック詳細部分の修正です。

- ブック詳細の学習時間は外に出し，見た目もトピック学習時間と同じにする
- ブック詳細にある「教材の主要な言語」は消す
- ブック詳細に「キーワード」を追加する


![スクリーンショット 0005-03-26 16 02 31](https://user-images.githubusercontent.com/47715432/227760816-57bba065-8bb1-4606-a299-530adfdfefc4.png)