### PR TITLE
feat: リリース済みのブックに関してはバージョン・リリース日を表示

### DIFF
--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -245,10 +245,23 @@ export default function ContentPreview({
         nowrap
         sx={{ mx: 2, mt: 1 }}
         value={[
-          {
-            key: "更新日",
-            value: getLocaleDateString(content.updatedAt, "ja"),
-          },
+          ...(content.type === "book" && content.release?.releasedAt
+            ? [
+                {
+                  key: "バージョン",
+                  value: content.release.version,
+                },
+                {
+                  key: "リリース日",
+                  value: getLocaleDateString(content.release.releasedAt, "ja"),
+                },
+              ]
+            : [
+                {
+                  key: "更新日",
+                  value: getLocaleDateString(content.updatedAt, "ja"),
+                },
+              ]),
           ...authors(content),
         ]}
       />

--- a/components/organisms/ReleasedBookCard.tsx
+++ b/components/organisms/ReleasedBookCard.tsx
@@ -2,6 +2,8 @@ import { useCallback, type ReactNode } from "react";
 import Typography from "@mui/material/Typography";
 import InputLabel from "@mui/material/InputLabel";
 import Checkbox from "@mui/material/Checkbox";
+import Button from "@mui/material/Button";
+import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import type { BookSchema } from "$server/models/book";
 import type { TopicSchema } from "$server/models/topic";
 import Card from "$atoms/Card";
@@ -14,9 +16,14 @@ import getLocaleDateString from "$utils/getLocaleDateString";
 export type ReleasedBookCardProps = {
   book: BookSchema;
   onTopicPreview(topic: TopicSchema): void;
+  onReleaseEditButtonClick?: () => void;
 };
 
-function ReleasedBookCard({ book, onTopicPreview }: ReleasedBookCardProps) {
+function ReleasedBookCard({
+  book,
+  onTopicPreview,
+  onReleaseEditButtonClick,
+}: ReleasedBookCardProps) {
   const onItemPreviewClick = useCallback(
     ([sectionIndex, topicIndex]: [
       sectionIndex: number,
@@ -33,6 +40,19 @@ function ReleasedBookCard({ book, onTopicPreview }: ReleasedBookCardProps) {
       <section>
         <Typography variant="h5" gutterBottom>
           {book.release?.version}
+          {onReleaseEditButtonClick && (
+            <>
+              {` `}
+              <Button
+                size="small"
+                color="primary"
+                onClick={onReleaseEditButtonClick}
+              >
+                <PeopleOutlinedIcon />
+                リリースの編集
+              </Button>
+            </>
+          )}
         </Typography>
         <DescriptionList
           sx={{ mb: 1 }}

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -215,6 +215,21 @@ export default function Book(props: Props) {
               inline
               nowrap
               value={[
+                ...(book.release?.releasedAt
+                  ? [
+                      {
+                        key: "バージョン",
+                        value: book.release.version,
+                      },
+                      {
+                        key: "リリース日",
+                        value: getLocaleDateString(
+                          book.release.releasedAt,
+                          "ja"
+                        ),
+                      },
+                    ]
+                  : []),
                 {
                   key: "作成日",
                   value: getLocaleDateString(book.createdAt, "ja"),

--- a/components/templates/ReleasedBook.tsx
+++ b/components/templates/ReleasedBook.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import ForkOutlinedIcon from "@mui/icons-material/ForkRightOutlined";
-import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import Box from "@mui/material/Box";
@@ -67,7 +66,7 @@ function ReleasedBook(props: Props) {
       }}
     >
       <Typography variant="h4">{book.name}</Typography>
-      <ReleasedBookCard {...props} />
+      <ReleasedBookCard {...props} onReleaseEditButtonClick={edit} />
       <Box
         className="released-book-row"
         sx={{
@@ -85,10 +84,6 @@ function ReleasedBook(props: Props) {
         <Button size="small" color="primary" onClick={handlers.fork}>
           <ForkOutlinedIcon />
           フォーク
-        </Button>
-        <Button size="small" color="primary" onClick={handlers.edit}>
-          <PeopleOutlinedIcon />
-          リリースの編集
         </Button>
         <Button size="small" color="primary" onClick={onBookTreeButtonClick}>
           <AccountTreeOutlinedIcon />


### PR DESCRIPTION
ref https://github.com/npocccties/chibichilo/issues/927

リリース済みであることをより分かりやすくします。
またリリースバージョンなどの情報の近くに編集ボタンを配置し、意味的に近い部分に配置することによってより分かりやすくします。

スクリーンショット

バージョン・リリース日の表示
![Screenshot from 2023-05-29 16-19-00](https://github.com/npocccties/chibichilo/assets/1730234/a6f14916-e52b-438c-acee-3f08eb65827a)
![Screenshot from 2023-05-29 16-19-33](https://github.com/npocccties/chibichilo/assets/1730234/1282a387-9ebf-4c90-a46f-61688c702422)

リリース編集ボタン
![Screenshot from 2023-05-29 16-18-32](https://github.com/npocccties/chibichilo/assets/1730234/2d72a5bb-2544-4442-84e9-a5b9985bcad1)