### PR TITLE
バージョンツリーをオーバレイ表示する

### DIFF
--- a/components/organisms/BookTreeDialog.tsx
+++ b/components/organisms/BookTreeDialog.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type Props = {
+export type Props = {
   nodeType?: TreeNodeType;
   node?: TreeNodeSchema;
   open: boolean;

--- a/components/organisms/VersionTreeDialog.tsx
+++ b/components/organisms/VersionTreeDialog.tsx
@@ -6,6 +6,7 @@ import type { BookSchema } from "$server/models/book";
 import React, { useState } from "react";
 import type { TreeNodeSchema } from "$server/models/book/tree";
 import BookTreeDialog from "$organisms/BookTreeDialog";
+import type { Props as BookTreeDialogProps } from "$organisms/BookTreeDialog";
 import Dialog from "@mui/material/Dialog";
 import IconButton from "$atoms/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
@@ -30,8 +31,9 @@ export type VersionTreeDialogProps = {
 export function VersionTreeDialog(props: VersionTreeDialogProps) {
   const { book, bookId, open, onClose } = props;
   const { tree, error } = useBookTree(bookId);
-  const [nodeType, setNodeType] = useState<TreeNodeType | undefined>();
-  const [node, setNode] = useState<TreeNodeSchema | undefined>();
+  const [bookTreeDialogProps, setBookTreeDialogProps] = useState<
+    Pick<BookTreeDialogProps, "nodeType" | "node" | "open">
+  >({ open: false });
   const classes = useStyles();
 
   if (error || !tree) return <Placeholder />;
@@ -40,12 +42,17 @@ export function VersionTreeDialog(props: VersionTreeDialogProps) {
     nodeType: TreeNodeType,
     node: TreeNodeSchema | undefined
   ) {
-    setNodeType(nodeType);
-    setNode(node);
+    setBookTreeDialogProps({
+      nodeType,
+      node,
+      open: true,
+    });
   }
 
   const handleBookTreeDialogClose = () => {
-    setNode(undefined);
+    setBookTreeDialogProps({
+      open: false,
+    });
   };
 
   return (
@@ -59,12 +66,12 @@ export function VersionTreeDialog(props: VersionTreeDialogProps) {
         <CloseIcon />
       </IconButton>
       <BookTreeDiagram book={book} tree={tree} onNodeClick={onNodeClick} />;
-      <BookTreeDialog
-        nodeType={nodeType}
-        node={node}
-        open={node != null}
-        onClose={handleBookTreeDialogClose}
-      />
+      {bookTreeDialogProps.open && (
+        <BookTreeDialog
+          {...bookTreeDialogProps}
+          onClose={handleBookTreeDialogClose}
+        />
+      )}
     </Dialog>
   );
 }

--- a/components/organisms/VersionTreeDialog.tsx
+++ b/components/organisms/VersionTreeDialog.tsx
@@ -9,6 +9,16 @@ import BookTreeDialog from "$organisms/BookTreeDialog";
 import Dialog from "@mui/material/Dialog";
 import IconButton from "$atoms/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
+import makeStyles from "@mui/styles/makeStyles";
+
+const useStyles = makeStyles((theme) => ({
+  closeButton: {
+    position: "fixed",
+    top: theme.spacing(4),
+    right: theme.spacing(3),
+    zIndex: 3,
+  },
+}));
 
 export type VersionTreeDialogProps = {
   book: BookSchema;
@@ -22,6 +32,7 @@ export function VersionTreeDialog(props: VersionTreeDialogProps) {
   const { tree, error } = useBookTree(bookId);
   const [nodeType, setNodeType] = useState<TreeNodeType | undefined>();
   const [node, setNode] = useState<TreeNodeSchema | undefined>();
+  const classes = useStyles();
 
   if (error || !tree) return <Placeholder />;
 
@@ -33,13 +44,14 @@ export function VersionTreeDialog(props: VersionTreeDialogProps) {
     setNode(node);
   }
 
-  const handleClose = () => {
+  const handleBookTreeDialogClose = () => {
     setNode(undefined);
   };
 
   return (
     <Dialog fullScreen open={open} onClose={onClose}>
       <IconButton
+        className={classes.closeButton}
         tooltipProps={{ title: "閉じる" }}
         onClick={onClose}
         size="large"
@@ -51,7 +63,7 @@ export function VersionTreeDialog(props: VersionTreeDialogProps) {
         nodeType={nodeType}
         node={node}
         open={node != null}
-        onClose={handleClose}
+        onClose={handleBookTreeDialogClose}
       />
     </Dialog>
   );

--- a/components/organisms/VersionTreeDialog.tsx
+++ b/components/organisms/VersionTreeDialog.tsx
@@ -1,0 +1,58 @@
+import Placeholder from "$templates/Placeholder";
+import useBookTree from "$utils/useBookTree";
+import BookTreeDiagram from "$templates/BookTreeDiagram";
+import type { TreeNodeType } from "$templates/BookTreeDiagram";
+import type { BookSchema } from "$server/models/book";
+import React, { useState } from "react";
+import type { TreeNodeSchema } from "$server/models/book/tree";
+import BookTreeDialog from "$organisms/BookTreeDialog";
+import Dialog from "@mui/material/Dialog";
+import IconButton from "$atoms/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+
+export type VersionTreeDialogProps = {
+  book: BookSchema;
+  bookId: BookSchema["id"];
+  open: boolean;
+  onClose: React.MouseEventHandler;
+};
+
+export function VersionTreeDialog(props: VersionTreeDialogProps) {
+  const { book, bookId, open, onClose } = props;
+  const { tree, error } = useBookTree(bookId);
+  const [nodeType, setNodeType] = useState<TreeNodeType | undefined>();
+  const [node, setNode] = useState<TreeNodeSchema | undefined>();
+
+  if (error || !tree) return <Placeholder />;
+
+  function onNodeClick(
+    nodeType: TreeNodeType,
+    node: TreeNodeSchema | undefined
+  ) {
+    setNodeType(nodeType);
+    setNode(node);
+  }
+
+  const handleClose = () => {
+    setNode(undefined);
+  };
+
+  return (
+    <Dialog fullScreen open={open} onClose={onClose}>
+      <IconButton
+        tooltipProps={{ title: "閉じる" }}
+        onClick={onClose}
+        size="large"
+      >
+        <CloseIcon />
+      </IconButton>
+      <BookTreeDiagram book={book} tree={tree} onNodeClick={onNodeClick} />;
+      <BookTreeDialog
+        nodeType={nodeType}
+        node={node}
+        open={node != null}
+        onClose={handleClose}
+      />
+    </Dialog>
+  );
+}

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -32,11 +32,11 @@ function Edit({ bookId, context }: Query) {
     : BookFork;
 
   handlers.onBookTreeButtonClick = () => {
-    setShowVersionTreeDialog(!showVersionTreeDialog);
+    setShowVersionTreeDialog(true);
   };
 
   function onClose() {
-    setShowVersionTreeDialog(!showVersionTreeDialog);
+    setShowVersionTreeDialog(false);
   }
 
   const versionTreeDialogProps: VersionTreeDialogProps = {

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -7,6 +7,9 @@ import ReleasedBook from "$templates/ReleasedBook";
 import BookFork from "$templates/BookFork";
 import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
 import useBookEditHandlers from "$utils/useBookEditHandlers";
+import { VersionTreeDialog } from "$organisms/VersionTreeDialog";
+import type { VersionTreeDialogProps } from "$organisms/VersionTreeDialog";
+import { useState } from "react";
 
 export type Query = {
   bookId: BookSchema["id"];
@@ -16,6 +19,7 @@ export type Query = {
 function Edit({ bookId, context }: Query) {
   const { error, book, topicPreviewDialogProps, ...handlers } =
     useBookEditHandlers({ bookId, context });
+  const [showVersionTreeDialog, setShowVersionTreeDialog] = useState(false);
 
   if (error) return <BookNotFoundProblem />;
   if (!book) return <Placeholder />;
@@ -27,11 +31,29 @@ function Edit({ bookId, context }: Query) {
       : BookEdit
     : BookFork;
 
+  handlers.onBookTreeButtonClick = () => {
+    setShowVersionTreeDialog(!showVersionTreeDialog);
+  };
+
+  function onClose() {
+    setShowVersionTreeDialog(!showVersionTreeDialog);
+  }
+
+  const versionTreeDialogProps: VersionTreeDialogProps = {
+    book,
+    bookId,
+    open: showVersionTreeDialog,
+    onClose,
+  };
+
   return (
     <>
       <Template book={book} {...handlers} />
       {topicPreviewDialogProps && (
         <TopicPreviewDialog {...topicPreviewDialogProps} />
+      )}
+      {showVersionTreeDialog && (
+        <VersionTreeDialog {...versionTreeDialogProps} />
       )}
     </>
   );


### PR DESCRIPTION
ref #893

バージョンツリーをオーバレイ表示するように変更しました。

components/organisms/VersionTreeDialog.tsx を作成し pages/book/edit/index.tsx を変更しています。

pages/book/tree/index.tsx, utils/useBookEditHandlers.ts onBookTreeButtonClick 関数
は使用しなくなりましたが、まだ削除していません。

components/templates/BookTreeDiagram.tsx, components/organisms/BookTreeDialog.tsx は、BookTree -> VersionTree に改名、templates -> organisms へ移動したほうが良さそうですが、まだ作業していません。
