### PR TITLE
fix: node 18.16.0 以降で発生する unzipper の誤動作対策

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -75,7 +75,7 @@
     "strict-uri-encode": "^2.0.0",
     "ts-jest": "^29.0.5",
     "tsup": "^6.7.0",
-    "unzipper": "^0.10.11",
+    "unzipper": "^0.10.14",
     "yn": "^5.0.0"
   }
 }

--- a/server/utils/book/importBooksUtil.ts
+++ b/server/utils/book/importBooksUtil.ts
@@ -40,7 +40,7 @@ class ImportBooksUtil {
   books: BookSchema[];
   errors: string[];
   timeRequired: number;
-  tmpdir?: string;
+  tmpdir: string;
   unzippedFiles: string[];
 
   constructor(user: UserSchema, params: BooksImportParams) {
@@ -49,6 +49,7 @@ class ImportBooksUtil {
     this.books = [];
     this.errors = [];
     this.timeRequired = 0;
+    this.tmpdir = "";
     this.unzippedFiles = [];
   }
 
@@ -177,7 +178,10 @@ class ImportBooksUtil {
 
     return new Promise((resolve) => {
       fs.createReadStream(file)
-        .pipe(unzipper.Extract({ path: this.tmpdir }))
+        .pipe(unzipper.Parse())
+        .on("entry", (entry) => {
+          entry.pipe(fs.createWriteStream(path.join(this.tmpdir, entry.path)));
+        })
         .on("close", () => {
           this.unzippedFiles = recursive(this.tmpdir);
           const jsonfiles: string[] = this.unzippedFiles.filter((filename) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14999,10 +14999,10 @@ untildify@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-unzipper@^0.10.11:
-  version "0.10.11"
-  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.11.tgz#0b4991446472cbdb92ee7403909f26c2419c782e"
-  integrity sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==
+unzipper@^0.10.14:
+  version "0.10.14"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.14.tgz#d2b33c977714da0fbc0f82774ad35470a7c962b1"
+  integrity sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==
   dependencies:
     big-integer "^1.6.17"
     binary "~0.3.0"


### PR DESCRIPTION
ref #925

unzipper を最新の 0.10.14 に更新してみましたが、動作は変わりませんでした。
unzipper の Extract ではなく Parse を使って自分でファイルを書くと問題が発生しません。
