### PR TITLE
フォーク数を表示する

### DIFF
--- a/components/templates/BookTreeDiagram.tsx
+++ b/components/templates/BookTreeDiagram.tsx
@@ -53,6 +53,22 @@ function node2RawNodeDatum(
   };
 }
 
+function setNumberOfFork(node: RawNodeDatum): number {
+  let sum = 0;
+  if (node.children) {
+    for (const child of node.children) {
+      sum = sum + setNumberOfFork(child);
+      if (child.name != null) {
+        sum = sum + 1;
+      }
+    }
+  }
+  if (node.attributes) {
+    node.attributes["forks"] = `フォーク数: ${sum}`;
+  }
+  return sum;
+}
+
 function tree2RawNodeDatum({ book, tree }: Props): RawNodeDatum {
   const nodeMap: Map<number, RawNodeDatum> = new Map();
 
@@ -72,7 +88,15 @@ function tree2RawNodeDatum({ book, tree }: Props): RawNodeDatum {
       }
     }
   }
+
+  // rootId ノードを探す
   const ret = tree.rootId != null && nodeMap.get(tree.rootId);
+
+  // フォーク数を計算して設定する
+  if (ret) {
+    setNumberOfFork(ret);
+  }
+
   return ret || { name: "No Data" };
 }
 
@@ -114,6 +138,11 @@ const renderCustomNodeElement: RenderCustomNodeElementFn = ({
           {nodeDatum.attributes?.creators && (
             <tspan x="40" dy="1.2em">
               {nodeDatum.attributes.creators}
+            </tspan>
+          )}
+          {nodeDatum.attributes?.forks && (
+            <tspan x="40" dy="1.2em">
+              {nodeDatum.attributes.forks}
             </tspan>
           )}
         </text>

--- a/components/templates/BookTreeDiagram.tsx
+++ b/components/templates/BookTreeDiagram.tsx
@@ -58,12 +58,12 @@ function setNumberOfFork(node: RawNodeDatum): number {
   if (node.children) {
     for (const child of node.children) {
       sum = sum + setNumberOfFork(child);
-      if (child.name != null) {
+      if (child.name) {
         sum = sum + 1;
       }
     }
   }
-  if (node.attributes) {
+  if (node.attributes && node.name && sum > 0) {
     node.attributes["forks"] = `フォーク数: ${sum}`;
   }
   return sum;


### PR DESCRIPTION
ref #902

バージョンツリー画面でフォーク数を表示します。
久しぶりに再帰呼び出しを使いました。
リーフノードの「フォーク数:0」は表示しなくても良いかも知れません。

![image](https://github.com/npocccties/chibichilo/assets/15375161/c1b59757-227e-433d-8e46-25e2e837dfdc)
