### PR TITLE
フォークできない問題の修正

### DIFF
--- a/server/services/book/fork/create.ts
+++ b/server/services/book/fork/create.ts
@@ -5,7 +5,6 @@ import { bookParamsSchema } from "$server/validators/bookParams";
 import authUser from "$server/auth/authUser";
 import authInstructor from "$server/auth/authInstructor";
 import bookExists from "$server/utils/book/bookExists";
-import { isUsersOrAdmin } from "$server/utils/session";
 import { bookSchema } from "$server/models/book";
 import forkBook from "$server/utils/book/forkBook";
 
@@ -13,13 +12,11 @@ export const createSchema: FastifySchema = {
   summary: "ブックのフォーク",
   description: outdent`
     ブックをフォークします。
-    教員または管理者でなければなりません。
-    教員は自身の著作のブックでなければなりません。`,
+    教員または管理者でなければなりません。`,
   params: bookParamsSchema,
   response: {
     201: bookSchema,
     400: {},
-    403: {},
     404: {},
   },
 };
@@ -37,7 +34,6 @@ export async function create({
   const found = await bookExists(params.book_id);
 
   if (!found) return { status: 404 };
-  if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
   const created = await forkBook(session.user.id, params.book_id);
 

--- a/server/utils/book/bookToBookSchema.ts
+++ b/server/utils/book/bookToBookSchema.ts
@@ -1,12 +1,10 @@
-import type { Prisma, Section, TopicSection } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import type { BookSchema } from "$server/models/book";
 import type { SectionSchema } from "$server/models/book/section";
-import type { TopicSchema } from "$server/models/topic";
 import {
   authorArg,
   authorToAuthorSchema,
 } from "$server/utils/author/authorToAuthorSchema";
-import type { TopicWithResource } from "$server/utils/topic/topicToTopicSchema";
 import {
   topicsWithResourcesArg,
   topicToTopicSchema,
@@ -58,13 +56,9 @@ export const getBookIncludingArg = (userId: number) => {
   } as const;
 };
 
-type TopicSectionWithTopic = TopicSection & {
-  topic: TopicWithResource;
-};
-
-type SectionWithTopics = Section & {
-  topicSections: TopicSectionWithTopic[];
-};
+type SectionWithTopics = Prisma.SectionGetPayload<
+  ReturnType<typeof getBookIncludingArg>["include"]["sections"]
+>;
 
 export type BookWithTopics = Prisma.BookGetPayload<
   typeof bookIncludingTopicsArg
@@ -88,17 +82,7 @@ function sectionToSectionSchema(
   return {
     ...section,
     topics: section.topicSections.map((topicSection) =>
-      topicSectionToTopicSchema(topicSection, ip)
+      topicToTopicSchema(topicSection.topic, ip)
     ),
-  };
-}
-
-function topicSectionToTopicSchema(
-  topicSection: TopicSectionWithTopic,
-  ip: string
-): TopicSchema {
-  return {
-    ...topicSection,
-    ...topicToTopicSchema(topicSection.topic, ip),
   };
 }


### PR DESCRIPTION
変更点

- sectionIdフィールドが含まれフォークに失敗する問題を修正
- 自身の著作のブック以外のフォークを許容

型に存在しないフィールドが含まれていました。
server/utils/book/bookToBookSchema.ts:R101
```
     ...topicSection,
```
ここでTopicに存在していないTopicSectionのフィールドを追加している処理がありました。
それを削除して修正しました。
(6bc5c18 [3年前のコミット](https://github.com/npocccties/chibichilo/blob/6bc5c180ffa6853a77663a2ef4ecb18e99ef8a9a/server/utils/user.ts#L89)でTopicSchemaとしては本来含めてはいけない意図していないフィールドが含まれている、 https://github.com/npocccties/chibichilo/compare/9fec5d32fcc583412b0d62bcaacb00e98aad28a4..0f9ca43aa3139278f0741fadfbb2f72989f94080 での変更漏れ)

また、自身の著者のブック以外でフォークが許可されていませんでした。
ほかの教員のブックに関してもフォークを許可します。
