### PR TITLE
feat:UI: Deep Linking でのリンクの選択画面でのいくつかの操作の廃止

### DIFF
--- a/components/organisms/AppBar.tsx
+++ b/components/organisms/AppBar.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles((theme) => ({
   inner: {
     display: "flex",
     alignItems: "center",
+    justifyContent: "space-between",
     maxWidth: theme.breakpoints.values.lg,
     width: "100%",
     margin: "0 auto",
@@ -79,8 +80,6 @@ const role = (session: SessionSchema) => {
 };
 
 function AppBar(props: Props, ref: Ref<HTMLDivElement>) {
-  const isDeepLink = true; // TODO:sessionに保存したDeepLinkのtarget_urlで判定する
-
   const {
     session,
     onBooksClick,
@@ -90,6 +89,7 @@ function AppBar(props: Props, ref: Ref<HTMLDivElement>) {
     onDashboardClick,
     ...others
   } = props;
+  const isDeepLink = !!session.ltiDlSettings?.deep_link_return_url;
   const appBarClasses = useAppBarStyles();
   const classes = useStyles();
   const [open, setOpen] = useState(false);
@@ -190,22 +190,24 @@ function AppBar(props: Props, ref: Ref<HTMLDivElement>) {
               )}
             </div>
           )}
-          <div className={clsx(classes.user, classes.margin)}>
-            <p>{session.user.name}</p>
-            <p className={classes.roles}>{role(session)}</p>
+          <div>
+            <div className={clsx(classes.user, classes.margin)}>
+              <p>{session.user.name}</p>
+              <p className={classes.roles}>{role(session)}</p>
+            </div>
+            {session && (
+              <>
+                <Button variant="text" color="primary" onClick={handleClick}>
+                  LTI情報
+                </Button>
+                <LtiItemDialog
+                  open={open}
+                  onClose={handleClose}
+                  session={session}
+                />
+              </>
+            )}
           </div>
-          {session && (
-            <>
-              <Button variant="text" color="primary" onClick={handleClick}>
-                LTI情報
-              </Button>
-              <LtiItemDialog
-                open={open}
-                onClose={handleClose}
-                session={session}
-              />
-            </>
-          )}
         </div>
       </Toolbar>
       <Snackbar

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -124,6 +124,7 @@ type Props = Parameters<typeof Checkbox>[0] & {
   onKeywordClick(keyword: Pick<KeywordSchema, "name">): void;
   onRelatedBookClick?(id: RelatedBook): void;
   linked?: boolean;
+  isDeepLink?: boolean;
 };
 
 export default function ContentPreview({
@@ -135,11 +136,10 @@ export default function ContentPreview({
   onKeywordClick,
   onRelatedBookClick,
   linked = content.type === "book" ? false : undefined,
+  isDeepLink,
   checked,
   ...checkboxProps
 }: Props) {
-  const isDeepLink = true; // TODO:sessionに保存したDeepLinkのtarget_urlで判定する
-
   const lineClamp = useLineClampStyles({
     fontSize: "0.75rem",
     lineClamp: 2,

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -16,10 +16,12 @@ import type { ContentSchema } from "$server/models/content";
 import type { BookSchema } from "$server/models/book";
 import type { LinkedBook } from "$types/linkedBook";
 import { useSearchAtom } from "$store/search";
+import type { SessionSchema } from "$server/models/session";
 
 export type Props = {
   totalCount: number;
   contents: ContentSchema[];
+  session?: SessionSchema;
   linkedBook?: LinkedBook;
   loading?: boolean;
   onContentPreviewClick(content: ContentSchema): void;
@@ -31,9 +33,8 @@ export type Props = {
 };
 
 export default function Books(props: Props) {
-  const isDeepLink = true; // TODO:sessionに保存したDeepLinkのtarget_urlで判定する
-
   const {
+    session,
     totalCount,
     contents,
     linkedBook,
@@ -45,6 +46,7 @@ export default function Books(props: Props) {
     onBookNewClick,
     onBooksImportClick,
   } = props;
+  const isDeepLink = !!session?.ltiDlSettings?.deep_link_return_url;
   const searchProps = useSearchAtom();
   const handleBookNewClick = () => onBookNewClick();
   const handleBooksImportClick = () => onBooksImportClick();
@@ -98,6 +100,7 @@ export default function Books(props: Props) {
             key={content.id}
             content={content}
             linked={content.id === linkedBook?.id}
+            isDeepLink={isDeepLink}
             onContentPreviewClick={onContentPreviewClick}
             onContentEditClick={onContentEditClick}
             onContentLinkClick={onContentLinkClick}

--- a/pages/books/index.tsx
+++ b/pages/books/index.tsx
@@ -20,7 +20,7 @@ const Books = (
 
 function Index() {
   const router = useRouter();
-  const { isContentEditable } = useSessionAtom();
+  const { session, isContentEditable } = useSessionAtom();
   const { linkedBook } = useLinkedBook();
   const {
     data: previewContent,
@@ -59,7 +59,7 @@ function Index() {
 
   return (
     <>
-      <Books linkedBook={linkedBook} {...handlers} />
+      <Books session={session} linkedBook={linkedBook} {...handlers} />
       {previewContent?.type === "book" && (
         <BookPreviewDialog {...dialogProps} book={previewContent}>
           {(props) => <Book {...props} />}


### PR DESCRIPTION
操作の廃止は以前仮実装を行いました。
関連：#973
issue: #970

このPRでは、実際にセッションの値を見て、Deep Linkか否かを判定し、いつくかの操作を廃止する対応を行いました。
