### PR TITLE
ブック作成・編集でのリンク切り替えの説明をtitle属性に追加/ツールURL指定時無効化

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -110,6 +110,7 @@ type Props = {
   topics?: TopicSchema[];
   id?: string;
   linked?: boolean;
+  hasLtiTargetLinkUri?: boolean;
   className?: string;
   variant?: "create" | "update";
   onSubmit?: (book: BookPropsWithSubmitOptions) => void;
@@ -123,6 +124,7 @@ export default function BookForm({
   className,
   id,
   linked = false,
+  hasLtiTargetLinkUri = false,
   variant = "create",
   onSubmit = () => undefined,
   onAuthorsUpdate,
@@ -158,7 +160,7 @@ export default function BookForm({
     authors: book?.authors ?? [],
     keywords: book?.keywords ?? [],
     publicBooks: book?.publicBooks ?? [],
-    submitWithLink: false,
+    submitWithLink: linked,
     topics: topics?.map((topic) => topic.id),
   };
   const { handleSubmit, register, setValue } =
@@ -335,6 +337,12 @@ export default function BookForm({
         <FormControlLabel
           className={classes.marginLeft}
           label="コースへ配信"
+          title={
+            hasLtiTargetLinkUri
+              ? "ツールURLが指定されているため、リンクの切り替えはできません"
+              : "リンクを切り替える"
+          }
+          disabled={hasLtiTargetLinkUri}
           control={
             <Checkbox
               id="submit-with-link"

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -123,7 +123,8 @@ export default function BookEdit({
       <BookForm
         className={classes.content}
         book={book}
-        linked={Boolean(session?.ltiTargetLinkUri || linked)}
+        linked={linked}
+        hasLtiTargetLinkUri={Boolean(session?.ltiTargetLinkUri)}
         variant="update"
         onSubmit={onSubmit}
         onAuthorsUpdate={onAuthorsUpdate}

--- a/components/templates/BookNew.tsx
+++ b/components/templates/BookNew.tsx
@@ -87,7 +87,8 @@ export default function BookNew({
       <BookForm
         book={defaultBook}
         topics={topics}
-        linked={Boolean(session?.ltiTargetLinkUri)}
+        linked={false}
+        hasLtiTargetLinkUri={Boolean(session?.ltiTargetLinkUri)}
         variant="create"
         onSubmit={onSubmit}
         onAuthorsUpdate={onAuthorsUpdate}


### PR DESCRIPTION
ref #999 https://github.com/npocccties/chibichilo/pull/980#issuecomment-1716764109

- ブック作成・編集での「コースへ提供」チェックボックスに関して、従来どおり表示しつつツールURLが指定されている場合は無効化するように変更します
  - ただし、チェックボックスをトグルスイッチのようにするといった変更は本PRには含めず別途とさせてください
![Screenshot from 2023-09-18 15-47-01](https://github.com/npocccties/chibichilo/assets/1730234/64b7ff39-d7c7-4935-838c-41589464d846)
