### PR TITLE
fix: 公開している提供中ブック視聴途中でブックが最初から再生される問題の修正

### DIFF
--- a/server/services/session.ts
+++ b/server/services/session.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest } from "fastify";
 import type Method from "$server/types/method";
-import { sessionSchema } from "$server/models/session";
+import { type SessionSchema, sessionSchema } from "$server/models/session";
 import { getSystemSettings } from "$server/utils/systemSettings";
 
 export const method: Method = {
@@ -17,12 +17,14 @@ export const hooks = {
   get: { auth: [] },
 };
 
-const nullSession = {
+const nullSession: SessionSchema = {
   oauthClient: {
     id: "",
     nonce: "",
   },
-  ltiVersion: "",
+  ltiMessageType: "LtiResourceLinkRequest",
+  ltiVersion: "1.3.0",
+  ltiDeploymentId: "",
   ltiUser: {
     id: "",
     name: "",
@@ -31,6 +33,7 @@ const nullSession = {
   ltiRoles: [],
   ltiResourceLinkRequest: { id: "", title: "" },
   ltiContext: { id: "", label: "", title: "" },
+  ltiResourceLink: null,
   user: {
     id: 0,
     ltiConsumerId: "",


### PR DESCRIPTION
session バリデーションのチェックに失敗するケースが存在しました。それを修正します。
これによって公開しているブックにアクセスしているとき GET /api/v2/session で 500 エラーになる問題を解決します。

fixed npocccties/chibichilo#1003
