### PR TITLE
feat:トピック詳細/タイムライン周りのデザイン更新

### DIFF
--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -1,16 +1,8 @@
 import { useMemo } from "react";
 import type { TopicSchema } from "$server/models/topic";
-import Typography from "@mui/material/Typography";
-import Chip from "@mui/material/Chip";
 import { useTheme } from "@mui/material/styles";
 import Video from "$organisms/Video";
-import DescriptionList from "$atoms/DescriptionList";
-import License from "$atoms/License";
-import Markdown from "$atoms/Markdown";
 import useSticky from "$utils/useSticky";
-import getLocaleDateString from "$utils/getLocaleDateString";
-import { authors } from "$utils/descriptionList";
-import formatInterval from "$utils/formatInterval";
 import { isVideoResource } from "$utils/videoResource";
 import { gray } from "$theme/colors";
 import type { ActivitySchema } from "$server/models/activity";
@@ -57,43 +49,6 @@ export default function TopicViewerContent({
           onEnded={onEnded}
         />
       )}
-      <header>
-        <Typography
-          sx={{
-            display: "inline-block",
-            verticalAlign: "middle",
-            mr: 1,
-            mb: 0.5,
-          }}
-          variant="h6"
-        >
-          {topic.name}
-        </Typography>
-        <Chip
-          sx={{ mr: 1, mb: 0.5 }}
-          label={`学習時間 ${formatInterval(0, topic.timeRequired * 1000)}`}
-        />
-        {topic.license && (
-          <License sx={{ mr: 1, mb: 0.5 }} license={topic.license} />
-        )}
-      </header>
-      <DescriptionList
-        inline
-        value={[
-          {
-            key: "作成日",
-            value: getLocaleDateString(topic.createdAt, "ja"),
-          },
-          {
-            key: "更新日",
-            value: getLocaleDateString(topic.updatedAt, "ja"),
-          },
-          ...authors(topic),
-        ]}
-      />
-      <article>
-        <Markdown>{topic.description}</Markdown>
-      </article>
     </>
   );
 }

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -108,7 +108,8 @@ function TabPanel({
     <div
       className={className}
       role="tabpanel"
-      id={`tabpanel=${index}`}
+      id={`panel-${index}`}
+      aria-labelledby={`tab-${index}`}
       aria-hidden={value !== index}
       {...other}
     >
@@ -285,23 +286,24 @@ export default function Video({
           />
         ))}
         <Tabs
+          aria-label="トピックビデオの詳細情報"
           className={tabsStyle}
           indicatorColor="primary"
           value={tabIndex}
           onChange={handleTabIndexChange}
         >
-          <Tab label="解説" id="tabpanel-0" aria-controls="tabpanel-0" />
+          <Tab label="解説" id="tab-0" aria-controls="panel-0" />
           {isStudent && (
             <Tab
               label="視聴時間詳細"
-              id="tabpanel-1"
-              aria-controls="tabpanel-1"
+              id="tab-1"
+              aria-controls="panel-1"
             />
           )}
           <Tab
             label="トピックの詳細"
-            id={`tabpanel-${isStudent ? 2 : 1}`}
-            aria-controls={`tabpanel-${isStudent ? 2 : 1}`}
+            id={`tab-${isStudent ? 2 : 1}`}
+            aria-controls={`panel-${isStudent ? 2 : 1}`}
           />
         </Tabs>
         <TabPanel value={tabIndex} index={0}>

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -1,14 +1,7 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import usePrevious from "@rooks/use-previous";
 import clsx from "clsx";
 import { css } from "@emotion/css";
-import type { AccordionProps } from "@mui/material/Accordion";
-import MuiAccordion from "@mui/material/Accordion";
-import type { AccordionSummaryProps } from "@mui/material/AccordionSummary";
-import MuiAccordionSummary from "@mui/material/AccordionSummary";
-import type { AccordionDetailsProps } from "@mui/material/AccordionDetails";
-import MuiAccordionDetails from "@mui/material/AccordionDetails";
-import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp";
 
 import type { TopicSchema } from "$server/models/topic";
 import type { VideoResourceSchema } from "$server/models/videoResource";
@@ -23,9 +16,17 @@ import type { ActivitySchema } from "$server/models/activity";
 import { isInstructor, isAdministrator } from "$utils/session";
 import { useSessionAtom } from "$store/session";
 import type { ButtonProps } from "@mui/material";
+import { Chip, Typography } from "@mui/material";
 import { Button } from "@mui/material";
-import { learningStatus } from "$theme/colors";
-
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import { gray, learningStatus } from "$theme/colors";
+import Markdown from "$atoms/Markdown";
+import formatInterval from "$utils/formatInterval";
+import License from "$atoms/License";
+import DescriptionList from "$atoms/DescriptionList";
+import getLocaleDateString from "$utils/getLocaleDateString";
+import { authors } from "$utils/descriptionList";
 
 const hidden = css({
   m: 0,
@@ -48,48 +49,16 @@ const videoStyle = {
   },
 } as const;
 
-const accordion = css({
-  padding: 0,
-  boxShadow: "none",
-  "&:before": {
-    display: "none",
-  },
+const tabsStyle = css({
+  marginBottom: "12px",
+  borderBottom: `1px solid ${gray[300]}`,
 });
 
-function Accordion(props: AccordionProps) {
-  return <MuiAccordion {...props} className={accordion} />;
-}
-
-const accordionSummary = css({
-  padding: 0,
-  flexDirection: "row-reverse",
-  "& .MuiAccordionSummary-expandIconWrapper": {
-    margin: "4px",
-  },
-  "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
-    transform: "rotate(90deg)",
-  },
-});
-
-function AccordionSummary(props: AccordionSummaryProps) {
-  return (
-    <MuiAccordionSummary
-      className={accordionSummary}
-      expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: "0.9rem" }} />}
-      {...props}
-    />
-  );
-}
-
-const accordionDetails = css({
+const timeLineDetail = css({
   display: "flex",
   justifyContent: "center",
-  padding: "0 8px 20px",
+  marginTop: "12px",
 });
-
-function AccordionDetails(props: AccordionDetailsProps) {
-  return <MuiAccordionDetails {...props} className={accordionDetails} />;
-}
 
 const skipButton = css({
   whiteSpace: "nowrap",
@@ -105,6 +74,48 @@ function SkipButton(props: ButtonProps) {
     </Button>
   );
 }
+
+// TODO:atomにコンポーネント化する
+const useTabIndex = () => {
+  const [tabIndex, setTabIndex] = useState(0);
+  const handleTabIndexChange = (
+    _: React.ChangeEvent<unknown>,
+    value: number
+  ) => {
+    setTabIndex(value);
+  };
+
+  return { tabIndex, handleTabIndexChange };
+};
+
+type TabPanelProps = {
+  className?: string;
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+};
+
+function TabPanel({
+  className,
+  children,
+  value,
+  index,
+  ...other
+}: TabPanelProps) {
+  return (
+    <div
+      className={className}
+      role="tabpanel"
+      hidden={value !== index}
+      id={`tabpanel=${index}`}
+      aria-labelledby={`tab-${index}`}
+      {...other}
+    >
+      {value === index && children}
+    </div>
+  );
+}
+// TODO:ここまで
 
 type Props = {
   className?: string;
@@ -252,6 +263,10 @@ export default function Video({
     }
   }, [timeRange, topic?.id, video]);
 
+  const { tabIndex, handleTabIndexChange } = useTabIndex();
+  const isStudent =
+    session && !isInstructor(session) && !isAdministrator(session);
+
   // 動画プレイヤーオブジェクトプールに存在する場合
   if (video.has(String(topic.id))) {
     return (
@@ -268,43 +283,89 @@ export default function Video({
             onEnded={String(topic.id) === id ? onEnded : undefined}
           />
         ))}
-        {session && !isInstructor(session) && !isAdministrator(session) && (
-          <Accordion>
-            <AccordionSummary>視聴時間詳細</AccordionSummary>
-            <AccordionDetails>
-              <SkipButton onClick={handleSkipWatch} />
-              <svg
+        <Tabs
+          className={tabsStyle}
+          indicatorColor="primary"
+          value={tabIndex}
+          onChange={handleTabIndexChange}
+        >
+          <Tab label="解説" />
+          {isStudent && <Tab label="視聴時間詳細" />}
+          <Tab label="トピックの詳細" />
+        </Tabs>
+        <TabPanel value={tabIndex} index={0}>
+          <article>
+            <Markdown>{topic.description}</Markdown>
+          </article>
+        </TabPanel>
+        {isStudent && (
+          <TabPanel value={tabIndex} index={1} className={timeLineDetail}>
+            <SkipButton onClick={handleSkipWatch} />
+            <svg
+              height={20}
+              width={BAR_SIZE}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                x={0}
+                y={0}
                 height={20}
                 width={BAR_SIZE}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  x={0}
-                  y={0}
-                  height={20}
-                  width={BAR_SIZE}
-                  stroke="black"
-                  fill="transparent"
-                />
-                {generateTimeRangeBarValue({
-                  timeRange,
-                  timeRequired: topic.timeRequired,
-                }).map((value) => {
-                  return (
-                    <React.Fragment key={value.id}>
-                      <rect
-                        x={value.positionX}
-                        width={value.width}
-                        height={20}
-                        fill={learningStatus.completed}
-                      />
-                    </React.Fragment>
-                  );
-                })}
-              </svg>
-            </AccordionDetails>
-          </Accordion>
+                stroke="black"
+                fill="transparent"
+              />
+              {generateTimeRangeBarValue({
+                timeRange,
+                timeRequired: topic.timeRequired,
+              }).map((value) => {
+                return (
+                  <React.Fragment key={value.id}>
+                    <rect
+                      x={value.positionX}
+                      width={value.width}
+                      height={20}
+                      fill={learningStatus.completed}
+                    />
+                  </React.Fragment>
+                );
+              })}
+            </svg>
+          </TabPanel>
         )}
+        <TabPanel value={tabIndex} index={isStudent ? 2 : 1}>
+          <Typography
+            sx={{
+              display: "inline-block",
+              verticalAlign: "middle",
+              mr: 1,
+              mb: 0.5,
+            }}
+            variant="h6"
+          >
+            {topic.name}
+          </Typography>
+          <Chip
+            sx={{ mr: 1, mb: 0.5 }}
+            label={`学習時間 ${formatInterval(0, topic.timeRequired * 1000)}`}
+          />
+          {topic.license && (
+            <License sx={{ mr: 1, mb: 0.5 }} license={topic.license} />
+          )}
+          <DescriptionList
+            inline
+            value={[
+              {
+                key: "作成日",
+                value: getLocaleDateString(topic.createdAt, "ja"),
+              },
+              {
+                key: "更新日",
+                value: getLocaleDateString(topic.updatedAt, "ja"),
+              },
+              ...authors(topic),
+            ]}
+          />
+        </TabPanel>
       </>
     );
   }

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -117,9 +117,8 @@ function TabPanel({
     <div
       className={className}
       role="tabpanel"
-      hidden={value !== index}
       id={`tabpanel=${index}`}
-      aria-labelledby={`tab-${index}`}
+      aria-hidden={value !== index}
       {...other}
     >
       {value === index && children}
@@ -300,9 +299,19 @@ export default function Video({
           value={tabIndex}
           onChange={handleTabIndexChange}
         >
-          <Tab label="解説" />
-          {isStudent && <Tab label="視聴時間詳細" />}
-          <Tab label="トピックの詳細" />
+          <Tab label="解説" id="tabpanel-0" aria-controls="tabpanel-0" />
+          {isStudent && (
+            <Tab
+              label="視聴時間詳細"
+              id="tabpanel-1"
+              aria-controls="tabpanel-1"
+            />
+          )}
+          <Tab
+            label="トピックの詳細"
+            id={`tabpanel-${isStudent ? 2 : 1}`}
+            aria-controls={`tabpanel-${isStudent ? 2 : 1}`}
+          />
         </Tabs>
         <TabPanel value={tabIndex} index={0}>
           <article>

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -294,11 +294,7 @@ export default function Video({
         >
           <Tab label="解説" id="tab-0" aria-controls="panel-0" />
           {isStudent && (
-            <Tab
-              label="視聴時間詳細"
-              id="tab-1"
-              aria-controls="panel-1"
-            />
+            <Tab label="視聴時間詳細" id="tab-1" aria-controls="panel-1" />
           )}
           <Tab
             label="トピックの詳細"

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -22,9 +22,10 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import { gray, learningStatus } from "$theme/colors";
 import Markdown from "$atoms/Markdown";
-import formatInterval from "$utils/formatInterval";
+import KeywordChip from "$atoms/KeywordChip";
 import License from "$atoms/License";
 import DescriptionList from "$atoms/DescriptionList";
+import formatInterval from "$utils/formatInterval";
 import getLocaleDateString from "$utils/getLocaleDateString";
 import { authors } from "$utils/descriptionList";
 
@@ -58,6 +59,16 @@ const timeLineDetail = css({
   display: "flex",
   justifyContent: "center",
   marginTop: "12px",
+});
+
+const keywords = css({
+  display: "flex",
+  listStyle: "none",
+  padding: 0,
+  margin: 0,
+  "& > *": {
+    marginRight: "4px",
+  },
 });
 
 const skipButton = css({
@@ -365,6 +376,17 @@ export default function Video({
               ...authors(topic),
             ]}
           />
+          {topic.keywords && (
+            <ul className={keywords}>
+              {topic.keywords.map((keyword) => {
+                return (
+                  <li key={keyword.id}>
+                    <KeywordChip keyword={keyword} />
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </TabPanel>
       </>
     );

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -16,6 +16,7 @@ import type { ActivitySchema } from "$server/models/activity";
 import { isInstructor, isAdministrator } from "$utils/session";
 import { useSessionAtom } from "$store/session";
 import type { ButtonProps } from "@mui/material";
+import { Box } from "@mui/material";
 import { Chip, Typography } from "@mui/material";
 import { Button } from "@mui/material";
 import Tabs from "@mui/material/Tabs";
@@ -59,16 +60,6 @@ const timeLineDetail = css({
   display: "flex",
   justifyContent: "center",
   marginTop: "12px",
-});
-
-const keywords = css({
-  display: "flex",
-  listStyle: "none",
-  padding: 0,
-  margin: 0,
-  "& > *": {
-    marginRight: "4px",
-  },
 });
 
 const skipButton = css({
@@ -386,15 +377,17 @@ export default function Video({
             ]}
           />
           {topic.keywords && (
-            <ul className={keywords}>
+            <Box sx={{ my: 1 }}>
               {topic.keywords.map((keyword) => {
                 return (
-                  <li key={keyword.id}>
-                    <KeywordChip keyword={keyword} />
-                  </li>
+                  <KeywordChip
+                    key={keyword.id}
+                    keyword={keyword}
+                    sx={{ mr: 0.5, maxWidth: "260px" }}
+                  />
                 );
               })}
-            </ul>
+            </Box>
           )}
         </TabPanel>
       </>


### PR DESCRIPTION
ブック詳細/トピック詳細/タイムライン周りのデザイン更新
https://github.com/npocccties/chibichilo/issues/876

のトピック詳細部分の修正です。

- トピック詳細に「キーワード」を追加する
- トピックエリアは，Tab UIパターンで | 解説 | 視聴時間詳細 | トピックの詳細 |で切り替えるようにする

![スクリーンショット 2023-03-26 22 57 48](https://user-images.githubusercontent.com/47715432/227780755-d7a2a6c3-6ab7-44c0-89c0-cdfd5180c5a5.png)

![スクリーンショット 2023-03-26 22 57 58](https://user-images.githubusercontent.com/47715432/227780761-93b8945b-65bb-481e-aacb-42f0414658d3.png)

![スクリーンショット 2023-03-26 22 58 07](https://user-images.githubusercontent.com/47715432/227780766-1baecfba-ddf9-4631-a4cd-af2fddc32c94.png)

