### PR TITLE
fix: キーワードが設定されているときフォークに失敗する不具合を修正

### DIFF
--- a/server/config/seeds/books.ts
+++ b/server/config/seeds/books.ts
@@ -10,6 +10,7 @@ const books = [
       { topics: [{ id: 4 }] },
       { topics: [{ id: 5 }] },
     ],
+    keywords: [{ name: "数学" }, { name: "入門微分積分学共通" }],
   },
 ];
 

--- a/server/utils/keyword/keywordsConnectOrCreateInput.ts
+++ b/server/utils/keyword/keywordsConnectOrCreateInput.ts
@@ -1,10 +1,12 @@
-import type { KeywordPropSchema } from "$server/models/keyword";
+import type { KeywordPropSchema, KeywordSchema } from "$server/models/keyword";
 
-function keywordsConnectOrCreateInput(keywords: KeywordPropSchema[]) {
+function keywordsConnectOrCreateInput<
+  Input extends Array<KeywordPropSchema> | Array<KeywordSchema>
+>(keywords: Input) {
   return {
-    connectOrCreate: keywords.map((keyword) => ({
-      where: keyword,
-      create: keyword,
+    connectOrCreate: keywords.map(({ name }) => ({
+      where: { name },
+      create: { name },
     })),
   };
 }


### PR DESCRIPTION
キーワードが設定されているときフォークに失敗する不具合がありました。
キーワード作成処理実行時のフィールドを厳格にすることによってその問題を修正します。