### PR TITLE
fix: 再生開始位置の設定が反映されない不具合の修正

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -239,7 +239,7 @@ export default function Video({
       };
 
       videoInstance.player.on("play", handlePlay);
-      videoInstance.player.on("firstplay", handleFirstPlay);
+      videoInstance.player.one("play", handleFirstPlay);
       videoInstance.player.ready(handleReady);
     }
     // TODO: videoの内容の変更検知は機能しないので修正したい。Mapオブジェクトでの管理をやめるかMap.prototype.set()を使用しないようにするなど必要かもしれない。

--- a/server/models/event.ts
+++ b/server/models/event.ts
@@ -9,7 +9,6 @@ export type EventType =
   | "seeking"
   | "seeked"
   | "trackchange"
-  | "firstplay"
   | "play"
   | "pause"
   | "ratechange"

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -62,14 +62,7 @@ function logger(tracker: PlayerTracker) {
     void send("trackchange", event, event.language ?? "off");
   });
 
-  for (const event of [
-    "forward",
-    "back",
-    "firstplay",
-    "ended",
-    "pause",
-    "play",
-  ] as const) {
+  for (const event of ["forward", "back", "ended", "pause", "play"] as const) {
     tracker.on(event, buildHandler(event));
   }
 

--- a/utils/eventLogger/playerTracker.ts
+++ b/utils/eventLogger/playerTracker.ts
@@ -35,8 +35,6 @@ export type PlayerEvents = {
   timeupdate: PlayerEvent;
   playbackratechange: PlayerEvent & { playbackRate: number };
   texttrackchange: PlayerEvent & { language?: string };
-  /** @deprecated */
-  firstplay: PlayerEvent;
 } & CustomEvents;
 
 const youtubeType = "video/youtube";
@@ -107,7 +105,6 @@ export class PlayerTracker extends (EventEmitter as {
       player.on(event, () => this.emit(event, this.stats));
     }
 
-    player.on("firstplay", () => this.emit("firstplay", this.stats));
     player.on("ratechange", () => {
       this.emit("playbackratechange", {
         ...this.stats,


### PR DESCRIPTION
fixed #985

Video.js v8でのfirstplayイベントの削除に起因して発生するようになっていた再生開始位置の設定機能の不具合を修正します。
