### PR TITLE
シェアしていないブックを表示しない

### DIFF
--- a/components/organisms/BookTreeDialog.tsx
+++ b/components/organisms/BookTreeDialog.tsx
@@ -13,6 +13,7 @@ import StripedMarkdown from "$atoms/StripedMarkdown";
 import groupBy from "lodash.groupby";
 import getLocaleListString from "$utils/getLocaleListString";
 import getLocaleDateTimeString from "$utils/getLocaleDateTimeString";
+import type { TreeNodeType } from "$templates/BookTreeDiagram";
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -21,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type Props = {
+  nodeType?: TreeNodeType;
   node?: TreeNodeSchema;
   open: boolean;
   onClose: React.MouseEventHandler;
@@ -57,16 +59,35 @@ function useNodeBody(node: TreeNodeSchema | undefined) {
       作成日: date2string(node?.createdAt),
       更新日: date2string(node?.updatedAt),
       ...authors(node?.authors),
-      解説: <StripedMarkdown content={node?.description || ""} />,
+      解説: node?.description ? (
+        <StripedMarkdown content={node?.description} />
+      ) : null,
     }),
     [node]
   );
 }
 
+function nodeType2msg(nodeType: TreeNodeType | undefined): string {
+  let ret = "不明なブック";
+  switch (nodeType) {
+    case "target":
+    case "normal":
+      ret = "ブック詳細";
+      break;
+    case "notshared":
+      ret = "シェアされていないブック";
+      break;
+    case "deleted":
+      ret = "削除されたブック";
+      break;
+  }
+  return ret;
+}
+
 export default function BookTreeDialog(props: Props) {
   const cardClasses = useCardStyles();
   const classes = useStyles();
-  const { node, open, onClose } = props;
+  const { nodeType, node, open, onClose } = props;
   const nodeBody = useNodeBody(node);
 
   return (
@@ -78,7 +99,7 @@ export default function BookTreeDialog(props: Props) {
     >
       <DialogContent>
         <Typography className={classes.title} variant="h5">
-          ブック詳細
+          {nodeType2msg(nodeType)}
         </Typography>
         <DescriptionList
           value={Object.entries(nodeBody).flatMap(([key, value]) =>

--- a/components/templates/BookTreeDiagram.tsx
+++ b/components/templates/BookTreeDiagram.tsx
@@ -21,12 +21,42 @@ import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useState } from "react";
+import { useSessionAtom } from "$store/session";
+import type { SessionSchema } from "$server/models/session";
 
 type Props = {
   book: BookSchema;
   tree: TreeResultSchema;
   onNodeClick?: (id: number) => void;
 };
+
+type TreeNodeType = "normal" | "target" | "notshared" | "deleted";
+
+function isAuthor(
+  authors: TreeNodeAuthorsSchema[] | undefined,
+  userId: number | undefined
+): boolean {
+  if (!authors || typeof userId === "undefined") return false;
+  return authors.some((author) => author.id === userId);
+}
+
+function node2type(
+  node: TreeNodeSchema,
+  targetId: number,
+  session: SessionSchema | undefined
+): TreeNodeType {
+  if (node.id === targetId) {
+    return "target";
+  }
+  if (node.name) {
+    if (isAuthor(node.authors, session?.user.id) || node.shared) {
+      return "normal";
+    } else {
+      return "notshared";
+    }
+  }
+  return "deleted";
+}
 
 function creators(authors: TreeNodeAuthorsSchema[]): string[] {
   return authors
@@ -36,24 +66,35 @@ function creators(authors: TreeNodeAuthorsSchema[]): string[] {
 
 function node2RawNodeDatum(
   node: TreeNodeSchema,
-  targetId: number
+  targetId: number,
+  session: SessionSchema | undefined
 ): RawNodeDatum {
+  let name = "";
   const attributes: Record<string, string | number | boolean> = {};
   attributes["id"] = node.id;
-  if (node.id === targetId) {
-    attributes["type"] = "target";
+
+  const nodeType: TreeNodeType = node2type(node, targetId, session);
+  attributes["type"] = nodeType;
+
+  if (nodeType === "target" || nodeType === "normal") {
+    if (node.name) {
+      name = node.name;
+    }
+    if (node.release?.version != null) {
+      attributes["version"] = node.release.version;
+    }
+    if (node.release?.releasedAt instanceof Date) {
+      attributes["releasedAt"] = getLocaleDateTimeString(
+        node.release.releasedAt
+      );
+    }
+    if (node.authors != null) {
+      attributes["creators"] = creators(node.authors).join(",");
+    }
   }
-  if (node.release?.version != null) {
-    attributes["version"] = node.release.version;
-  }
-  if (node.release?.releasedAt instanceof Date) {
-    attributes["releasedAt"] = getLocaleDateTimeString(node.release.releasedAt);
-  }
-  if (node.authors != null) {
-    attributes["creators"] = creators(node.authors).join(",");
-  }
+
   return {
-    name: node.name || "",
+    name,
     attributes,
     children: [],
   };
@@ -75,12 +116,15 @@ function setNumberOfFork(node: RawNodeDatum): number {
   return sum;
 }
 
-function tree2RawNodeDatum({ book, tree }: Props): RawNodeDatum {
+function tree2RawNodeDatum(
+  { book, tree }: Props,
+  session: SessionSchema | undefined
+): RawNodeDatum {
   const nodeMap: Map<number, RawNodeDatum> = new Map();
 
   // すべてのノードを登録する
   for (const node of tree.nodes) {
-    const rawNodeDatum = node2RawNodeDatum(node, book.id);
+    const rawNodeDatum = node2RawNodeDatum(node, book.id, session);
     nodeMap.set(node.id, rawNodeDatum);
   }
 
@@ -106,14 +150,26 @@ function tree2RawNodeDatum({ book, tree }: Props): RawNodeDatum {
   return ret || { name: "No Data" };
 }
 
-const circleClass = { className: "rd3t-target-node" };
+function type2className(type: string | undefined) {
+  if (!type) type = "normal";
+  return `rd3t-${type}-node`;
+}
 
 const circleStyle = css`
-  circle {
+  circle.${type2className("normal")} {
     fill: ${gray[100]};
   }
-  circle.${circleClass.className} {
+  circle.${type2className("target")} {
     fill: ${primary[400]};
+  }
+  circle.${type2className("notshared")} {
+    stroke-dasharray: 2;
+    fill: ${gray[100]};
+  }
+  circle.${type2className("deleted")} {
+    stroke: ${gray[500]};
+    stroke-dasharray: 2;
+    fill: ${gray[100]};
   }
 `;
 
@@ -121,11 +177,13 @@ const renderCustomNodeElement: RenderCustomNodeElementFn = ({
   nodeDatum,
   onNodeClick,
 }) => {
-  const target = nodeDatum.attributes?.type === "target" ? circleClass : {};
+  const className = type2className(
+    nodeDatum.attributes?.type as string | undefined
+  );
 
   return (
     <>
-      <circle r="15" onClick={onNodeClick} {...target}></circle>
+      <circle r="15" onClick={onNodeClick} className={className}></circle>
       <g className="rd3t-label">
         <text className="rd3t-label__title" textAnchor="start" x="40">
           {nodeDatum.name}
@@ -176,7 +234,8 @@ function getD3TreeOptions() {
 }
 
 function BookTreeDiagram(props: Props) {
-  const data = tree2RawNodeDatum(props);
+  const { session } = useSessionAtom();
+  const data = tree2RawNodeDatum(props, session);
   const options = getD3TreeOptions();
   const [zoom, setZoom] = useState(1.0);
   const ratio = 1.1;

--- a/components/templates/BookTreeDiagram.tsx
+++ b/components/templates/BookTreeDiagram.tsx
@@ -108,7 +108,7 @@ function setNumberOfFork(node: RawNodeDatum): number {
   if (node.children) {
     for (const child of node.children) {
       sum = sum + setNumberOfFork(child);
-      if (child.name) {
+      if (child.attributes?.type !== "deleted") {
         sum = sum + 1;
       }
     }

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -543,7 +543,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * ブックをフォークします。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックをフォークします。 教員または管理者でなければなりません。
      * ブックのフォーク
      */
     async apiV2BookBookIdForkPostRaw(requestParameters: ApiV2BookBookIdForkPostRequest): Promise<runtime.ApiResponse<InlineResponse2005Books>> {
@@ -566,7 +566,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * ブックをフォークします。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックをフォークします。 教員または管理者でなければなりません。
      * ブックのフォーク
      */
     async apiV2BookBookIdForkPost(requestParameters: ApiV2BookBookIdForkPostRequest): Promise<InlineResponse2005Books> {

--- a/openapi/models/InlineResponse2008Nodes.ts
+++ b/openapi/models/InlineResponse2008Nodes.ts
@@ -56,6 +56,12 @@ export interface InlineResponse2008Nodes {
     description?: string;
     /**
      * 
+     * @type {boolean}
+     * @memberof InlineResponse2008Nodes
+     */
+    shared?: boolean;
+    /**
+     * 
      * @type {Date}
      * @memberof InlineResponse2008Nodes
      */
@@ -94,6 +100,7 @@ export function InlineResponse2008NodesFromJSONTyped(json: any, ignoreDiscrimina
         'parentId': !exists(json, 'parentId') ? undefined : json['parentId'],
         'name': !exists(json, 'name') ? undefined : json['name'],
         'description': !exists(json, 'description') ? undefined : json['description'],
+        'shared': !exists(json, 'shared') ? undefined : json['shared'],
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
         'updatedAt': !exists(json, 'updatedAt') ? undefined : (new Date(json['updatedAt'])),
         'authors': !exists(json, 'authors') ? undefined : ((json['authors'] as Array<any>).map(InlineResponse2008AuthorsFromJSON)),
@@ -114,6 +121,7 @@ export function InlineResponse2008NodesToJSON(value?: InlineResponse2008Nodes | 
         'parentId': value.parentId,
         'name': value.name,
         'description': value.description,
+        'shared': value.shared,
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),
         'updatedAt': value.updatedAt === undefined ? undefined : (value.updatedAt.toISOString()),
         'authors': value.authors === undefined ? undefined : ((value.authors as Array<any>).map(InlineResponse2008AuthorsToJSON)),

--- a/pages/book/tree/index.tsx
+++ b/pages/book/tree/index.tsx
@@ -3,27 +3,22 @@ import Placeholder from "$templates/Placeholder";
 import BookNotFoundProblem from "$templates/TopicNotFoundProblem";
 import useBookTree from "$utils/useBookTree";
 import BookTreeDiagram from "$templates/BookTreeDiagram";
+import type { TreeNodeType } from "$templates/BookTreeDiagram";
 import { useSessionAtom } from "$store/session";
 import { useBook } from "$utils/book";
 import type { BookSchema } from "$server/models/book";
 import type { Query as BookEditQuery } from "$pages/book/edit";
 import { useState } from "react";
-import type {
-  TreeNodeSchema,
-  TreeResultSchema,
-} from "$server/models/book/tree";
+import type { TreeNodeSchema } from "$server/models/book/tree";
 import BookTreeDialog from "$organisms/BookTreeDialog";
 
 export type Query = BookEditQuery;
-
-function getNode(tree: TreeResultSchema, id: number) {
-  return tree.nodes.filter((node) => node.id == id)[0];
-}
 
 function BookTree({ bookId }: { bookId: BookSchema["id"] }) {
   const { isContentEditable } = useSessionAtom();
   const { book, error } = useBook(bookId, isContentEditable);
   const { tree, error: error2 } = useBookTree(bookId);
+  const [nodeType, setNodeType] = useState<TreeNodeType | undefined>();
   const [node, setNode] = useState<TreeNodeSchema | undefined>();
   const [open, setOpen] = useState(false);
 
@@ -31,13 +26,13 @@ function BookTree({ bookId }: { bookId: BookSchema["id"] }) {
   if (!book) return <Placeholder />;
   if (!tree) return <Placeholder />;
 
-  function onNodeClick(id: number) {
-    if (tree == null) return;
-    const node = getNode(tree, id);
-    if (node && node.name) {
-      setNode(node);
-      setOpen(true);
-    }
+  function onNodeClick(
+    nodeType: TreeNodeType,
+    node: TreeNodeSchema | undefined
+  ) {
+    setNodeType(nodeType);
+    setNode(node);
+    setOpen(true);
   }
 
   const handleClose = () => {
@@ -47,7 +42,12 @@ function BookTree({ bookId }: { bookId: BookSchema["id"] }) {
   return (
     <>
       <BookTreeDiagram book={book} tree={tree} onNodeClick={onNodeClick} />;
-      <BookTreeDialog node={node} open={open} onClose={handleClose} />
+      <BookTreeDialog
+        nodeType={nodeType}
+        node={node}
+        open={open}
+        onClose={handleClose}
+      />
     </>
   );
 }

--- a/server/models/book/tree.ts
+++ b/server/models/book/tree.ts
@@ -23,6 +23,7 @@ export const TreeNodeAuthorsSchema = {
 export type TreeNodeSchema = Pick<Node, "id" | "parentId"> & {
   name?: Book["name"];
   description?: Book["description"];
+  shared?: Book["shared"];
   createdAt?: Book["createdAt"];
   updatedAt?: Book["updatedAt"];
   authors?: TreeNodeAuthorsSchema[];
@@ -37,6 +38,7 @@ export const TreeNodeSchema = {
     parentId: { type: "integer", nullable: true },
     name: { type: "string", nullable: true },
     description: { type: "string", nullable: true },
+    shared: { type: "boolean", nullable: true },
     createdAt: { type: "string", format: "date-time", nullable: true },
     updatedAt: { type: "string", format: "date-time", nullable: true },
     authors: { type: "array", items: TreeNodeAuthorsSchema, nullable: true },

--- a/server/utils/book/findTree.ts
+++ b/server/utils/book/findTree.ts
@@ -61,6 +61,7 @@ function nodeToTreeNode(node: NodeWithBook): TreeNodeSchema {
   const {
     name,
     description,
+    shared,
     createdAt,
     updatedAt,
     authors = [],
@@ -71,6 +72,7 @@ function nodeToTreeNode(node: NodeWithBook): TreeNodeSchema {
     parentId,
     name,
     description,
+    shared,
     createdAt,
     updatedAt,
     authors: authors.map((author) => authorToTreeNodeAuthor(author)),


### PR DESCRIPTION
ref #893 

バージョンツリー画面でシェアしていないブックと削除済みブックの表示方法を変更しました。

- /api/v2/book/{book_id}/tree が返すブック毎の TreeNodeSchema に shared を追加しました
- 円を点線で表示し、削除済みは少し薄いグレーにしています。
- `クリックすると、「シェアしていないブック」「削除されたブック」と表示します

![image](https://github.com/npocccties/chibichilo/assets/15375161/1eb085ac-d24a-4867-9076-38271d8e6a7c)

![image](https://github.com/npocccties/chibichilo/assets/15375161/943fa750-fa38-4ff9-b4c3-4aeebfbef0e6)
