### PR TITLE
fix: 2回目以降も再生開始位置の設定が反映される不具合の修正

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -225,8 +225,14 @@ export default function Video({
         if (videoInstance.stopTimeOver) videoInstance.player.pause();
       };
       const handleFirstPlay = () => {
-        if (Number.isFinite(startTime))
-          videoInstance.player.currentTime(startTime || 0);
+        if (!videoInstance.firstPlay) return;
+
+        // NOTE: 初回playイベントは再生位置を移動して再生する
+        if (startTime && Number.isFinite(startTime)) {
+          videoInstance.player.currentTime(startTime);
+        }
+
+        videoInstance.firstPlay = false;
       };
       const handleReady = () => {
         if (videoInstance.stopTimeOver) {

--- a/types/videoInstance.ts
+++ b/types/videoInstance.ts
@@ -9,6 +9,8 @@ export type VideoJsInstance = {
   player: VideoJsPlayer;
   tracks?: VideoJsTextTrackList;
   stopTimeOver: boolean;
+  /** 初回再生 */
+  firstPlay: boolean;
 };
 
 export type VimeoInstance = {

--- a/utils/video/getVideoInstance.ts
+++ b/utils/video/getVideoInstance.ts
@@ -33,6 +33,7 @@ function getVideoInstance(
         }),
         tracks: buildTracks(resource.tracks),
         stopTimeOver: false,
+        firstPlay: true,
       };
     case "https://vimeo.com/":
       return {
@@ -51,6 +52,7 @@ function getVideoInstance(
         }),
         tracks: buildTracks(resource.tracks),
         stopTimeOver: false,
+        firstPlay: true,
       };
     }
   }


### PR DESCRIPTION
ref #986

#986 変更によって動画プレイヤーコンポーネントがマウントされるたびに初回再生用のハンドラーが注入される問題がありました。動画プレイヤーオブジェクトごとに1度しか呼ばれないように抑制します。