### PR TITLE
編集中／リリース条件の絞り込み の試作

### DIFF
--- a/components/atoms/AuthorFilter.tsx
+++ b/components/atoms/AuthorFilter.tsx
@@ -14,6 +14,9 @@ const options: ReadonlyArray<{
   { value: "self", label: "自分" },
   { value: "other", label: "自分以外" },
   { value: "all", label: "すべて" },
+  { value: "edit", label: "編集中" },
+  { value: "release", label: "リリース" },
+  { value: "other-release", label: "他人のリリース" },
 ];
 
 type Props = {

--- a/server/models/authorFilter.ts
+++ b/server/models/authorFilter.ts
@@ -23,6 +23,30 @@ export type AuthorFilter =
       by: UserSchema["id"];
       /** 利用者が管理者であるか否か (管理者: true、それ以外: false) */
       admin: boolean;
+    }
+  | {
+      /** 編集中 */
+      type: "edit";
+      /** 利用者 */
+      by: UserSchema["id"];
+      /** 利用者が管理者であるか否か (管理者: true、それ以外: false) */
+      admin: boolean;
+    }
+  | {
+      /** リリース */
+      type: "release";
+      /** 利用者 */
+      by: UserSchema["id"];
+      /** 利用者が管理者であるか否か (管理者: true、それ以外: false) */
+      admin: boolean;
+    }
+  | {
+      /** 他者のリリース */
+      type: "other-release";
+      /** 利用者 */
+      by: UserSchema["id"];
+      /** 利用者が管理者であるか否か (管理者: true、それ以外: false) */
+      admin: boolean;
     };
 
 export type AuthorFilterType = AuthorFilter["type"];

--- a/server/utils/search/bookSearch.ts
+++ b/server/utils/search/bookSearch.ts
@@ -8,7 +8,7 @@ import {
 import makeSortOrderQuery from "$server/utils/makeSortOrderQuery";
 import prisma from "$server/utils/prisma";
 import type { BookSearchQuery } from "$server/models/searchQuery";
-import createScopes from "./createScopes";
+import { createScopesBook } from "./createScopes";
 
 /**
  * 検索クエリーによるブック検索
@@ -41,7 +41,7 @@ async function bookSearch(
   const insensitiveMode = { mode: "insensitive" as const };
   const where: Prisma.BookWhereInput = {
     AND: [
-      ...createScopes(filter),
+      ...createScopesBook(filter),
       // NOTE: text - 検索文字列 (名称 OR 説明 OR 著者名 OR キーワード)
       ...text.map((t) => ({
         OR: [

--- a/server/utils/search/topicSearch.ts
+++ b/server/utils/search/topicSearch.ts
@@ -9,6 +9,7 @@ import {
 } from "$server/utils/topic/topicToTopicSchema";
 import type { TopicSearchQuery } from "$server/models/searchQuery";
 import createScopes from "./createScopes";
+import { createScopesTopic } from "./createScopes";
 
 /**
  * 検索クエリーによるトピック検索
@@ -39,7 +40,7 @@ async function topicSearch(
   const insensitiveMode = { mode: "insensitive" as const };
   const where: Prisma.TopicWhereInput = {
     AND: [
-      ...createScopes(filter),
+      ...createScopesTopic(filter),
       // NOTE: text - 検索文字列 (名称 OR 説明 OR 著者名 OR キーワード)
       ...text.map((t) => ({
         OR: [

--- a/server/validators/searchProps.ts
+++ b/server/validators/searchProps.ts
@@ -12,7 +12,7 @@ export const SearchProps = {
     q: { type: "string" },
     filter: {
       type: "string",
-      enum: ["all", "self", "other"],
+      enum: ["all", "self", "other", "edit", "release", "other-release"],
     },
     sort: {
       type: "string",


### PR DESCRIPTION
以下の機能の実装です。
- [機能4] ブック一覧 編集中／リリース条件の絞り込み
- [機能55] トピック一覧 編集中／リリース条件の絞り込み

既存機能と動作を比べることができるよう、次のようにしています。
- 既存の絞り込み機能に、[編集中] [リリース] [他人のリリース]を追加した
- [自分] [自分以外] [共有あり/なし/すべて] は UI を削除する予定
- [すべて]は残してもよいかも

管理用のプルリクなので、すぐ feat-vm2 ブランチにマージします。
