### PR TITLE
feat: Target Link URI をもとに LTI Resource Link として紐付ける

### DIFF
--- a/server/utils/ltiResourceLink.ts
+++ b/server/utils/ltiResourceLink.ts
@@ -48,6 +48,7 @@ export async function upsertLtiResourceLink(
     book: { connect: { id: bookId } },
     consumer: { connect: { id: consumerId } },
     creator: { connect: { id: creatorId } },
+    updatedAt: new Date(),
   };
 
   await prisma.$transaction([


### PR DESCRIPTION
resolved #967 resolved #968

- feat: Target Link URI をもとに LTI Resource Link として紐付ける

確認したこと: Tool URL を変更し LTI Resource Link によって提供されるブックが変更可能なこと
その提供されているブックにリダイレクトされること

[Screencast from 2023年07月11日 18時56分46秒.webm](https://github.com/npocccties/chibichilo/assets/1730234/ccdbc791-74ae-4699-be0a-e3be2e93fe48)

http://localhost:3000/book?bookId=1 → http://localhost:3000/book?bookId=2 に変更出来ることを確認
また、従来どおり操作できることを一通り確認