### PR TITLE
feat: 視聴ログ: 初回再生時であることを判定するためのplayイベントの拡張

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -203,51 +203,63 @@ export default function Video({
         }
       });
       void videoInstance.player.setCurrentTime(startTime || 0);
-    } else {
-      const handleSeeked = () => {
-        const currentTime = videoInstance.player.currentTime();
-        // @ts-expect-error startTime is number
-        if (Number.isFinite(startTime) && currentTime < startTime) {
-          videoInstance.player.currentTime(startTime || 0);
-        }
-      };
-      const handleTimeUpdate = () => {
-        if (videoInstance.stopTimeOver) return;
-        const currentTime = videoInstance.player.currentTime();
-        if (isValidPlaybackEnd({ currentTime, stopTime })) {
-          videoInstance.stopTimeOver = true;
-          videoInstance.player.pause();
-          onEnded?.();
-        }
-      };
-      const handlePlay = () => {
-        // 終了位置より後ろにシークすると、意図せず再生が再開してしまうことがあるので、ユーザーの操作によらない再生開始を抑制する
-        if (videoInstance.stopTimeOver) videoInstance.player.pause();
-      };
-      const handleFirstPlay = () => {
-        if (!videoInstance.firstPlay) return;
-
-        // NOTE: 初回playイベントは再生位置を移動して再生する
-        if (startTime && Number.isFinite(startTime)) {
-          videoInstance.player.currentTime(startTime);
-        }
-
-        videoInstance.firstPlay = false;
-      };
-      const handleReady = () => {
-        if (videoInstance.stopTimeOver) {
-          if (Number.isFinite(startTime))
-            videoInstance.player.currentTime(startTime || 0);
-          videoInstance.stopTimeOver = false;
-        }
-        videoInstance.player.on("timeupdate", handleTimeUpdate);
-        videoInstance.player.on("seeked", handleSeeked);
-      };
-
-      videoInstance.player.on("play", handlePlay);
-      videoInstance.player.one("play", handleFirstPlay);
-      videoInstance.player.ready(handleReady);
+      return;
     }
+
+    const handleSeeked = () => {
+      const currentTime = videoInstance.player.currentTime();
+      // @ts-expect-error startTime is number
+      if (Number.isFinite(startTime) && currentTime < startTime) {
+        videoInstance.player.currentTime(startTime || 0);
+      }
+    };
+
+    const handleTimeUpdate = () => {
+      if (videoInstance.stopTimeOver) return;
+      const currentTime = videoInstance.player.currentTime();
+      if (isValidPlaybackEnd({ currentTime, stopTime })) {
+        videoInstance.stopTimeOver = true;
+        videoInstance.player.pause();
+        onEnded?.();
+      }
+    };
+
+    const handlePlay = () => {
+      // 終了位置より後ろにシークすると、意図せず再生が再開してしまうことがあるので、ユーザーの操作によらない再生開始を抑制する
+      if (videoInstance.stopTimeOver) videoInstance.player.pause();
+    };
+
+    const handleFirstPlay = () => {
+      if (!videoInstance.firstPlay) return;
+
+      // NOTE: 初回playイベントは再生位置を移動して再生する
+      if (startTime && Number.isFinite(startTime)) {
+        videoInstance.player.currentTime(startTime);
+      }
+
+      videoInstance.firstPlay = false;
+    };
+
+    const handleReady = () => {
+      if (videoInstance.stopTimeOver) {
+        if (Number.isFinite(startTime))
+          videoInstance.player.currentTime(startTime || 0);
+        videoInstance.stopTimeOver = false;
+      }
+      videoInstance.player.on("timeupdate", handleTimeUpdate);
+      videoInstance.player.on("seeked", handleSeeked);
+    };
+
+    videoInstance.player.on("play", handlePlay);
+    videoInstance.player.one("play", handleFirstPlay);
+    videoInstance.player.ready(handleReady);
+
+    return () => {
+      videoInstance.player.off("timeupdate", handleTimeUpdate);
+      videoInstance.player.off("seeked", handleSeeked);
+      videoInstance.player.off("play", handlePlay);
+      videoInstance.player.off("play", handleFirstPlay);
+    };
     // TODO: videoの内容の変更検知は機能しないので修正したい。Mapオブジェクトでの管理をやめるかMap.prototype.set()を使用しないようにするなど必要かもしれない。
   }, [video, itemExists, prevItemIndex, itemIndex, onEnded]);
 

--- a/utils/eventLogger/logger.ts
+++ b/utils/eventLogger/logger.ts
@@ -1,12 +1,12 @@
 import type { EventType } from "$server/models/event";
 import { api } from "$utils/api";
-import type { PlayerEvent, PlayerEvents, PlayerTracker } from "./playerTracker";
+import type { PlayerStats, PlayerEvents, PlayerTracker } from "./playerTracker";
 import { load as loadPlaybackRate } from "$utils/playbackRate";
 import { load } from "./loggerSessionPersister";
 import getFilePath from "./getFilePath";
 
 /** v1のときのトラッキング用コードの移植 */
-function send(eventType: EventType, event: PlayerEvent, detail?: string) {
+function send(eventType: EventType, event: PlayerStats, detail?: string) {
   const session = load();
   if (!session) return;
   const idPrefix = session.oauthClient.id;
@@ -62,9 +62,13 @@ function logger(tracker: PlayerTracker) {
     void send("trackchange", event, event.language ?? "off");
   });
 
-  for (const event of ["forward", "back", "ended", "pause", "play"] as const) {
+  for (const event of ["forward", "back", "ended", "pause"] as const) {
     tracker.on(event, buildHandler(event));
   }
+
+  tracker.on("play", function (event) {
+    void send("play", event, event.firstPlay ? "first" : undefined);
+  });
 
   tracker.on("playbackratechange", function (event) {
     const persistentRate = loadPlaybackRate();

--- a/utils/eventLogger/playerTracker.ts
+++ b/utils/eventLogger/playerTracker.ts
@@ -2,7 +2,6 @@ import type { StrictEventEmitter } from "strict-event-emitter-types";
 import { EventEmitter } from "events";
 import type { VideoJsPlayer } from "$types/videoJsPlayer";
 import VimeoPlayer from "@vimeo/player";
-import type { VideoResourceSchema } from "$server/models/videoResource";
 import youtubePlayedShims from "$utils/youtubePlayedShims";
 
 const basicEventsMap = [
@@ -14,27 +13,27 @@ const basicEventsMap = [
   "timeupdate",
 ] as const;
 
-export type PlayerEvent = Pick<VideoResourceSchema, "providerUrl" | "url"> & {
-  /** ビデオの経過時間 (秒) */
-  currentTime: number;
-};
+export type PlayerStats = Pick<
+  PlayerTracker,
+  "providerUrl" | "url" | "currentTime" | "firstPlay"
+>;
 
 type CustomEvents = {
-  nextvideo: PlayerEvent & { video: number };
-  forward: PlayerEvent;
-  back: PlayerEvent;
-  durationchange: PlayerEvent & { duration: number };
+  nextvideo: PlayerStats & { video: number };
+  forward: PlayerStats;
+  back: PlayerStats;
+  durationchange: PlayerStats & { duration: number };
 };
 
 export type PlayerEvents = {
-  ended: PlayerEvent;
-  pause: PlayerEvent;
-  play: PlayerEvent;
-  seeked: PlayerEvent;
-  seeking: PlayerEvent;
-  timeupdate: PlayerEvent;
-  playbackratechange: PlayerEvent & { playbackRate: number };
-  texttrackchange: PlayerEvent & { language?: string };
+  ended: PlayerStats;
+  pause: PlayerStats;
+  play: PlayerStats;
+  seeked: PlayerStats;
+  seeking: PlayerStats;
+  timeupdate: PlayerStats;
+  playbackratechange: PlayerStats & { playbackRate: number };
+  texttrackchange: PlayerStats & { language?: string };
 } & CustomEvents;
 
 const youtubeType = "video/youtube";
@@ -51,6 +50,8 @@ export class PlayerTracker extends (EventEmitter as {
   readonly url: string;
   /** 現在再生時間 */
   currentTime = 0;
+  /** 初回再生 */
+  firstPlay = true;
   /** 再生した時間範囲の取得 */
   readonly getPlayed: () => Promise<[number, number][]>;
 
@@ -91,9 +92,9 @@ export class PlayerTracker extends (EventEmitter as {
     this.emit("nextvideo", { ...this.stats, video });
   }
 
-  get stats() {
-    const { providerUrl, url, currentTime } = this;
-    return { providerUrl, url, currentTime };
+  get stats(): PlayerStats {
+    const { providerUrl, url, currentTime, firstPlay } = this;
+    return { providerUrl, url, currentTime, firstPlay };
   }
 
   private intoVideoJs(player: VideoJsPlayer) {
@@ -104,6 +105,10 @@ export class PlayerTracker extends (EventEmitter as {
     for (const event of basicEventsMap) {
       player.on(event, () => this.emit(event, this.stats));
     }
+
+    player.on("play", () => {
+      this.firstPlay = false;
+    });
 
     player.on("ratechange", () => {
       this.emit("playbackratechange", {
@@ -137,6 +142,10 @@ export class PlayerTracker extends (EventEmitter as {
     for (const event of basicEventsMap) {
       player.on(event, () => this.emit(event, this.stats));
     }
+
+    player.on("play", () => {
+      this.firstPlay = false;
+    });
 
     player.on("playbackratechange", (data: { playbackRate: number }) => {
       this.emit("playbackratechange", {


### PR DESCRIPTION
resolved #995 

この変更によって初回・トピック切り替えのタイミングで発火していたplayイベントについて、新たに"first"を付与します。

確認方法:

1. `yarn dev | grep 'play.*videoplayerlog'` コマンドで開発用サーバーを起動
2. 学習者がアクセスする
3. 操作をしながらログを確認

[Screencast from 2023年08月29日 15時56分21秒.webm](https://github.com/npocccties/chibichilo/assets/1730234/0c481464-1784-4e2c-8e51-08c294952b84)