### PR TITLE
feat: 視聴ログ: 自動再生機能によるplayイベントを記録しないように変更

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -203,51 +203,73 @@ export default function Video({
         }
       });
       void videoInstance.player.setCurrentTime(startTime || 0);
-    } else {
-      const handleSeeked = () => {
-        const currentTime = videoInstance.player.currentTime();
-        // @ts-expect-error startTime is number
-        if (Number.isFinite(startTime) && currentTime < startTime) {
-          videoInstance.player.currentTime(startTime || 0);
-        }
-      };
-      const handleTimeUpdate = () => {
-        if (videoInstance.stopTimeOver) return;
-        const currentTime = videoInstance.player.currentTime();
-        if (isValidPlaybackEnd({ currentTime, stopTime })) {
-          videoInstance.stopTimeOver = true;
-          videoInstance.player.pause();
-          onEnded?.();
-        }
-      };
-      const handlePlay = () => {
-        // 終了位置より後ろにシークすると、意図せず再生が再開してしまうことがあるので、ユーザーの操作によらない再生開始を抑制する
-        if (videoInstance.stopTimeOver) videoInstance.player.pause();
-      };
-      const handleFirstPlay = () => {
-        if (!videoInstance.firstPlay) return;
-
-        // NOTE: 初回playイベントは再生位置を移動して再生する
-        if (startTime && Number.isFinite(startTime)) {
-          videoInstance.player.currentTime(startTime);
-        }
-
-        videoInstance.firstPlay = false;
-      };
-      const handleReady = () => {
-        if (videoInstance.stopTimeOver) {
-          if (Number.isFinite(startTime))
-            videoInstance.player.currentTime(startTime || 0);
-          videoInstance.stopTimeOver = false;
-        }
-        videoInstance.player.on("timeupdate", handleTimeUpdate);
-        videoInstance.player.on("seeked", handleSeeked);
-      };
-
-      videoInstance.player.on("play", handlePlay);
-      videoInstance.player.one("play", handleFirstPlay);
-      videoInstance.player.ready(handleReady);
+      return;
     }
+
+    const handleSeeked = () => {
+      const currentTime = videoInstance.player.currentTime();
+      // @ts-expect-error startTime is number
+      if (Number.isFinite(startTime) && currentTime < startTime) {
+        videoInstance.player.currentTime(startTime || 0);
+      }
+    };
+
+    const handleTimeUpdate = () => {
+      if (videoInstance.stopTimeOver) return;
+      const currentTime = videoInstance.player.currentTime();
+      if (isValidPlaybackEnd({ currentTime, stopTime })) {
+        videoInstance.stopTimeOver = true;
+        videoInstance.player.pause();
+        onEnded?.();
+      }
+    };
+
+    const handlePlay = () => {
+      // 終了位置より後ろにシークすると、意図せず再生が再開してしまうことがあるので、ユーザーの操作によらない再生開始を抑制する
+      if (videoInstance.stopTimeOver) videoInstance.player.pause();
+    };
+
+    const triggerUserPlay = () =>
+      videoInstance.player.trigger("video-js-user-triggered-play");
+
+    const handleFirstPlay = async () => {
+      // NOTE: 初回playイベントは再生位置を移動して再生する
+      if (videoInstance.firstPlay && startTime && Number.isFinite(startTime)) {
+        videoInstance.player.currentTime(startTime);
+      }
+
+      if (videoInstance.firstPlay) {
+        videoInstance.firstPlay = false;
+      }
+
+      // NOTE: 以降のplayイベントを自動再生ではない学習者起因でのイベントとみなす
+      while (videoInstance.player.currentTime() < (startTime || 0) + 0.001) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      videoInstance.player.on("play", triggerUserPlay);
+    };
+
+    const handleReady = () => {
+      if (videoInstance.stopTimeOver) {
+        if (Number.isFinite(startTime))
+          videoInstance.player.currentTime(startTime || 0);
+        videoInstance.stopTimeOver = false;
+      }
+      videoInstance.player.on("timeupdate", handleTimeUpdate);
+      videoInstance.player.on("seeked", handleSeeked);
+    };
+
+    videoInstance.player.on("play", handlePlay);
+    videoInstance.player.one("play", handleFirstPlay);
+    videoInstance.player.ready(handleReady);
+
+    return () => {
+      videoInstance.player.off("timeupdate", handleTimeUpdate);
+      videoInstance.player.off("seeked", handleSeeked);
+      videoInstance.player.off("play", handlePlay);
+      videoInstance.player.off("play", handleFirstPlay);
+      videoInstance.player.off("play", triggerUserPlay);
+    };
     // TODO: videoの内容の変更検知は機能しないので修正したい。Mapオブジェクトでの管理をやめるかMap.prototype.set()を使用しないようにするなど必要かもしれない。
   }, [video, itemExists, prevItemIndex, itemIndex, onEnded]);
 


### PR DESCRIPTION
resolved #981

- fix: 再生開始位置の設定が反映されない不具合の修正
- feat: 視聴ログ: 自動再生機能によるplayイベントを記録しないように変更

ページ読み込み直後の自動再生によってplayイベントが記録されていました。分析のノイズになるのを避けるためにこのイベントの収集を回避します。この変更によって、初回・トピック切り替えのタイミングで発火していたplayイベントが抑制されます。

確認方法:

1. `yarn dev | grep 'play.*videoplayerlog'` コマンドで開発用サーバーを起動
2. 学習者がアクセスする
3. 操作をしながらログを確認

[Screencast from 2023年07月19日 17時10分16秒.webm](https://github.com/npocccties/chibichilo/assets/1730234/8ae22218-f065-4e25-a902-f8415fb5d162)
