### PR TITLE
上書きインポート機能の改良

### DIFF
--- a/server/services/bookImport.ts
+++ b/server/services/bookImport.ts
@@ -49,7 +49,7 @@ export async function importBook({
   if (!found) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
-  const result = await importBookUtil(session.user, body, params.book_id);
+  const result = await importBookUtil(session, body, params.book_id);
   return {
     status: result.errors && result.errors.length ? 400 : 201,
     body: result,

--- a/server/services/bookImport.ts
+++ b/server/services/bookImport.ts
@@ -10,6 +10,8 @@ import authInstructor from "$server/auth/authInstructor";
 import { importBookUtil } from "$server/utils/book/importBooksUtil";
 import type { BookParams } from "$server/validators/bookParams";
 import { bookParamsSchema } from "$server/validators/bookParams";
+import bookExists from "$server/utils/book/bookExists";
+import { isUsersOrAdmin } from "$server/utils/session";
 
 export type Params = BooksImportParams;
 
@@ -17,12 +19,15 @@ export const importSchema: FastifySchema = {
   summary: "ブックの上書きインポート",
   description: outdent`
     ブックを上書きインポートします。
-    教員または管理者でなければなりません。`,
+    教員または管理者でなければなりません。
+    教員は自身の著作のブックでなければなりません。`,
   params: bookParamsSchema,
   body: BooksImportParams,
   response: {
     201: booksImportResultSchema,
     400: booksImportResultSchema,
+    403: {},
+    404: {},
   },
 };
 
@@ -39,6 +44,11 @@ export async function importBook({
   params: BookParams;
   body: BooksImportParams;
 }) {
+  const found = await bookExists(params.book_id);
+
+  if (!found) return { status: 404 };
+  if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
+
   const result = await importBookUtil(session.user, body, params.book_id);
   return {
     status: result.errors && result.errors.length ? 400 : 201,

--- a/server/utils/book/importBooksUtil.ts
+++ b/server/utils/book/importBooksUtil.ts
@@ -367,13 +367,22 @@ class ImportBooksUtil {
       for (const job of jobs) {
         const found = await topicExists(job.orig.id);
         if (!found) {
-          this.errors.push(`対象のトピックが見つかりませんでした。`);
-          return;
+          this.errors.push(
+            `対象のトピック ${job.import.name} が見つかりませんでした。`
+          );
+          continue;
         }
         if (!isUsersOrAdmin(session, found.authors)) {
-          this.errors.push(`対象のトピックが自身の著作ではありません。`);
-          return;
+          this.errors.push(
+            `対象のトピック ${job.import.name} が自身の著作ではありません。`
+          );
         }
+      }
+      if (this.errors.length) {
+        this.errors.push(
+          `自身の著作ではないトピックが指定されているため、ブックの上書きを行いませんでした。`
+        );
+        return;
       }
 
       // 処理するトピックのビデオファイルだけをアップロードする


### PR DESCRIPTION
以下の 2つの issue に対応します。
- #994 
- #1001

同じファイル server/utils/book/importBooksUtil.ts を変更するため、ひとつのプルリクにしています。

#994 の経緯は次のとおりです。
- #990 に対応するためにコードを変更したところ、階層ディレクトリを含む zip ファイルを解凍することができなくなった
- unzip 以外の部分のコードは、もともと階層ディレクトリを含む zip ファイルに対応していた

ブックを上書きインポートするとき、自身の著作でないトピックが含まれている場合は、次のようなメッセージが表示されます。

![image](https://github.com/npocccties/chibichilo/assets/15375161/3f0b076a-4832-4ba2-ba32-e54b16ce78b5)
