### PR TITLE
authorに、原著者と管理者を追加

### DIFF
--- a/server/models/author.ts
+++ b/server/models/author.ts
@@ -9,6 +9,8 @@ const _roleNames = {
   author: "作成者",
   "co-author": "共同作成者",
   collaborator: "協力者",
+  "original-author": "原著者",
+  administrator: "管理者",
 } as const;
 
 /** 著者 */

--- a/server/prisma/migrations/20241003121824_add_role_name/migration.sql
+++ b/server/prisma/migrations/20241003121824_add_role_name/migration.sql
@@ -1,0 +1,3 @@
+-- add content roles
+INSERT INTO "content_roles" ("id", "role_name") VALUES (6, 'original-author');
+INSERT INTO "content_roles" ("id", "role_name") VALUES (7, 'administrator');


### PR DESCRIPTION
作成者の選択肢に、原著者と管理者を追加しました。
UI で選択、保存できることを確認しています。
その他の取り扱いは、変更していません。

![image](https://github.com/user-attachments/assets/7eabf4d3-d773-4138-820f-9b0f639f39b2)
