### PR TITLE
ブック、トピック一覧の絞り込み機能を変更

### DIFF
--- a/components/atoms/AuthorFilter.tsx
+++ b/components/atoms/AuthorFilter.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import type { SxProps } from "@mui/system";
 import RadioGroup from "@mui/material/RadioGroup";
-import FormLabel from "@mui/material/FormLabel";
 import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
@@ -11,12 +10,9 @@ const options: ReadonlyArray<{
   value: AuthorFilterType;
   label: string;
 }> = [
-  { value: "self", label: "自分" },
-  { value: "other", label: "自分以外" },
-  { value: "all", label: "すべて" },
   { value: "edit", label: "編集中" },
   { value: "release", label: "リリース" },
-  { value: "other-release", label: "他人のリリース" },
+  { value: "other-release", label: "共有されたリリース" },
 ];
 
 type Props = {
@@ -42,7 +38,6 @@ function AuthorFilter({
   );
   return (
     <FormControl component="fieldset" sx={sx}>
-      <FormLabel component="legend">作成者</FormLabel>
       <RadioGroup value={value} onChange={handleChange} row={row}>
         {options.map(({ value, label }) => (
           <FormControlLabel

--- a/components/organisms/FilterColumn.tsx
+++ b/components/organisms/FilterColumn.tsx
@@ -5,13 +5,11 @@ import FormControl from "@mui/material/FormControl";
 import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
 import AuthorFilter from "$atoms/AuthorFilter";
-import SharedFilter from "$atoms/SharedFilter";
 import CourseChip from "$atoms/CourseChip";
 import KeywordChip from "$atoms/KeywordChip";
 import TextField from "$atoms/TextField";
 import licenses from "$utils/licenses";
 import { useSearchAtom } from "$store/search";
-import type { SharedFilterType } from "$types/sharedFilter";
 import BookChip from "$atoms/BookChip";
 
 type Props = {
@@ -25,7 +23,6 @@ export default function FilterColumn({ sx, variant }: Props) {
     searchQuery,
     relatedBooks,
     onAuthorFilterChange,
-    onSharedFilterChange,
     onLicenseFilterChange,
     onLtiContextDelete,
     onKeywordDelete,
@@ -42,33 +39,25 @@ export default function FilterColumn({ sx, variant }: Props) {
         sx={{ display: "flex", mb: 2 }}
         onFilterChange={onAuthorFilterChange}
       />
-      <SharedFilter
-        value={String(searchQuery?.shared?.[0] ?? "all") as SharedFilterType}
-        sx={{ display: "flex", mb: 2 }}
-        disabled={query.filter === "other"}
-        onFilterChange={onSharedFilterChange}
-      />
-      {variant === "topic" && (
-        <TextField
-          label="ライセンス"
-          select
-          fullWidth
-          defaultValue="all"
-          onChange={(event) => {
-            onLicenseFilterChange(String(event.target.value));
-          }}
-          inputProps={{ displayEmpty: true }}
-          sx={{ mb: 2, maxWidth: "80%" }}
-        >
-          <MenuItem value="all">すべて</MenuItem>
-          <MenuItem value="none">未設定</MenuItem>
-          {Object.entries(licenses).map(([value, { name }]) => (
-            <MenuItem key={value} value={value}>
-              {name}
-            </MenuItem>
-          ))}
-        </TextField>
-      )}
+      <TextField
+        label="ライセンス"
+        select
+        fullWidth
+        defaultValue="all"
+        onChange={(event) => {
+          onLicenseFilterChange(String(event.target.value));
+        }}
+        inputProps={{ displayEmpty: true }}
+        sx={{ mb: 2, maxWidth: "80%" }}
+      >
+        <MenuItem value="all">すべて</MenuItem>
+        <MenuItem value="none">未設定</MenuItem>
+        {Object.entries(licenses).map(([value, { name }]) => (
+          <MenuItem key={value} value={value}>
+            {name}
+          </MenuItem>
+        ))}
+      </TextField>
       {variant === "book" && (
         <FormControl component="fieldset" sx={{ display: "block", mb: 2 }}>
           <FormLabel component="legend" sx={{ mb: 1 }}>

--- a/store/search.ts
+++ b/store/search.ts
@@ -74,7 +74,7 @@ export function useSearchAtom() {
       updateQuery({
         type,
         q: "",
-        filter: "self",
+        filter: "edit",
         sort: "updated",
         perPage: 30,
         page: 0,


### PR DESCRIPTION
ボタンを削減しました。
「他人のリリース」は「共有されたリリース」に変更しました。
ブック一覧の絞り込み条件で、ライセンスを指定できるようにしました。
デフォルトで [編集中] コンテンツが表示されます。

![image](https://github.com/user-attachments/assets/d65dae84-d017-4ba6-b7cf-59a055aaab55)
