### PR TITLE
Tool URL (target_link_uri) が設定されている場合、リンクの変更を禁止

### DIFF
--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -15,6 +15,7 @@ import type { TopicSchema } from "$server/models/topic";
 import type { AuthorSchema } from "$server/models/author";
 import type { IsContentEditable } from "$server/models/content";
 import { useConfirm } from "material-ui-confirm";
+import { useSessionAtom } from "$store/session";
 import useDialogProps from "$utils/useDialogProps";
 
 const useStyles = makeStyles((theme) => ({
@@ -73,6 +74,7 @@ export default function BookEdit({
   isContentEditable,
   linked = false,
 }: Props) {
+  const { session } = useSessionAtom();
   const classes = useStyles();
   const confirm = useConfirm();
   const {
@@ -121,7 +123,7 @@ export default function BookEdit({
       <BookForm
         className={classes.content}
         book={book}
-        linked={linked}
+        linked={Boolean(session?.ltiTargetLinkUri || linked)}
         variant="update"
         onSubmit={onSubmit}
         onAuthorsUpdate={onAuthorsUpdate}

--- a/components/templates/BookNew.tsx
+++ b/components/templates/BookNew.tsx
@@ -49,7 +49,7 @@ export default function BookNew({
   onAuthorsUpdate,
   onAuthorSubmit,
 }: Props) {
-  const { isContentEditable } = useSessionAtom();
+  const { session, isContentEditable } = useSessionAtom();
   const forkFrom =
     book && !isContentEditable(book) && book.authors.length > 0 && book.authors;
   const defaultBook = book && {
@@ -87,6 +87,7 @@ export default function BookNew({
       <BookForm
         book={defaultBook}
         topics={topics}
+        linked={Boolean(session?.ltiTargetLinkUri)}
         variant="create"
         onSubmit={onSubmit}
         onAuthorsUpdate={onAuthorsUpdate}

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -26,7 +26,7 @@ export type Props = {
   loading?: boolean;
   onContentPreviewClick(content: ContentSchema): void;
   onContentEditClick(content: ContentSchema): void;
-  onContentLinkClick(content: ContentSchema, checked: boolean): void;
+  onContentLinkClick?(content: ContentSchema, checked: boolean): void;
   onLinkedBookClick?(book: BookSchema): void;
   onBookNewClick(): void;
   onBooksImportClick(): void;

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -43,7 +43,7 @@ function Edit({ bookId, context }: Query) {
     ...props
   }: BookPropsWithSubmitOptions) {
     await updateBook({ id: bookId, ...props });
-    if (submitWithLink) await onBookLinking({ id: bookId });
+    if (submitWithLink) await onBookLinking?.({ id: bookId });
     return back();
   }
   async function handleDelete({ id }: Pick<BookSchema, "id">) {

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -99,7 +99,9 @@ function Show(query: Query) {
     onTopicEnded: handleTopicNext,
     onItemClick: handleTopicNext,
     onBookEditClick: handleBookEditClick,
-    onOtherBookLinkClick: handleOtherBookLinkClick,
+    onOtherBookLinkClick: session?.ltiTargetLinkUri
+      ? undefined
+      : handleOtherBookLinkClick,
     onTopicEditClick: handleTopicEditClick,
   };
 

--- a/utils/useBookLinkingHandlers.ts
+++ b/utils/useBookLinkingHandlers.ts
@@ -86,6 +86,14 @@ function useBookLinkingHandlers() {
     [update, destroy, ltiResourceLink, query]
   );
 
+  // LTI Resource Link Request かつ Target URI が設定済みの場合は変更禁止
+  if (
+    session?.ltiMessageType === "LtiResourceLinkRequest" &&
+    Boolean(session?.ltiTargetLinkUri)
+  ) {
+    return {};
+  }
+
   return { onBookLinking };
 }
 

--- a/utils/useBookNewHandlers.ts
+++ b/utils/useBookNewHandlers.ts
@@ -32,7 +32,7 @@ function useBookNewHandlers(
           ...authors,
         ],
       });
-      if (submitWithLink) await onBookLinking({ id: book.id });
+      if (submitWithLink) await onBookLinking?.({ id: book.id });
       await router.replace(
         pagesPath.book.edit.$url({
           query: {


### PR DESCRIPTION
resolved #969

- Tool URL (target\_link\_uri) が設定されている場合、リンクの変更を禁止


確認したこと

- 従来どおり操作できること
- DL設定後、ブック一覧画面、閲覧、作成、編集画面でリンクの変更のためのボタンが表示されないこと