### PR TITLE
ブック編集画面/リリース画面でのボタンの配置

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -97,11 +97,9 @@ const AccordionDetails = styled((props: AccordionDetailsProps) => (
 const label = {
   create: {
     submit: "作成",
-    submitWithLink: "作成したブックを配信",
   },
   update: {
     submit: "更新",
-    submitWithLink: "更新したブックを配信",
   },
 } as const;
 
@@ -109,13 +107,11 @@ type Props = {
   book?: BookSchema;
   topics?: TopicSchema[];
   id?: string;
-  linked?: boolean;
   className?: string;
   variant?: "create" | "update";
   onSubmit?: (book: BookPropsWithSubmitOptions) => void;
   onAuthorsUpdate(authors: AuthorSchema[]): void;
   onAuthorSubmit(author: Pick<AuthorSchema, "email">): void;
-  onReleaseButtonClick?: () => void;
 };
 
 export default function BookForm({
@@ -123,12 +119,10 @@ export default function BookForm({
   topics,
   className,
   id,
-  linked = false,
   variant = "create",
   onSubmit = () => undefined,
   onAuthorsUpdate,
   onAuthorSubmit,
-  onReleaseButtonClick,
 }: Props) {
   const cardClasses = useCardStyles();
   const classes = useStyles();
@@ -333,7 +327,7 @@ export default function BookForm({
       <Button variant="contained" color="primary" type="submit">
         {label[variant].submit}
       </Button>
-      {!linked && (
+      {variant === "create" && (
         <FormControlLabel
           className={classes.marginLeft}
           label="コースへ配信"
@@ -347,15 +341,6 @@ export default function BookForm({
             />
           }
         />
-      )}
-      {variant !== "create" && typeof onReleaseButtonClick !== "undefined" && (
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={onReleaseButtonClick}
-        >
-          リリース
-        </Button>
       )}
     </Card>
   );

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -1,18 +1,14 @@
-import type { Story } from "@storybook/react";
+import type { StoryObj } from "@storybook/react";
 import BookEdit from "./BookEdit";
 import { book } from "samples";
 
 export default {
-  title: "templates/BookEdit",
   component: BookEdit,
   parameters: { layout: "fullscreen" },
 };
 
-const Template: Story<Parameters<typeof BookEdit>[0]> = (args) => {
-  return <BookEdit {...args} isContentEditable={() => true} />;
-};
-
-export const Default = Template.bind({});
-Default.args = {
-  book,
+export const Default: StoryObj<typeof BookEdit> = {
+  args: {
+    book,
+  },
 };

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -1,10 +1,10 @@
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import Box from "@mui/material/Box";
 import makeStyles from "@mui/styles/makeStyles";
+import LinkSwitch from "$atoms/LinkSwitch";
 import SectionsEdit from "$organisms/SectionsEdit";
 import BookForm from "$organisms/BookForm";
 import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
@@ -57,7 +57,7 @@ type Props = {
   onBookImportClick(): void;
   onAuthorsUpdate(authors: AuthorSchema[]): void;
   onAuthorSubmit(author: Pick<AuthorSchema, "email">): void;
-  onLinkButtonClick(): void;
+  onLinkSwitchClick(checked: boolean): void;
   onReleaseButtonClick(): void;
   isContentEditable?: IsContentEditable;
   linked?: boolean;
@@ -75,10 +75,10 @@ export default function BookEdit({
   onBookImportClick,
   onAuthorsUpdate,
   onAuthorSubmit,
-  onLinkButtonClick,
+  onLinkSwitchClick,
   onReleaseButtonClick,
   isContentEditable,
-  linked = false,
+  linked,
 }: Props) {
   const classes = useStyles();
   const confirm = useConfirm();
@@ -140,15 +140,13 @@ export default function BookEdit({
           gap: 2,
         }}
       >
-        <Button
-          size="small"
-          color="primary"
-          onClick={onLinkButtonClick}
-          disabled={linked}
-        >
-          <LinkOutlinedIcon />
+        <Typography component="label" variant="caption">
+          <LinkSwitch
+            defaultChecked={linked}
+            onChange={(_, checked) => onLinkSwitchClick(checked)}
+          />
           コースへ配信
-        </Button>
+        </Typography>
         <Button size="small" color="primary" onClick={onReleaseButtonClick}>
           <PeopleOutlinedIcon />
           リリース

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -1,6 +1,9 @@
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
+import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
+import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
+import Box from "@mui/material/Box";
 import makeStyles from "@mui/styles/makeStyles";
 import SectionsEdit from "$organisms/SectionsEdit";
 import BookForm from "$organisms/BookForm";
@@ -54,6 +57,7 @@ type Props = {
   onBookImportClick(): void;
   onAuthorsUpdate(authors: AuthorSchema[]): void;
   onAuthorSubmit(author: Pick<AuthorSchema, "email">): void;
+  onLinkButtonClick(): void;
   onReleaseButtonClick(): void;
   isContentEditable?: IsContentEditable;
   linked?: boolean;
@@ -71,6 +75,7 @@ export default function BookEdit({
   onBookImportClick,
   onAuthorsUpdate,
   onAuthorSubmit,
+  onLinkButtonClick,
   onReleaseButtonClick,
   isContentEditable,
   linked = false,
@@ -123,17 +128,36 @@ export default function BookEdit({
       <BookForm
         className={classes.content}
         book={book}
-        linked={linked}
         variant="update"
         onSubmit={onSubmit}
         onAuthorsUpdate={onAuthorsUpdate}
         onAuthorSubmit={onAuthorSubmit}
-        onReleaseButtonClick={onReleaseButtonClick}
       />
-      <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
-        <DeleteOutlinedIcon />
-        ブックを削除
-      </Button>
+      <Box
+        className="book-edit-row"
+        sx={{
+          display: "flex",
+          gap: 2,
+        }}
+      >
+        <Button
+          size="small"
+          color="primary"
+          onClick={onLinkButtonClick}
+          disabled={linked}
+        >
+          <LinkOutlinedIcon />
+          コースへ配信
+        </Button>
+        <Button size="small" color="primary" onClick={onReleaseButtonClick}>
+          <PeopleOutlinedIcon />
+          リリース
+        </Button>
+        <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
+          <DeleteOutlinedIcon />
+          ブックを削除
+        </Button>
+      </Box>
       {previewTopic && (
         <TopicPreviewDialog {...dialogProps} topic={previewTopic} />
       )}

--- a/components/templates/BookNew.tsx
+++ b/components/templates/BookNew.tsx
@@ -68,13 +68,13 @@ export default function BookNew({
           は必須項目です
         </Typography>
       </Typography>
-      {forkFrom && (
+      {forkFrom && forkFrom.length > 0 && (
         <Alert className={classes.alert} severity="info">
           {forkFrom.map(({ name }) => `${name} さん`).join("、")}
           のブックをフォークしようとしています
         </Alert>
       )}
-      {topics && (
+      {topics && topics.length > 0 && (
         <Alert className={classes.alert} severity="info">
           以下のトピックを追加します
           <ul>

--- a/components/templates/ReleasedBook.tsx
+++ b/components/templates/ReleasedBook.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
+import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import ForkOutlinedIcon from "@mui/icons-material/ForkRightOutlined";
 import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
@@ -13,6 +14,8 @@ import ReleasedBookCard, {
 } from "$organisms/ReleasedBookCard";
 
 type Props = ReleasedBookCardProps & {
+  linked?: boolean;
+  onLinkButtonClick(): void;
   onForkButtonClick(book: Pick<BookSchema, "id">): void;
   onReleaseEditButtonClick(book: Pick<BookSchema, "id">): void;
   onDeleteButtonClick(book: Pick<BookSchema, "id">): void;
@@ -21,6 +24,8 @@ type Props = ReleasedBookCardProps & {
 function ReleasedBook(props: Props) {
   const {
     book,
+    linked = false,
+    onLinkButtonClick: link,
     onForkButtonClick: fork,
     onReleaseEditButtonClick: edit,
     onDeleteButtonClick: del,
@@ -70,6 +75,10 @@ function ReleasedBook(props: Props) {
           gap: 2,
         }}
       >
+        <Button size="small" color="primary" onClick={link} disabled={linked}>
+          <LinkOutlinedIcon />
+          コースへ配信
+        </Button>
         <Button size="small" color="primary" onClick={handlers.fork}>
           <ForkOutlinedIcon />
           フォーク

--- a/components/templates/ReleasedBook.tsx
+++ b/components/templates/ReleasedBook.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import ForkOutlinedIcon from "@mui/icons-material/ForkRightOutlined";
 import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import Box from "@mui/material/Box";
 import { useConfirm } from "material-ui-confirm";
+import LinkSwitch from "$atoms/LinkSwitch";
 import Container from "$atoms/Container";
 import type { BookSchema } from "$server/models/book";
 import ReleasedBookCard, {
@@ -15,7 +15,7 @@ import ReleasedBookCard, {
 
 type Props = ReleasedBookCardProps & {
   linked?: boolean;
-  onLinkButtonClick(): void;
+  onLinkSwitchClick(checked: boolean): void;
   onForkButtonClick(book: Pick<BookSchema, "id">): void;
   onReleaseEditButtonClick(book: Pick<BookSchema, "id">): void;
   onDeleteButtonClick(book: Pick<BookSchema, "id">): void;
@@ -25,7 +25,7 @@ function ReleasedBook(props: Props) {
   const {
     book,
     linked = false,
-    onLinkButtonClick: link,
+    onLinkSwitchClick: link,
     onForkButtonClick: fork,
     onReleaseEditButtonClick: edit,
     onDeleteButtonClick: del,
@@ -75,10 +75,13 @@ function ReleasedBook(props: Props) {
           gap: 2,
         }}
       >
-        <Button size="small" color="primary" onClick={link} disabled={linked}>
-          <LinkOutlinedIcon />
+        <Typography component="label" variant="caption">
+          <LinkSwitch
+            defaultChecked={linked}
+            onChange={(_, checked) => link(checked)}
+          />
           コースへ配信
-        </Button>
+        </Typography>
         <Button size="small" color="primary" onClick={handlers.fork}>
           <ForkOutlinedIcon />
           フォーク

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -89,8 +89,8 @@ function Edit({ bookId, context }: Query) {
   async function handleReleaseButtonClick() {
     return router.push(pagesPath.book.release.$url({ query }));
   }
-  async function onLinkButtonClick() {
-    await handleBookLink({ id: bookId });
+  async function onLinkSwitchClick(checked: boolean) {
+    await handleBookLink({ id: bookId }, checked);
   }
   const {
     data: previewTopic,
@@ -112,7 +112,7 @@ function Edit({ bookId, context }: Query) {
     onTopicEditClick: handleTopicEditClick,
     onAuthorsUpdate: handleAuthorsUpdate,
     onAuthorSubmit: handleAuthorSubmit,
-    onLinkButtonClick,
+    onLinkSwitchClick,
     onReleaseButtonClick: handleReleaseButtonClick,
     isContentEditable: () => true,
   };
@@ -123,7 +123,7 @@ function Edit({ bookId, context }: Query) {
   if (book.release) {
     const handlers_for_releasedbook = {
       onTopicPreview: handleTopicPreviewClick,
-      onLinkButtonClick,
+      onLinkSwitchClick,
       onForkButtonClick: () => {
         console.log("fork button");
       },

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -41,12 +41,11 @@ function Edit({ bookId, context }: Query) {
     }
   };
   async function handleSubmit({
-    sections: _,
-    submitWithLink,
+    sections: _sections,
+    submitWithLink: _submitWithLink,
     ...props
   }: BookPropsWithSubmitOptions) {
     await updateBook({ id: bookId, ...props });
-    if (submitWithLink) await handleBookLink({ id: bookId });
     return back();
   }
   async function handleDelete({ id }: Pick<BookSchema, "id">) {
@@ -90,6 +89,9 @@ function Edit({ bookId, context }: Query) {
   async function handleReleaseButtonClick() {
     return router.push(pagesPath.book.release.$url({ query }));
   }
+  async function onLinkButtonClick() {
+    await handleBookLink({ id: bookId });
+  }
   const {
     data: previewTopic,
     dispatch: setPreviewTopic,
@@ -97,8 +99,9 @@ function Edit({ bookId, context }: Query) {
   } = useDialogProps<TopicSchema>();
   const handleTopicPreviewClick = (topic: TopicSchema) =>
     setPreviewTopic(topic);
+  const linked = bookId === session?.ltiResourceLink?.bookId;
   const handlers = {
-    linked: bookId === session?.ltiResourceLink?.bookId,
+    linked,
     onSubmit: handleSubmit,
     onDelete: handleDelete,
     onCancel: handleCancel,
@@ -109,6 +112,7 @@ function Edit({ bookId, context }: Query) {
     onTopicEditClick: handleTopicEditClick,
     onAuthorsUpdate: handleAuthorsUpdate,
     onAuthorSubmit: handleAuthorSubmit,
+    onLinkButtonClick,
     onReleaseButtonClick: handleReleaseButtonClick,
     isContentEditable: () => true,
   };
@@ -119,6 +123,7 @@ function Edit({ bookId, context }: Query) {
   if (book.release) {
     const handlers_for_releasedbook = {
       onTopicPreview: handleTopicPreviewClick,
+      onLinkButtonClick,
       onForkButtonClick: () => {
         console.log("fork button");
       },
@@ -127,7 +132,12 @@ function Edit({ bookId, context }: Query) {
     };
     return (
       <>
-        <ReleasedBook book={book} {...handlers_for_releasedbook} />;
+        <ReleasedBook
+          book={book}
+          linked={linked}
+          {...handlers_for_releasedbook}
+        />
+        ;
         {previewTopic && (
           <TopicPreviewDialog {...dialogProps} topic={previewTopic} />
         )}

--- a/utils/useBookLinkHandler.ts
+++ b/utils/useBookLinkHandler.ts
@@ -1,16 +1,23 @@
 import { useCallback } from "react";
 import type { BookSchema } from "$server/models/book";
 import { useSessionAtom } from "$store/session";
-import { updateLtiResourceLink } from "$utils/ltiResourceLink";
+import {
+  destroyLtiResourceLink,
+  updateLtiResourceLink,
+} from "$utils/ltiResourceLink";
 import getLtiResourceLink from "$utils/getLtiResourceLink";
 
 function useBookLinkHandler() {
   const { session } = useSessionAtom();
   const handler = useCallback(
-    async ({ id: bookId }: Pick<BookSchema, "id">) => {
+    async ({ id: bookId }: Pick<BookSchema, "id">, checked: boolean) => {
       const ltiResourceLink = getLtiResourceLink(session);
       if (ltiResourceLink == null) return;
-      await updateLtiResourceLink({ ...ltiResourceLink, bookId });
+      if (checked) {
+        await updateLtiResourceLink({ ...ltiResourceLink, bookId });
+      } else {
+        await destroyLtiResourceLink(ltiResourceLink);
+      }
     },
     [session]
   );

--- a/utils/useBookNewHandlers.ts
+++ b/utils/useBookNewHandlers.ts
@@ -32,7 +32,7 @@ function useBookNewHandlers(
           ...authors,
         ],
       });
-      if (submitWithLink) await handleBookLink({ id: book.id });
+      if (submitWithLink) await handleBookLink({ id: book.id }, true);
       await router.replace(
         pagesPath.book.edit.$url({
           query: {


### PR DESCRIPTION
ブックの編集画面とリリース画面でのボタンの配置を変更します。

リリース画面: 「コースへの提供」ボタンを配置しました
ブック編集画面: 「コースへ提供」ボタンをフォームの外に配置してリリースボタンなどと並ぶように調整しました

スクリーンショット

Before: コースに提供すると「コースへ提供」ボタンが非表示になる都合で狭く配置される
![Screenshot from 2023-04-24 17-59-44](https://user-images.githubusercontent.com/1730234/233959036-081b24d8-5c6a-44ba-9323-92f41720bfcc.png)

After
リリース画面:
![Screenshot from 2023-04-24 18-30-39](https://user-images.githubusercontent.com/1730234/233959339-4d9d1f61-1385-4952-b719-ce3e306fd969.png)

ブック編集画面:
![Screenshot from 2023-04-24 18-32-27](https://user-images.githubusercontent.com/1730234/233959391-c6f77ece-cf9d-455c-9628-c1ff164d090a.png)

