### PR TITLE
feat: IPアドレスによるクライアント認証の廃止

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,1 @@
+trailingComma: es5

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -34,11 +34,11 @@ async function seed() {
   // TODO: upsert時の一意性の問題が解決したら `Promise.all()` 等に修正して。
   //       See also https://github.com/prisma/prisma/issues/3242
   for (const topic of topics) {
-    await upsertTopic(creatorId, topic, "");
+    await upsertTopic(creatorId, topic);
   }
 
   const createdBooks = (await Promise.all(
-    books.map((book) => createBook(creatorId, book, ""))
+    books.map((book) => createBook(creatorId, book))
   )) as BookSchema[];
 
   // TODO: upsert時の一意性の問題が解決したら `Promise.all()` 等に修正して。

--- a/server/services/activity.ts
+++ b/server/services/activity.ts
@@ -42,12 +42,10 @@ export const hooks = {
 export async function index({
   session,
   query,
-  ip,
 }: FastifyRequest<{ Querystring: Query }>) {
   const body = await findAllActivity(
     session,
-    Boolean(query.current_lti_context_only),
-    ip
+    Boolean(query.current_lti_context_only)
   );
 
   return { status: 200, body };

--- a/server/services/book/activity/update.ts
+++ b/server/services/book/activity/update.ts
@@ -59,7 +59,7 @@ export async function update(
   const client = await findClient(req.session.oauthClient.id);
   if (client == null) return { status: 401 };
 
-  const book = await findBook(req.params.book_id, req.session.user.id, req.ip);
+  const book = await findBook(req.params.book_id, req.session.user.id);
   if (book == null) return { status: 404 };
 
   const topics =

--- a/server/services/book/create.ts
+++ b/server/services/book/create.ts
@@ -25,9 +25,8 @@ export const createHooks = {
 export async function create({
   session,
   body,
-  ip,
 }: FastifyRequest<{ Body: BookProps }>) {
-  const created = await createBook(session.user.id, body, ip);
+  const created = await createBook(session.user.id, body);
 
   return {
     status: created == null ? 400 : 201,

--- a/server/services/book/public.ts
+++ b/server/services/book/public.ts
@@ -32,7 +32,6 @@ export const hook = {
 export async function method({
   params,
   headers,
-  ip,
 }: FastifyRequest<{ Params: BookPublicParams; Headers: BookPublicHeaders }>) {
   const { token } = params;
   const { originreferer } = headers;
@@ -42,7 +41,7 @@ export async function method({
     return { status: 404 };
   }
 
-  const book = await findBook(publicBook.bookId, publicBook.userId, ip);
+  const book = await findBook(publicBook.bookId, publicBook.userId);
 
   return {
     status: book == null ? 404 : 200,

--- a/server/services/book/show.ts
+++ b/server/services/book/show.ts
@@ -27,7 +27,6 @@ export const showHooks = {
 export async function show({
   session,
   params,
-  ip,
 }: FastifyRequest<{ Params: BookParams }>) {
   const { book_id: bookId } = params;
 
@@ -35,7 +34,7 @@ export async function show({
     return { status: 403 };
   }
 
-  const book = await findBook(bookId, session.user.id, ip);
+  const book = await findBook(bookId, session.user.id);
 
   return {
     status: book == null ? 404 : 200,

--- a/server/services/book/update.ts
+++ b/server/services/book/update.ts
@@ -34,21 +34,16 @@ export async function update({
   session,
   body,
   params,
-  ip,
 }: FastifyRequest<{ Body: BookProps; Params: BookParams }>) {
   const found = await bookExists(params.book_id);
 
   if (!found) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
-  const created = await updateBook(
-    session.user.id,
-    {
-      ...body,
-      id: params.book_id,
-    },
-    ip
-  );
+  const created = await updateBook(session.user.id, {
+    ...body,
+    id: params.book_id,
+  });
 
   return {
     status: created == null ? 400 : 201,

--- a/server/services/books.ts
+++ b/server/services/books.ts
@@ -38,13 +38,10 @@ export const hooks = {
   get: { auth: [authUser, authInstructor] },
 };
 
-export async function index({
-  query,
-  ip,
-}: FastifyRequest<{ Querystring: Query }>) {
+export async function index({ query }: FastifyRequest<{ Querystring: Query }>) {
   const page = query.page ?? 0;
   const perPage = query.per_page ?? 50;
-  const books = await findBooks(query.sort, page, perPage, ip);
+  const books = await findBooks(query.sort, page, perPage);
 
   return {
     status: 200,

--- a/server/services/resources.ts
+++ b/server/services/resources.ts
@@ -38,13 +38,10 @@ export const hooks = {
   get: { auth: [authUser, authInstructor] },
 };
 
-export async function index({
-  query,
-  ip,
-}: FastifyRequest<{ Querystring: Query }>) {
+export async function index({ query }: FastifyRequest<{ Querystring: Query }>) {
   const page = query.page ?? 0;
   const perPage = query.per_page ?? 50;
-  const resources = await findResources(query.sort, page, perPage, ip);
+  const resources = await findResources(query.sort, page, perPage);
 
   return {
     status: 200,

--- a/server/services/search.ts
+++ b/server/services/search.ts
@@ -30,7 +30,6 @@ export const hooks = {
 export async function index({
   session,
   query,
-  ip,
 }: FastifyRequest<{ Querystring: Query }>) {
   const filter = {
     type: query.filter ?? "all",
@@ -51,8 +50,7 @@ export async function index({
         sort,
         page,
         perPage,
-        session.user.id,
-        ip
+        session.user.id
       );
 
       return {

--- a/server/services/topic/create.ts
+++ b/server/services/topic/create.ts
@@ -28,7 +28,6 @@ export async function create({
   hostname,
   session,
   body,
-  ip,
 }: FastifyRequest<{
   Body: TopicProps;
 }>) {
@@ -37,7 +36,7 @@ export async function create({
     return { status: 400 };
   }
 
-  const created = await createTopic(session.user.id, body, ip);
+  const created = await createTopic(session.user.id, body);
 
   return {
     status: created == null ? 400 : 201,

--- a/server/services/topic/show.ts
+++ b/server/services/topic/show.ts
@@ -25,10 +25,9 @@ export const showHooks = {
 
 export async function show({
   params,
-  ip,
 }: FastifyRequest<{ Params: TopicParams }>) {
   const { topic_id: topicId } = params;
-  const topic = await findTopic(topicId, ip);
+  const topic = await findTopic(topicId);
 
   return {
     status: topic == null ? 404 : 200,

--- a/server/services/topic/update.ts
+++ b/server/services/topic/update.ts
@@ -38,7 +38,6 @@ export async function update({
   session,
   body,
   params,
-  ip,
 }: FastifyRequest<{
   Body: TopicProps;
   Params: TopicParams;
@@ -53,11 +52,10 @@ export async function update({
     return { status: 400 };
   }
 
-  const created = await upsertTopic(
-    session.user.id,
-    { ...body, id: params.topic_id },
-    ip
-  );
+  const created = await upsertTopic(session.user.id, {
+    ...body,
+    id: params.topic_id,
+  });
 
   if (created == null) return { status: 400 };
 

--- a/server/services/topics.ts
+++ b/server/services/topics.ts
@@ -38,13 +38,10 @@ export const hooks = {
   get: { auth: [authUser, authInstructor] },
 };
 
-export async function index({
-  query,
-  ip,
-}: FastifyRequest<{ Querystring: Query }>) {
+export async function index({ query }: FastifyRequest<{ Querystring: Query }>) {
   const page = query.page ?? 0;
   const perPage = query.per_page ?? 50;
-  const topics = await findTopics(query.sort, page, perPage, ip);
+  const topics = await findTopics(query.sort, page, perPage);
 
   return {
     status: 200,

--- a/server/services/user/books.ts
+++ b/server/services/user/books.ts
@@ -34,12 +34,11 @@ export const hooks = {
 export async function index({
   query,
   params,
-  ip,
 }: FastifyRequest<{ Querystring: Query; Params: Params }>) {
   const page = query.page ?? 0;
   const perPage = query.per_page ?? 50;
   const { user_id: userId } = params;
-  const books = await findBooksBy(userId, query.sort, page, perPage, ip);
+  const books = await findBooksBy(userId, query.sort, page, perPage);
 
   return {
     status: 200,

--- a/server/services/user/topics.ts
+++ b/server/services/user/topics.ts
@@ -34,12 +34,11 @@ export const hooks = {
 export async function index({
   query,
   params,
-  ip,
 }: FastifyRequest<{ Querystring: Query; Params: Params }>) {
   const page = query.page ?? 0;
   const perPage = query.per_page ?? 50;
   const { user_id: userId } = params;
-  const topics = await findTopicsBy(userId, query.sort, page, perPage, ip);
+  const topics = await findTopicsBy(userId, query.sort, page, perPage);
 
   return {
     status: 200,

--- a/server/services/videoTrack/create.ts
+++ b/server/services/videoTrack/create.ts
@@ -36,12 +36,7 @@ export async function create(
   }>
 ) {
   const url = `${req.protocol}://${req.hostname}${req.url}`;
-  const created = await createVideoTrack(
-    url,
-    req.params.resource_id,
-    req.body,
-    req.ip
-  );
+  const created = await createVideoTrack(url, req.params.resource_id, req.body);
 
   return {
     status: created == null ? 400 : 201,

--- a/server/services/videoTrack/show.ts
+++ b/server/services/videoTrack/show.ts
@@ -25,7 +25,6 @@ export const showHooks = {
 export async function show({
   params,
   query,
-  ip,
 }: FastifyRequest<{
   Params: VideoTrackParams;
   Querystring: TopicResourceProps;
@@ -33,7 +32,6 @@ export async function show({
   if (
     !checkVttAccessToken(
       query.accessToken,
-      ip,
       params.resource_id,
       params.video_track_id
     )

--- a/server/services/wowza/show.ts
+++ b/server/services/wowza/show.ts
@@ -34,13 +34,11 @@ export const showHooks = {
 export async function show({
   params,
   query,
-  ip,
 }: FastifyRequest<{ Params: Params; Querystring: Query }>) {
   const path = params["*"];
 
   if (disabled(path)) return { status: 404 };
-  if (!checkWowzaAccessToken(query.accessToken, ip, path))
-    return { status: 403 };
+  if (!checkWowzaAccessToken(query.accessToken, path)) return { status: 403 };
 
   const expires: Record<string, string> =
     WOWZA_EXPIRES_IN > 0

--- a/server/utils/activity/bookWithActivity.ts
+++ b/server/utils/activity/bookWithActivity.ts
@@ -8,12 +8,8 @@ import { getDisplayableBook } from "$server/utils/displayableBook";
 import contentBy from "$server/utils/contentBy";
 import isCompleted from "./isCompleted";
 
-function bookToCourseBook(
-  user: Pick<UserSchema, "id">,
-  book: BookWithTopics,
-  ip: string
-) {
-  const courseBook = getDisplayableBook(bookToBookSchema(book, ip), (content) =>
+function bookToCourseBook(user: Pick<UserSchema, "id">, book: BookWithTopics) {
+  const courseBook = getDisplayableBook(bookToBookSchema(book), (content) =>
     contentBy(content, user)
   );
 
@@ -25,7 +21,6 @@ export function toSchema({
   user,
   books,
   activities,
-  ip,
 }: {
   user: Pick<UserSchema, "id">;
   books: Array<BookWithTopics>;
@@ -35,13 +30,12 @@ export function toSchema({
       "learner" | "topic" | "totalTimeMs" | "createdAt" | "updatedAt"
     >
   >;
-  ip: string;
 }): {
   courseBooks: Array<CourseBookSchema>;
   bookActivities: Array<BookActivitySchema>;
 } {
   const courseBooks = books.flatMap((book) => {
-    const courseBook = bookToCourseBook(user, book, ip);
+    const courseBook = bookToCourseBook(user, book);
     return courseBook ? [courseBook] : [];
   });
   const bookActivities = courseBooks.flatMap((book) =>

--- a/server/utils/activity/findAllActivity.ts
+++ b/server/utils/activity/findAllActivity.ts
@@ -69,8 +69,7 @@ async function findLtiMembers(
  */
 async function findAllActivity(
   session: SessionSchema,
-  currentLtiContextOnly: boolean,
-  ip: string
+  currentLtiContextOnly: boolean
 ): Promise<{
   learners: Array<LearnerSchema>;
   courseBooks: Array<CourseBookSchema>;
@@ -95,7 +94,6 @@ async function findAllActivity(
     user,
     books,
     activities,
-    ip,
   });
 
   return { learners: ltiMembers, courseBooks, bookActivities };

--- a/server/utils/book/bookToBookSchema.ts
+++ b/server/utils/book/bookToBookSchema.ts
@@ -69,35 +69,29 @@ export type BookWithTopics = Prisma.BookGetPayload<
   typeof bookIncludingTopicsArg
 >;
 
-export function bookToBookSchema(book: BookWithTopics, ip: string): BookSchema {
+export function bookToBookSchema(book: BookWithTopics): BookSchema {
   return {
     ...book,
     authors: book.authors.map(authorToAuthorSchema),
     ltiResourceLinks: book.ltiResourceLinks.map(ltiResourceLinkToSchema),
-    sections: book.sections.map((section) =>
-      sectionToSectionSchema(section, ip)
-    ),
+    sections: book.sections.map((section) => sectionToSectionSchema(section)),
   };
 }
 
-function sectionToSectionSchema(
-  section: SectionWithTopics,
-  ip: string
-): SectionSchema {
+function sectionToSectionSchema(section: SectionWithTopics): SectionSchema {
   return {
     ...section,
     topics: section.topicSections.map((topicSection) =>
-      topicSectionToTopicSchema(topicSection, ip)
+      topicSectionToTopicSchema(topicSection)
     ),
   };
 }
 
 function topicSectionToTopicSchema(
-  topicSection: TopicSectionWithTopic,
-  ip: string
+  topicSection: TopicSectionWithTopic
 ): TopicSchema {
   return {
     ...topicSection,
-    ...topicToTopicSchema(topicSection.topic, ip),
+    ...topicToTopicSchema(topicSection.topic),
   };
 }

--- a/server/utils/book/createBook.ts
+++ b/server/utils/book/createBook.ts
@@ -9,8 +9,7 @@ import upsertPublicBooks from "$server/utils/publicBook/upsertPublicBooks";
 
 async function createBook(
   userId: UserSchema["id"],
-  { publicBooks, ...book }: BookProps,
-  ip: string
+  { publicBooks, ...book }: BookProps
 ): Promise<BookSchema | undefined> {
   const timeRequired = await aggregateTimeRequired(book);
   const sectionsCreateInput = book.sections?.map(sectionCreateInput) ?? [];
@@ -28,7 +27,7 @@ async function createBook(
 
   await prisma.$transaction(upsertPublicBooks(userId, id, publicBooks ?? []));
 
-  return findBook(id, userId, ip);
+  return findBook(id, userId);
 }
 
 export default createBook;

--- a/server/utils/book/findBook.ts
+++ b/server/utils/book/findBook.ts
@@ -8,8 +8,7 @@ import {
 
 async function findBook(
   bookId: Book["id"],
-  userId: number,
-  ip: string
+  userId: number
 ): Promise<BookSchema | undefined> {
   const book = await prisma.book.findUnique({
     ...getBookIncludingArg(userId),
@@ -17,7 +16,7 @@ async function findBook(
   });
   if (book == null) return;
 
-  return bookToBookSchema(book, ip);
+  return bookToBookSchema(book);
 }
 
 export default findBook;

--- a/server/utils/book/findBooks.ts
+++ b/server/utils/book/findBooks.ts
@@ -9,8 +9,7 @@ import {
 async function findBooks(
   sort = "updated",
   page: number,
-  perPage: number,
-  ip: string
+  perPage: number
 ): Promise<BookSchema[]> {
   const books = await prisma.book.findMany({
     ...bookIncludingTopicsArg,
@@ -19,7 +18,7 @@ async function findBooks(
     take: perPage,
   });
 
-  return books.map((book) => bookToBookSchema(book, ip));
+  return books.map((book) => bookToBookSchema(book));
 }
 
 export default findBooks;

--- a/server/utils/book/importBooksUtil.ts
+++ b/server/utils/book/importBooksUtil.ts
@@ -79,7 +79,7 @@ class ImportBooksUtil {
 
       const books = [];
       for (const book of await prisma.$transaction(transactions)) {
-        const res = await findBook(book.id, this.user.id, "");
+        const res = await findBook(book.id, this.user.id);
         if (res) books.push(res as BookSchema);
       }
 
@@ -101,7 +101,7 @@ class ImportBooksUtil {
       ]);
 
       for (const book of books) {
-        const res = await findBook(book.id, this.user.id, "");
+        const res = await findBook(book.id, this.user.id);
         if (res) this.books.push(res as BookSchema);
       }
     } catch (e) {

--- a/server/utils/book/updateBook.ts
+++ b/server/utils/book/updateBook.ts
@@ -22,8 +22,7 @@ function upsertSections(bookId: Book["id"], sections: SectionProps[]) {
 
 async function updateBook(
   userId: number,
-  { id, sections, publicBooks, ...book }: Pick<Book, "id"> & BookProps,
-  ip: string
+  { id, sections, publicBooks, ...book }: Pick<Book, "id"> & BookProps
 ): Promise<BookSchema | undefined> {
   const ops: Array<PrismaPromise<unknown>> = [];
 
@@ -56,7 +55,7 @@ async function updateBook(
 
   await prisma.$transaction(ops);
 
-  return await findBook(id, userId, ip);
+  return await findBook(id, userId);
 }
 
 function removePublicBooks(

--- a/server/utils/resource/findResources.ts
+++ b/server/utils/resource/findResources.ts
@@ -6,8 +6,7 @@ import { resourceWithVideoArg, resourceToResourceSchema } from "./toSchema";
 async function findResources(
   sort = "updated",
   page: number,
-  perPage: number,
-  ip: string
+  perPage: number
 ): Promise<ResourceSchema[]> {
   const sortQuery = makeSortOrderQuery(sort);
   const resources = await prisma.resource.findMany({
@@ -17,7 +16,7 @@ async function findResources(
     take: perPage,
   });
 
-  return resources.map((resource) => resourceToResourceSchema(resource, ip));
+  return resources.map((resource) => resourceToResourceSchema(resource));
 }
 
 export default findResources;

--- a/server/utils/resource/toSchema.ts
+++ b/server/utils/resource/toSchema.ts
@@ -17,20 +17,15 @@ export const resourceWithVideoArg = {
 type ResourceWithVideo = Prisma.ResourceGetPayload<typeof resourceWithVideoArg>;
 
 export function resourceToResourceSchema(
-  resource: ResourceWithVideo,
-  ip: string
+  resource: ResourceWithVideo
 ): ResourceSchema {
   return {
-    accessToken: getWowzaAccessToken(
-      ip,
-      resource.url,
-      resource.video?.providerUrl
-    ),
+    accessToken: getWowzaAccessToken(resource.url, resource.video?.providerUrl),
     ...resource.video,
     tracks: resource.video?.tracks.map((track) => ({
       ...track,
       url: `${API_BASE_PATH}/resource/${resource.id}/video_track/${track.id}/vtt`,
-      accessToken: getVttAccessToken(ip, resource.id, track.id),
+      accessToken: getVttAccessToken(resource.id, track.id),
     })),
     ...resource,
   };

--- a/server/utils/search/bookSearch.ts
+++ b/server/utils/search/bookSearch.ts
@@ -36,8 +36,7 @@ async function bookSearch(
   sort: string,
   page: number,
   perPage: number,
-  userId: number,
-  ip: string
+  userId: number
 ): Promise<SearchResultSchema> {
   const insensitiveMode = { mode: "insensitive" as const };
   const where: Prisma.BookWhereInput = {
@@ -169,7 +168,7 @@ async function bookSearch(
   });
 
   const contents = books
-    .map((book) => bookToBookSchema(book, ip))
+    .map((book) => bookToBookSchema(book))
     .map((book) => ({ type: "book" as const, ...book }));
 
   return { totalCount, contents, page, perPage };

--- a/server/utils/search/search.ts
+++ b/server/utils/search/search.ts
@@ -12,20 +12,12 @@ async function search(
   sort: string,
   page: number,
   perPage: number,
-  userId: number,
-  ip: string
+  userId: number
 ): Promise<SearchResultSchema> {
   const query = parse(queryText);
   switch (type) {
     case "topic": {
-      return await topicSearch(
-        { type, ...query },
-        filter,
-        sort,
-        page,
-        perPage,
-        ip
-      );
+      return await topicSearch({ type, ...query }, filter, sort, page, perPage);
     }
     case "book": {
       return await bookSearch(
@@ -34,8 +26,7 @@ async function search(
         sort,
         page,
         perPage,
-        userId,
-        ip
+        userId
       );
     }
     default:

--- a/server/utils/search/topicSearch.ts
+++ b/server/utils/search/topicSearch.ts
@@ -34,8 +34,7 @@ async function topicSearch(
   filter: AuthorFilter,
   sort: string,
   page: number,
-  perPage: number,
-  ip: string
+  perPage: number
 ): Promise<SearchResultSchema> {
   const insensitiveMode = { mode: "insensitive" as const };
   const where: Prisma.TopicWhereInput = {
@@ -136,7 +135,7 @@ async function topicSearch(
   });
   const relatedBooksMap = new Map(relatedBooks.map((book) => [book.id, book]));
   const contents = topics
-    .map((topic) => topicToTopicSchema(topic, ip, { relatedBooksMap }))
+    .map((topic) => topicToTopicSchema(topic, { relatedBooksMap }))
     .map((topic) => ({
       type: "topic" as const,
       ...topic,

--- a/server/utils/topic/createTopic.ts
+++ b/server/utils/topic/createTopic.ts
@@ -9,8 +9,7 @@ import topicCreateInput from "./topicCreateInput";
 
 async function createTopic(
   authorId: User["id"],
-  topic: TopicProps,
-  ip: string
+  topic: TopicProps
 ): Promise<TopicSchema | undefined> {
   const created = await prisma.topic.create({
     data: topicCreateInput(authorId, topic),
@@ -25,7 +24,7 @@ async function createTopic(
 
   if (!found) return;
 
-  return topicToTopicSchema(found, ip);
+  return topicToTopicSchema(found);
 }
 
 export default createTopic;

--- a/server/utils/topic/findTopic.ts
+++ b/server/utils/topic/findTopic.ts
@@ -7,8 +7,7 @@ import {
 } from "./topicToTopicSchema";
 
 async function findTopic(
-  topicId: Topic["id"],
-  ip: string
+  topicId: Topic["id"]
 ): Promise<TopicSchema | undefined> {
   const topic = await prisma.topic.findUnique({
     ...topicsWithResourcesArg,
@@ -16,7 +15,7 @@ async function findTopic(
   });
   if (topic == null) return;
 
-  return topicToTopicSchema(topic, ip);
+  return topicToTopicSchema(topic);
 }
 
 export default findTopic;

--- a/server/utils/topic/findTopics.ts
+++ b/server/utils/topic/findTopics.ts
@@ -9,8 +9,7 @@ import {
 async function findTopics(
   sort = "updated",
   page: number,
-  perPage: number,
-  ip: string
+  perPage: number
 ): Promise<TopicSchema[]> {
   const topics = await prisma.topic.findMany({
     ...topicsWithResourcesArg,
@@ -19,7 +18,7 @@ async function findTopics(
     take: perPage,
   });
 
-  return topics.map((topic) => topicToTopicSchema(topic, ip));
+  return topics.map((topic) => topicToTopicSchema(topic));
 }
 
 export default findTopics;

--- a/server/utils/topic/topicToTopicSchema.ts
+++ b/server/utils/topic/topicToTopicSchema.ts
@@ -25,13 +25,11 @@ export type TopicWithResource = Prisma.TopicGetPayload<
 /**
  * TopicSchemaへの変換
  * @param topicWithResource データベースで扱われるリソース含むTopic
- * @param ip req.ip
  * @param options オプション
  * @param options.relatedBooksMap トピックに関連するブックの集合
  */
 export function topicToTopicSchema(
   { topicSection, ...topic }: TopicWithResource,
-  ip: string,
   options?: {
     relatedBooksMap: Map<Book["id"], Book>;
   }
@@ -39,7 +37,7 @@ export function topicToTopicSchema(
   return {
     ...topic,
     authors: topic.authors.map(authorToAuthorSchema),
-    resource: resourceToResourceSchema(topic.resource, ip),
+    resource: resourceToResourceSchema(topic.resource),
     relatedBooks: options && [
       ...topicSection
         .reduce((books, ts) => {

--- a/server/utils/topic/upsertTopic.ts
+++ b/server/utils/topic/upsertTopic.ts
@@ -27,8 +27,7 @@ function topicUpdateInput(topic: TopicProps, keywords: KeywordSchema[]) {
 
 async function upsertTopic(
   authorId: User["id"],
-  { id, ...topic }: TopicProps & Pick<Topic, "id">,
-  ip: string
+  { id, ...topic }: TopicProps & Pick<Topic, "id">
 ): Promise<TopicSchema | undefined> {
   const keywordsBeforeUpdate = await prisma.keyword.findMany({
     where: { topics: { some: { id } } },
@@ -42,7 +41,7 @@ async function upsertTopic(
 
   if (!created) return;
 
-  return topicToTopicSchema(created, ip);
+  return topicToTopicSchema(created);
 }
 
 export default upsertTopic;

--- a/server/utils/topicResourceToken.ts
+++ b/server/utils/topicResourceToken.ts
@@ -14,7 +14,20 @@ const SECRET_KEY = SESSION_SECRET.substring(0, 32);
 // providerUrl == "https://www.wowza.com/" ではないwowza動画が存在するため、wowza以外のサービスでなければwowzaと判定する
 const EXCEPT_WOWZA_URL = ["https://www.youtube.com/", "https://vimeo.com/"];
 
-export function getAccessToken(value: Record<string, unknown>) {
+type WowzaClaim = {
+  expired: string | null;
+  url: string;
+};
+
+type VttClaim = {
+  expired: string;
+  resourceId: number;
+  videoTrackId: number;
+};
+
+type Claim = WowzaClaim | VttClaim;
+
+export function getAccessToken<Value extends Claim>(value: Value) {
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv(
     PUBLIC_ACCESS_CRYPTO_ALGORITHM,
@@ -28,7 +41,9 @@ export function getAccessToken(value: Record<string, unknown>) {
   return iv.toString(ENCODING) + SEPARATOR + encrypted.toString(ENCODING);
 }
 
-export function parseAccessToken(accessToken: string) {
+export function parseAccessToken<Value extends Claim>(
+  accessToken: string
+): Value {
   const [iv, encrypted] = accessToken.split(SEPARATOR);
   const decipher = crypto.createDecipheriv(
     PUBLIC_ACCESS_CRYPTO_ALGORITHM,
@@ -43,36 +58,30 @@ export function parseAccessToken(accessToken: string) {
 }
 
 export function getWowzaAccessToken(
-  ip: string,
   url: string,
   providerUrl: string | null | undefined
 ) {
-  if (!ip || EXCEPT_WOWZA_URL.includes(providerUrl ?? "")) return "";
+  if (EXCEPT_WOWZA_URL.includes(providerUrl ?? "")) return "";
 
   const value = {
-    ip,
     expired:
       WOWZA_EXPIRES_IN > 0
-        ? new Date(new Date().getTime() + WOWZA_EXPIRES_IN * 1000)
+        ? new Date(new Date().getTime() + WOWZA_EXPIRES_IN * 1000).toISOString()
         : null,
     url,
   };
   return getAccessToken(value);
 }
 
-export function checkWowzaAccessToken(
-  accessToken: string,
-  ip: string,
-  path: string
-) {
+export function checkWowzaAccessToken(accessToken: string, path: string) {
   if (!accessToken) return false;
 
   try {
-    const value = parseAccessToken(accessToken);
+    const value = parseAccessToken<WowzaClaim>(accessToken);
     return (
-      value.ip == ip &&
-      (WOWZA_EXPIRES_IN === 0 ||
-        new Date(value.expired).getTime() > new Date().getTime()) &&
+      WOWZA_EXPIRES_IN !== 0 &&
+      value.expired != null &&
+      new Date(value.expired).getTime() > new Date().getTime() &&
       new URL(value.url).pathname == `${API_BASE_PATH}/wowza/${path}`
     );
   } catch (e) {
@@ -80,36 +89,27 @@ export function checkWowzaAccessToken(
   }
 }
 
-export function getVttAccessToken(
-  ip: string,
-  resourceId: number,
-  videoTrackId: number
-) {
-  if (!ip) return "";
-
+export function getVttAccessToken(resourceId: number, videoTrackId: number) {
   const value = {
-    ip,
     expired: new Date(
       new Date().getTime() + VTT_ACCESS_TOKEN_EXPIRES_IN * 1000
-    ),
+    ).toISOString(),
     resourceId,
     videoTrackId,
   };
-  return getAccessToken(value);
+  return getAccessToken<VttClaim>(value);
 }
 
 export function checkVttAccessToken(
   accessToken: string,
-  ip: string,
   resourceId: number,
   videoTrackId: number
 ) {
   if (!accessToken) return false;
 
   try {
-    const value = parseAccessToken(accessToken);
+    const value = parseAccessToken<VttClaim>(accessToken);
     return (
-      value.ip == ip &&
       new Date(value.expired).getTime() > new Date().getTime() &&
       value.resourceId == resourceId &&
       value.videoTrackId == videoTrackId

--- a/server/utils/user.ts
+++ b/server/utils/user.ts
@@ -51,8 +51,7 @@ export async function findBooksBy(
   by: User["id"],
   sort = "updated",
   page: number,
-  perPage: number,
-  ip: string
+  perPage: number
 ): Promise<BookSchema[]> {
   const authorship = await prisma.authorship.findMany({
     where: { userId: by },
@@ -67,7 +66,7 @@ export async function findBooksBy(
   });
 
   return authorship.flatMap(({ book }) =>
-    book == null ? [] : [bookToBookSchema(book, ip)]
+    book == null ? [] : [bookToBookSchema(book)]
   );
 }
 
@@ -75,8 +74,7 @@ export async function findTopicsBy(
   by: User["id"],
   sort = "updated",
   page: number,
-  perPage: number,
-  ip: string
+  perPage: number
 ): Promise<TopicSchema[]> {
   const authorship = await prisma.authorship.findMany({
     where: { userId: by },
@@ -91,6 +89,6 @@ export async function findTopicsBy(
   });
 
   return authorship.flatMap(({ topic }) =>
-    topic == null ? [] : [topicToTopicSchema(topic, ip)]
+    topic == null ? [] : [topicToTopicSchema(topic)]
   );
 }

--- a/server/utils/videoTrack/createVideoTrack.ts
+++ b/server/utils/videoTrack/createVideoTrack.ts
@@ -9,8 +9,7 @@ import { getVttAccessToken } from "$server/utils/topicResourceToken";
 async function createVideoTrack(
   createRequestUrl: string,
   resourceId: Resource["id"],
-  { content, ...props }: VideoTrackProps,
-  ip: string
+  { content, ...props }: VideoTrackProps
 ): Promise<undefined | VideoTrackSchema> {
   const resource = await prisma.resource.findUnique({
     where: { id: resourceId },
@@ -35,7 +34,7 @@ async function createVideoTrack(
   return {
     ...created,
     url: `${createRequestUrl}/${created.id}/vtt`,
-    accessToken: getVttAccessToken(ip, resourceId, created.id),
+    accessToken: getVttAccessToken(resourceId, created.id),
   };
 }
 

--- a/server/utils/wowza/token.ts
+++ b/server/utils/wowza/token.ts
@@ -3,7 +3,6 @@ import { createHash } from "crypto";
 /**
  * Wowza Streaming Engine のクライアントのための署名の作成
  * パラメータ名にアルファベットA-Za-z以外を含めると正しい署名の得られない可能性があるので注意
- * @todo "Include client IP address in hash generation" 未対応
  * @param contentPath コンテンツのパス
  * @param params パラメーター
  * @param prefix SecureToken prefix
@@ -40,7 +39,6 @@ export function sign(
 /**
  * Wowza Streaming Engine のクライアントのためのURLクエリの生成
  * パラメータ名にアルファベットA-Za-z以外を含めると正しい署名の得られない可能性があるので注意
- * @todo "Include client IP address in hash generation" 未対応
  * @param contentPath コンテンツのパス
  * @param params パラメーター
  * @param secret 共通鍵


### PR DESCRIPTION
resolved #972

外側インターフェースに複数IPアドレスがついているケースなど、必ずしもチェックが機能するとはいえず、一部の環境で可用性が損なわれる問題がありました。
IPアドレスによるチェックを行わないように変更します。
