### PR TITLE
2024年 版管理 9月14日バージョン

### DIFF
--- a/components/organisms/AuthorsInput.tsx
+++ b/components/organisms/AuthorsInput.tsx
@@ -124,7 +124,7 @@ export default function AuthorsInput({
             onClick={handleAuthorRemove(author)}
             color="warning"
             tooltipProps={{ title: "この教員を取り除く" }}
-            disabled={session?.user?.email === author.email}
+            disabled={disabled || session?.user?.email === author.email}
           >
             <PersonRemoveIcon />
           </IconButton>

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -29,7 +29,7 @@ import useOembed from "$utils/useOembed";
 import { NEXT_PUBLIC_BASE_PATH } from "$utils/env";
 import BookChip from "$atoms/BookChip";
 import type { RelatedBook } from "$server/models/topic";
-import type { ReleaseSchema } from "$server/models/book/release";
+import { getReleaseFromRelatedBooks } from "$utils/release";
 
 type HeaderProps = Parameters<typeof Checkbox>[0] & {
   checkable: boolean;
@@ -159,17 +159,10 @@ export default function ContentPreview({
   const handleContentLinkClick = (_: unknown, checked: boolean) => {
     onContentLinkClick?.(content, checked);
   };
-  let release: ReleaseSchema | undefined = undefined;
-  if (content.type === "book") {
-    release = content.release;
-  } else if (content.relatedBooks) {
-    for (const relatedBook of content.relatedBooks) {
-      if (relatedBook.release) {
-        release = relatedBook.release;
-        break;
-      }
-    }
-  }
+  const release =
+    content.type === "book"
+      ? content.release
+      : getReleaseFromRelatedBooks(content.relatedBooks);
   return (
     <Preview className={clsx({ selected: checked })}>
       <Header

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -29,6 +29,7 @@ import useOembed from "$utils/useOembed";
 import { NEXT_PUBLIC_BASE_PATH } from "$utils/env";
 import BookChip from "$atoms/BookChip";
 import type { RelatedBook } from "$server/models/topic";
+import type { ReleaseSchema } from "$server/models/book/release";
 
 type HeaderProps = Parameters<typeof Checkbox>[0] & {
   checkable: boolean;
@@ -158,6 +159,18 @@ export default function ContentPreview({
   const handleContentLinkClick = (_: unknown, checked: boolean) => {
     onContentLinkClick?.(content, checked);
   };
+  let release: ReleaseSchema | undefined = undefined;
+  if (content.type === "book") {
+    release = content.release;
+  } else if (content.relatedBooks) {
+    for (const relatedBook of content.relatedBooks) {
+      if (relatedBook.release) {
+        release = relatedBook.release;
+        break;
+      }
+    }
+  }
+  console.log(release);
   return (
     <Preview className={clsx({ selected: checked })}>
       <Header
@@ -239,15 +252,15 @@ export default function ContentPreview({
         nowrap
         sx={{ mx: 2, mt: 1 }}
         value={[
-          ...(content.type === "book" && content.release?.releasedAt
+          ...(release?.releasedAt
             ? [
                 {
                   key: "バージョン",
-                  value: content.release.version,
+                  value: release.version,
                 },
                 {
                   key: "リリース日",
-                  value: getLocaleDateString(content.release.releasedAt, "ja"),
+                  value: getLocaleDateString(release.releasedAt, "ja"),
                 },
               ]
             : [

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -170,7 +170,6 @@ export default function ContentPreview({
       }
     }
   }
-  console.log(release);
   return (
     <Preview className={clsx({ selected: checked })}>
       <Header

--- a/components/organisms/TopicForm/TimeRequiredInputControl.tsx
+++ b/components/organisms/TopicForm/TimeRequiredInputControl.tsx
@@ -9,6 +9,7 @@ type Props<TFieldValues extends FieldValues> = {
   topic?: Pick<TopicSchema, "timeRequired">;
   name: FieldPath<TFieldValues>;
   control: Control<TFieldValues>;
+  disabled: boolean;
 };
 
 function TimeRequiredInputControl<TFieldValues extends FieldValues>(
@@ -25,7 +26,8 @@ function TimeRequiredInputControl<TFieldValues extends FieldValues>(
         label="学習時間 (秒)"
         type="number"
         inputProps={{ ...field, min: 1 }}
-        required
+        required={!props.disabled}
+        disabled={props.disabled}
       />
       {modified && !close && (
         <Alert severity="warning" onClose={() => toggleClose()}>

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   isContentEditable: () => false,
   onOverwriteClick: console.log,
   onReleaseUpdate: console.log,
+  onRelease: console.log,
 };
 
 export const Default = () => {

--- a/components/templates/BookEditReleased.stories.tsx
+++ b/components/templates/BookEditReleased.stories.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   isContentEditable: () => false,
   onOverwriteClick: console.log,
   onReleaseUpdate: console.log,
+  onRelease: console.log,
 };
 
 export const Default = () => {

--- a/components/templates/TopicEdit.tsx
+++ b/components/templates/TopicEdit.tsx
@@ -14,6 +14,7 @@ import type {
 import type { AuthorSchema } from "$server/models/author";
 import { useConfirm } from "material-ui-confirm";
 import AddIcon from "@mui/icons-material/Add";
+import { getReleaseFromRelatedBooks } from "$utils/release";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -71,21 +72,29 @@ export default function TopicEdit(props: Props) {
     });
     onDelete(topic);
   };
+  const released = Boolean(getReleaseFromRelatedBooks(topic.relatedBooks));
 
   return (
     <Container className={classes.container} maxWidth="md">
       <BackButton onClick={onCancel}>戻る</BackButton>
-      <Typography className={classes.title} variant="h4">
-        トピックの編集
-        <Button size="small" color="primary" onClick={onImportClick}>
-          <AddIcon sx={{ mr: 0.5 }} />
-          上書きインポート
-        </Button>
-        <Typography variant="caption" component="span" aria-hidden="true">
-          <RequiredDot />
-          は必須項目です
+      {released && (
+        <Typography className={classes.title} variant="h4">
+          トピックの表示
         </Typography>
-      </Typography>
+      )}
+      {!released && (
+        <Typography className={classes.title} variant="h4">
+          トピックの編集
+          <Button size="small" color="primary" onClick={onImportClick}>
+            <AddIcon sx={{ mr: 0.5 }} />
+            上書きインポート
+          </Button>
+          <Typography variant="caption" component="span" aria-hidden="true">
+            <RequiredDot />
+            は必須項目です
+          </Typography>
+        </Typography>
+      )}
       <TopicForm
         className={classes.form}
         topic={topic}
@@ -97,10 +106,12 @@ export default function TopicEdit(props: Props) {
         onAuthorsUpdate={onAuthorsUpdate}
         onAuthorSubmit={onAuthorSubmit}
       />
-      <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
-        <DeleteOutlinedIcon />
-        トピックを削除
-      </Button>
+      {!released && (
+        <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
+          <DeleteOutlinedIcon />
+          トピックを削除
+        </Button>
+      )}
     </Container>
   );
 }

--- a/openapi/models/InlineResponse2005RelatedBooks.ts
+++ b/openapi/models/InlineResponse2005RelatedBooks.ts
@@ -13,6 +13,13 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import {
+    InlineResponse2005Release,
+    InlineResponse2005ReleaseFromJSON,
+    InlineResponse2005ReleaseFromJSONTyped,
+    InlineResponse2005ReleaseToJSON,
+} from './';
+
 /**
  * 
  * @export
@@ -51,10 +58,10 @@ export interface InlineResponse2005RelatedBooks {
     shared?: boolean;
     /**
      * 
-     * @type {object}
+     * @type {InlineResponse2005Release}
      * @memberof InlineResponse2005RelatedBooks
      */
-    release?: object;
+    release?: InlineResponse2005Release;
 }
 
 export function InlineResponse2005RelatedBooksFromJSON(json: any): InlineResponse2005RelatedBooks {
@@ -72,7 +79,7 @@ export function InlineResponse2005RelatedBooksFromJSONTyped(json: any, ignoreDis
         'description': !exists(json, 'description') ? undefined : json['description'],
         'language': !exists(json, 'language') ? undefined : json['language'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'release': !exists(json, 'release') ? undefined : json['release'],
+        'release': !exists(json, 'release') ? undefined : InlineResponse2005ReleaseFromJSON(json['release']),
     };
 }
 
@@ -90,7 +97,7 @@ export function InlineResponse2005RelatedBooksToJSON(value?: InlineResponse2005R
         'description': value.description,
         'language': value.language,
         'shared': value.shared,
-        'release': value.release,
+        'release': InlineResponse2005ReleaseToJSON(value.release),
     };
 }
 

--- a/server/models/book/release.ts
+++ b/server/models/book/release.ts
@@ -31,7 +31,7 @@ export type ReleaseSchema = FromSchema<
           format: "date-time";
         };
         output: Date;
-      }
+      },
     ];
   }
 >;

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -16,12 +16,25 @@ const RelatedBook = {
     description: { type: "string" },
     language: { type: "string" },
     shared: { type: "boolean" },
-    release: { releaseSchema, nullable: true },
+    release: { ...releaseSchema, nullable: true },
   },
   additionalProperties: false,
 } as const;
 
-export type RelatedBook = FromSchema<typeof RelatedBook>;
+export type RelatedBook = FromSchema<
+  typeof RelatedBook,
+  {
+    deserialize: [
+      {
+        pattern: {
+          type: "string";
+          format: "date-time";
+        };
+        output: Date;
+      },
+    ];
+  }
+>;
 
 export type TopicProps = Pick<
   Prisma.TopicCreateInput,

--- a/utils/release.ts
+++ b/utils/release.ts
@@ -1,0 +1,15 @@
+import type { ReleaseSchema } from "$server/models/book/release";
+import type { RelatedBook } from "$server/models/topic";
+
+export function getReleaseFromRelatedBooks(
+  relatedBooks: RelatedBook[] | undefined
+): ReleaseSchema | undefined {
+  if (!relatedBooks) return;
+
+  for (const relatedBook of relatedBooks) {
+    if (relatedBook.release) {
+      return relatedBook.release;
+    }
+  }
+  return;
+}


### PR DESCRIPTION
トピック編集画面で、編集中/リリース済みトピックを区別して表示します。
リリースモード開発_機能整理.xlsx の、機能63-77 に対応します。
変更点の詳細については、次回 9月17日のアジェンダ https://github.com/npocccties/chibichilo-db-refactoring/issues/29
に記載予定です。

記録用のプルリクなので、すぐ feat-vm2 にマージします。
