### PR TITLE
前回リリースの表示

### DIFF
--- a/components/templates/ReleaseEdit.tsx
+++ b/components/templates/ReleaseEdit.tsx
@@ -16,7 +16,13 @@ export type Props = {
 type ParentBookProps = Partial<Props["parentBook"]>;
 
 function ParentBook(props: ParentBookProps = {}) {
-  if (props.id == null) return null;
+  if (props.id == null) {
+    return (
+      <Card>
+        <Typography variant="h5">前回のリリースはありません</Typography>
+      </Card>
+    );
+  }
 
   return (
     <Card>

--- a/components/templates/ReleaseEdit.tsx
+++ b/components/templates/ReleaseEdit.tsx
@@ -7,7 +7,7 @@ import DescriptionList from "$atoms/DescriptionList";
 import getLocaleDateString from "$utils/getLocaleDateString";
 import type { ReleaseProps } from "$server/models/book/release";
 
-type Props = {
+export type Props = {
   book: BookSchema;
   parentBook?: Pick<BookSchema, "id" | "name" | "release">;
   onSubmit(release: ReleaseProps): void;

--- a/pages/book/release/index.tsx
+++ b/pages/book/release/index.tsx
@@ -21,18 +21,21 @@ function getParentBook(
   bookId: number,
   tree: TreeResultSchema
 ): ReleaseEditProps["parentBook"] {
-  let parentBook: ReleaseEditProps["parentBook"];
-  const bookNode = getNode(tree, bookId);
-  if (bookNode && bookNode.parentId) {
-    const parentNode = getNode(tree, bookNode.parentId);
-    if (parentNode) {
-      const { name, release } = parentNode;
-      if (name && release) {
-        parentBook = { id: bookNode.parentId, name, release };
-      }
-    }
+  // 親ブックIDを取得
+  const parentId = getNode(tree, bookId)?.parentId;
+  if (parentId == null) return;
+
+  // 親ブックノードを取得
+  const parentNode = getNode(tree, parentId);
+  if (!parentNode) return;
+
+  // リリース情報があれば返す
+  const { name, release } = parentNode;
+  if (name && release) {
+    return { id: parentId, name, release };
   }
-  return parentBook;
+
+  return;
 }
 
 function Release({ bookId, context }: Query) {

--- a/pages/book/release/index.tsx
+++ b/pages/book/release/index.tsx
@@ -5,14 +5,40 @@ import { useSessionAtom } from "$store/session";
 import { releaseBook, useBook } from "$utils/book";
 import type { Query as BookEditQuery } from "../edit";
 import { pagesPath } from "$utils/$path";
+import type { Props as ReleaseEditProps } from "$templates/ReleaseEdit";
 import ReleaseEdit from "$templates/ReleaseEdit";
 import type { ReleaseProps } from "$server/models/book/release";
+import useBookTree from "$utils/useBookTree";
+import type { TreeResultSchema } from "$server/models/book/tree";
 
 export type Query = BookEditQuery;
+
+function getNode(tree: TreeResultSchema, id: number) {
+  return tree.nodes.filter((node) => node.id == id)[0];
+}
+
+function getParentBook(
+  bookId: number,
+  tree: TreeResultSchema
+): ReleaseEditProps["parentBook"] {
+  let parentBook: ReleaseEditProps["parentBook"];
+  const bookNode = getNode(tree, bookId);
+  if (bookNode && bookNode.parentId) {
+    const parentNode = getNode(tree, bookNode.parentId);
+    if (parentNode) {
+      const { name, release } = parentNode;
+      if (name && release) {
+        parentBook = { id: bookNode.parentId, name, release };
+      }
+    }
+  }
+  return parentBook;
+}
 
 function Release({ bookId, context }: Query) {
   const { isContentEditable } = useSessionAtom();
   const { book, error } = useBook(bookId, isContentEditable);
+  const { tree, error: error2 } = useBookTree(bookId);
   const router = useRouter();
   const bookEditQuery = { bookId, ...(context && { context }) };
   const back = () =>
@@ -29,7 +55,9 @@ function Release({ bookId, context }: Query) {
   if (error) return <BookNotFoundProblem />;
   if (!book) return <Placeholder />;
 
-  return <ReleaseEdit book={book} {...handlers} />;
+  const parentBook = tree && !error2 ? getParentBook(bookId, tree) : undefined;
+
+  return <ReleaseEdit book={book} parentBook={parentBook} {...handlers} />;
 }
 
 function Router() {


### PR DESCRIPTION
ref #915

リリース画面で、前回リリースのバージョン、ブック名、リリース日を表示します。
直接の親ブックとそのリリース情報が存在するときに表示します。
ルートブックのとき、親ブックが削除された場合は、何も表示されません。

> リリースが存在しない場合に関しても利用者に通知するほうが一貫性があるというフィードバック

これ、具体的にどんな話しだっかのが記憶がありません。何か追加するべき点があれば、ご指摘ください。

![image](https://github.com/npocccties/chibichilo/assets/15375161/f64b9ef6-9b7e-4f5f-b506-67db14ba01e0)
