### PR TITLE
fix:配信中ブックのビデオや解説エリアがトピック数に応じてずれる

### DIFF
--- a/components/organisms/TopicViewerContent.tsx
+++ b/components/organisms/TopicViewerContent.tsx
@@ -43,7 +43,8 @@ export default function TopicViewerContent({
       {isVideoResource(topic.resource) && (
         <Video
           className={sticky}
-          sx={{ mt: -2, mx: -3, mb: 2 }}
+          // NOTE:親要素の領域幅いっぱいに表示するため、マイナスマージンを設定している
+          sx={{ mx: -3 }}
           topic={topic}
           timeRange={timeRange}
           onEnded={onEnded}

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
 import usePrevious from "@rooks/use-previous";
-import clsx from "clsx";
 import { css } from "@emotion/css";
 
 import type { TopicSchema } from "$server/models/topic";
@@ -29,14 +28,6 @@ import DescriptionList from "$atoms/DescriptionList";
 import formatInterval from "$utils/formatInterval";
 import getLocaleDateString from "$utils/getLocaleDateString";
 import { authors } from "$utils/descriptionList";
-
-const hidden = css({
-  m: 0,
-  width: 0,
-  "& *": {
-    visibility: "hidden",
-  },
-});
 
 const videoStyle = {
   "& > *": {
@@ -273,18 +264,22 @@ export default function Video({
   if (video.has(String(topic.id))) {
     return (
       <>
-        {Array.from(video.entries()).map(([id, videoInstance]) => (
-          <VideoPlayer
-            key={id}
-            className={clsx(className, {
-              [hidden]: String(topic.id) !== id,
-            })}
-            sx={{ ...videoStyle, ...sx }}
-            videoInstance={videoInstance}
-            autoplay={String(topic.id) === id}
-            onEnded={String(topic.id) === id ? onEnded : undefined}
-          />
-        ))}
+        {Array.from(video.entries()).map(([id, videoInstance]) => {
+          if (String(topic.id) !== id) {
+            return null;
+          }
+
+          return (
+            <VideoPlayer
+              key={id}
+              className={className}
+              sx={{ ...videoStyle, ...sx }}
+              videoInstance={videoInstance}
+              autoplay={true}
+              onEnded={onEnded}
+            />
+          );
+        })}
         <Tabs
           aria-label="トピックビデオの詳細情報"
           className={tabsStyle}

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import usePrevious from "@rooks/use-previous";
+import clsx from "clsx";
 import { css } from "@emotion/css";
 
 import type { TopicSchema } from "$server/models/topic";
@@ -28,6 +29,14 @@ import DescriptionList from "$atoms/DescriptionList";
 import formatInterval from "$utils/formatInterval";
 import getLocaleDateString from "$utils/getLocaleDateString";
 import { authors } from "$utils/descriptionList";
+
+const hidden = css({
+  m: 0,
+  width: 0,
+  "& *": {
+    visibility: "hidden",
+  },
+});
 
 const videoStyle = {
   "& > *": {
@@ -264,22 +273,18 @@ export default function Video({
   if (video.has(String(topic.id))) {
     return (
       <>
-        {Array.from(video.entries()).map(([id, videoInstance]) => {
-          if (String(topic.id) !== id) {
-            return null;
-          }
-
-          return (
-            <VideoPlayer
-              key={id}
-              className={className}
-              sx={{ ...videoStyle, ...sx }}
-              videoInstance={videoInstance}
-              autoplay={true}
-              onEnded={onEnded}
-            />
-          );
-        })}
+        {Array.from(video.entries()).map(([id, videoInstance]) => (
+          <VideoPlayer
+            key={id}
+            className={clsx(className, {
+              [hidden]: String(topic.id) !== id,
+            })}
+            sx={{ ...videoStyle, ...sx }}
+            videoInstance={videoInstance}
+            autoplay={String(topic.id) === id}
+            onEnded={String(topic.id) === id ? onEnded : undefined}
+          />
+        ))}
         <Tabs
           aria-label="トピックビデオの詳細情報"
           className={tabsStyle}

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -33,6 +33,7 @@ import { authors } from "$utils/descriptionList";
 const hidden = css({
   m: 0,
   width: 0,
+  height: 0,
   "& *": {
     visibility: "hidden",
   },


### PR DESCRIPTION
#921 の修正です。

ずれてしまうのは、空のVideoJSPlayerが生成されてしまうことが原因でした。
非表示の要素を表示しないことで修正しました。

以下のようなwarningが出てしまうので要対応ですが、動作に問題ないことを確認しました。
```
YouTube player is not attached to the DOM. API calls should be made after the onReady event. See more: https://developers.google.com/youtube/iframe_api_reference#Events 
```
 