### PR TITLE
ツリー画面に拡大、縮小、リセットボタンを追加

### DIFF
--- a/components/organisms/BookTreeDialog.tsx
+++ b/components/organisms/BookTreeDialog.tsx
@@ -69,8 +69,6 @@ export default function BookTreeDialog(props: Props) {
   const { node, open, onClose } = props;
   const nodeBody = useNodeBody(node);
 
-  console.log(nodeBody);
-
   return (
     <Dialog
       open={open}

--- a/components/templates/BookTreeDiagram.tsx
+++ b/components/templates/BookTreeDiagram.tsx
@@ -219,7 +219,12 @@ function BookTreeDiagram(props: Props) {
           gap: 2,
         }}
       >
-        <Button size="small" color="primary" onClick={handleZoomIn}>
+        <Button
+          disabled={zoom >= 1.0}
+          size="small"
+          color="primary"
+          onClick={handleZoomIn}
+        >
           <ZoomInIcon />
           拡大
         </Button>

--- a/components/templates/BookTreeDiagram.tsx
+++ b/components/templates/BookTreeDiagram.tsx
@@ -15,6 +15,12 @@ import type {
 import { css } from "@emotion/css";
 import { gray, primary } from "$theme/colors";
 import getLocaleDateTimeString from "$utils/getLocaleDateTimeString";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import { useState } from "react";
 
 type Props = {
   book: BookSchema;
@@ -165,7 +171,6 @@ function getD3TreeOptions() {
       x: 40,
       y: 100,
     },
-    zoom: 1.0,
     zoomable: false,
   };
 }
@@ -173,12 +178,28 @@ function getD3TreeOptions() {
 function BookTreeDiagram(props: Props) {
   const data = tree2RawNodeDatum(props);
   const options = getD3TreeOptions();
+  const [zoom, setZoom] = useState(1.0);
+  const ratio = 1.1;
 
   const onNodeClickRaw: TreeNodeEventCallback = (node, _) => {
     if (props.onNodeClick && typeof node.data.attributes?.id === "number") {
       props.onNodeClick(node.data.attributes?.id);
     }
   };
+
+  function handleZoomIn() {
+    let newZoom = zoom * ratio;
+    if (newZoom > 1.0) newZoom = 1.0;
+    setZoom(newZoom);
+  }
+
+  function handleZoomOut() {
+    setZoom(zoom / ratio);
+  }
+
+  function handleReset() {
+    setZoom(1.0);
+  }
 
   return (
     <Container
@@ -192,7 +213,26 @@ function BookTreeDiagram(props: Props) {
       }}
     >
       <Typography variant="h4">{props.book.name}</Typography>
-      <Tree data={data} {...options} onNodeClick={onNodeClickRaw} />
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+        }}
+      >
+        <Button size="small" color="primary" onClick={handleZoomIn}>
+          <ZoomInIcon />
+          拡大
+        </Button>
+        <Button size="small" color="primary" onClick={handleZoomOut}>
+          <ZoomOutIcon />
+          縮小
+        </Button>
+        <Button size="small" color="primary" onClick={handleReset}>
+          <RestartAltIcon />
+          リセット
+        </Button>
+      </Box>
+      <Tree data={data} zoom={zoom} {...options} onNodeClick={onNodeClickRaw} />
     </Container>
   );
 }

--- a/pages/book/tree/index.tsx
+++ b/pages/book/tree/index.tsx
@@ -32,7 +32,6 @@ function BookTree({ bookId }: { bookId: BookSchema["id"] }) {
   if (!tree) return <Placeholder />;
 
   function onNodeClick(id: number) {
-    console.log(id);
     if (tree == null) return;
     const node = getNode(tree, id);
     if (node && node.name) {


### PR DESCRIPTION
ref #892 

ツリー画面に拡大、縮小、リセットボタンを追加しました。
- zoom パラメータの初期値は 1.0
- 1.0以上に拡大することはできない
- 拡大は zoom を 1.1倍
- 縮小は zoom を 1.1で割る
- リセットすると zoom が 1.0 に戻る
- zoom パラメータが変化すると、ツリーの表示位置はリセットされる

![image](https://github.com/npocccties/chibichilo/assets/15375161/91b87a9e-982c-4d76-b55c-48cf592e6b06)
