### PR TITLE
fix: 動画に設定した字幕の選択肢が複数表示される問題の修正

### DIFF
--- a/utils/video/getVideoJsPlayer.ts
+++ b/utils/video/getVideoJsPlayer.ts
@@ -17,6 +17,10 @@ const defaultOptions = {
   playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
   language: "ja",
   languages: { ja },
+  html5: {
+    // NOTE: HLS再生環境で動画に設定した字幕の選択肢が複数表示されることがあるため無効化
+    nativeTextTracks: false,
+  },
 };
 
 function getVideoJsPlayer(


### PR DESCRIPTION
fixed #860

nativeTextTracksが有効化されている環境でブラウザネイティブの字幕(テキストトラック)を追加すると、mp3音声対応のために導入しているvideojs-hlsjs-pluginの内部処理と競合して動画に設定した字幕の選択肢が複数表示される問題がありました。
Video.jsのオプションhtml5.nativeTextTracksを無効化しVideo.jsによってエミュレートされるテキストトラック使用することによってこの問題を回避します。

https://videojs.com/guides/text-tracks/#emulated-text-tracks

## 前提条件

- Wowza
- mp3を含むHLS
- Video.js 8
- videojs-hlsjs-plugin
- Windows10+ or macOS Monterey+

## 現象の詳細

- Wowzaを対象にした場合、問題が発生することがあることを手元の環境でも確認  (確認した動画は HLS/mp3 )
- player.addRemoteTextTrack() メソッドの呼び出しは通常通り1度しか行われていない
  - components/organisms/Video/VideoJs.tsx:L61
- トレースしていくと Video.js 内部では addRemoteTextTrack() が余計に1度多く呼び出されることがある
  - `@meikidd/videojs-hlsjs-plugin`
    - https://github.com/meikidd/videojs-hlsjs-plugin/blob/master/lib/videojs-hlsjs-plugin.js#L298-L318

## #861 への影響

変更後 `TextTrack.mode` プロパティを記憶・設定することで表示の切り替えを行えることを確認済み:

```js
// 例
player.remoteTextTracks()[0].mode = 'showing' // or 'disabled'
```

https://developer.mozilla.org/ja/docs/Web/API/TextTrack/mode#showing
