### PR TITLE
fix: 学習時間 "0" が表示される不具合の修正

### DIFF
--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -176,12 +176,13 @@ export default function Book(props: Props) {
           >
             {book?.name}
           </Typography>
-          {book?.timeRequired && (
-            <Chip
-              sx={{ mr: 1, mb: 0.5 }}
-              label={`学習時間 ${formatInterval(0, book.timeRequired * 1000)}`}
-            />
-          )}
+          <Chip
+            sx={{ mr: 1, mb: 0.5 }}
+            label={`学習時間 ${formatInterval(
+              0,
+              (book?.timeRequired ?? 0) * 1000
+            )}`}
+          />
           {book?.shared && <SharedIndicator />}
           {isInstructor &&
             book &&


### PR DESCRIPTION
ref #929

学習時間が0のときfalseではなくnumberのまま扱われ表示される不具合がありました。
0の場合も同じデザインにすることによってその不具合を回避します。
