### PR TITLE
リリース時にトピックを選択する

### DIFF
--- a/components/molecules/SectionsTree.tsx
+++ b/components/molecules/SectionsTree.tsx
@@ -138,10 +138,12 @@ export default function SectionsTree(props: Props) {
                     {topic.shared && (
                       <SharedIndicator className={classes.shared} />
                     )}
-                    <PreviewButton
-                      variant="topic"
-                      onClick={handle(onItemPreviewClick)}
-                    />
+                    {onItemPreviewClick && (
+                      <PreviewButton
+                        variant="topic"
+                        onClick={handle(onItemPreviewClick)}
+                      />
+                    )}
                     {isContentEditable?.(topic) && onItemEditClick && (
                       <EditButton
                         variant="topic"

--- a/components/organisms/ReleaseItemList.tsx
+++ b/components/organisms/ReleaseItemList.tsx
@@ -84,8 +84,8 @@ export default function ReleaseItemList(props: Props) {
     <Card classes={cardClasses}>
       <TreeView>
         {releases.map((item, index) => (
-          // eslint-disable-next-line react/jsx-key
           <ReleaseItem
+            key={index}
             item={item}
             index={index}
             onItemEditClick={onItemEditClick}

--- a/components/templates/ReleaseEdit.tsx
+++ b/components/templates/ReleaseEdit.tsx
@@ -9,7 +9,7 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import SectionsTree from "$molecules/SectionsTree";
 import Card from "@mui/material/Card";
 import useCardStyles from "$styles/card";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export type Props = {
   book: BookSchema;
@@ -20,6 +20,16 @@ function ReleaseEdit(props: Props) {
   const { book, onSubmit } = props;
   const cardClasses = useCardStyles();
   const [selectedNodeIds, select] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    const nodeIds: string[] = [];
+    book.sections.map((section) => {
+      section.topics.map((topic, topicIndex) => {
+        const nodeId = `${book.id}-${section.id}-${topic.id}:${topicIndex}`;
+        nodeIds.push(nodeId);
+      });
+    });
+    select(() => new Set(nodeIds));
+  }, [book, select]);
   const handleTreeChange = (nodeId: string) => {
     select((nodeIds) =>
       nodeIds.delete(nodeId) ? new Set(nodeIds) : new Set(nodeIds.add(nodeId))
@@ -57,6 +67,7 @@ function ReleaseEdit(props: Props) {
             bookId={book.id}
             sections={book.sections}
             onTreeChange={handleTreeChange}
+            selectedIndexes={selectedNodeIds}
           />
         </TreeView>
       </Card>

--- a/components/templates/ReleaseEdit.tsx
+++ b/components/templates/ReleaseEdit.tsx
@@ -3,6 +3,13 @@ import Container from "$atoms/Container";
 import type { BookSchema } from "$server/models/book";
 import ReleaseForm from "$organisms/ReleaseForm";
 import type { ReleaseProps } from "$server/models/book/release";
+import TreeView from "@mui/lab/TreeView";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import SectionsTree from "$molecules/SectionsTree";
+import Card from "@mui/material/Card";
+import useCardStyles from "$styles/card";
+import { useState } from "react";
 
 export type Props = {
   book: BookSchema;
@@ -10,6 +17,25 @@ export type Props = {
 };
 
 function ReleaseEdit(props: Props) {
+  const { book, onSubmit } = props;
+  const cardClasses = useCardStyles();
+  const [selectedNodeIds, select] = useState<Set<string>>(new Set());
+  const handleTreeChange = (nodeId: string) => {
+    select((nodeIds) =>
+      nodeIds.delete(nodeId) ? new Set(nodeIds) : new Set(nodeIds.add(nodeId))
+    );
+  };
+  const handleSubmit = (props: ReleaseProps) => {
+    const topics: number[] = [];
+    selectedNodeIds.forEach((nodeId) => {
+      const [_bookId, _sectionId, topicId] = nodeId
+        .replace(/:[^:]*$/, "")
+        .split("-")
+        .map((id) => Number(id));
+      topics.push(topicId);
+    });
+    onSubmit({ ...props, topics });
+  };
   return (
     <Container
       maxWidth="md"
@@ -20,11 +46,20 @@ function ReleaseEdit(props: Props) {
         gap: 2,
       }}
     >
-      <Typography variant="h4">{props.book.name}</Typography>
-      <ReleaseForm
-        release={props.book?.release ?? {}}
-        onSubmit={props.onSubmit}
-      />
+      <Typography variant="h4">{book.name}</Typography>
+      <ReleaseForm release={book.release ?? {}} onSubmit={handleSubmit} />
+      <Card classes={cardClasses}>
+        <TreeView
+          defaultCollapseIcon={<ExpandMoreIcon />}
+          defaultExpandIcon={<ChevronRightIcon />}
+        >
+          <SectionsTree
+            bookId={book.id}
+            sections={book.sections}
+            onTreeChange={handleTreeChange}
+          />
+        </TreeView>
+      </Card>
     </Container>
   );
 }

--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -102,6 +102,16 @@ export default function Topics(props: Props) {
     dispatch: handlePreviewClick,
     ...dialogProps
   } = useDialogProps<ContentSchema>();
+
+  const enableBookNewButton =
+    isAdministrator || searchProps.query.filter === "edit";
+  const enableShareButton =
+    isAdministrator || searchProps.query.filter === "release";
+  const enableDeleteButton =
+    isAdministrator ||
+    searchProps.query.filter === "edit" ||
+    searchProps.query.filter === "release";
+
   return (
     <Container twoColumns maxWidth="xl">
       <Typography sx={{ mt: 5, gridArea: "title" }} variant="h4">
@@ -178,15 +188,17 @@ export default function Topics(props: Props) {
       />
       {selected.size > 0 && (
         <ActionFooter maxWidth="lg">
-          <Button
-            color="primary"
-            size="large"
-            variant="contained"
-            onClick={handleBookNewClick}
-          >
-            ブック作成
-          </Button>
-          {(isAdministrator || searchProps.query.filter === "self") && (
+          {enableBookNewButton && (
+            <Button
+              color="primary"
+              size="large"
+              variant="contained"
+              onClick={handleBookNewClick}
+            >
+              ブック作成
+            </Button>
+          )}
+          {enableShareButton && (
             <>
               <Button
                 color="primary"
@@ -204,15 +216,17 @@ export default function Topics(props: Props) {
               >
                 シェア解除
               </Button>
-              <Button
-                color="error"
-                size="large"
-                variant="contained"
-                onClick={handleTopicsDeleteClick}
-              >
-                削除
-              </Button>
             </>
+          )}
+          {enableDeleteButton && (
+            <Button
+              color="error"
+              size="large"
+              variant="contained"
+              onClick={handleTopicsDeleteClick}
+            >
+              削除
+            </Button>
           )}
         </ActionFooter>
       )}

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -2806,7 +2806,10 @@ export enum ApiV2SearchGetTypeEnum {
 export enum ApiV2SearchGetFilterEnum {
     all = 'all',
     self = 'self',
-    other = 'other'
+    other = 'other',
+    edit = 'edit',
+    release = 'release',
+    other_release = 'other-release'
 }
 /**
     * @export

--- a/openapi/models/InlineObject6.ts
+++ b/openapi/models/InlineObject6.ts
@@ -31,6 +31,12 @@ export interface InlineObject6 {
      * @memberof InlineObject6
      */
     comment?: string;
+    /**
+     * 
+     * @type {Array<number>}
+     * @memberof InlineObject6
+     */
+    topics?: Array<number>;
 }
 
 export function InlineObject6FromJSON(json: any): InlineObject6 {
@@ -45,6 +51,7 @@ export function InlineObject6FromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'version': !exists(json, 'version') ? undefined : json['version'],
         'comment': !exists(json, 'comment') ? undefined : json['comment'],
+        'topics': !exists(json, 'topics') ? undefined : json['topics'],
     };
 }
 
@@ -59,6 +66,7 @@ export function InlineObject6ToJSON(value?: InlineObject6 | null): any {
         
         'version': value.version,
         'comment': value.comment,
+        'topics': value.topics,
     };
 }
 

--- a/openapi/models/InlineObject7.ts
+++ b/openapi/models/InlineObject7.ts
@@ -31,6 +31,12 @@ export interface InlineObject7 {
      * @memberof InlineObject7
      */
     comment?: string;
+    /**
+     * 
+     * @type {Array<number>}
+     * @memberof InlineObject7
+     */
+    topics?: Array<number>;
 }
 
 export function InlineObject7FromJSON(json: any): InlineObject7 {
@@ -45,6 +51,7 @@ export function InlineObject7FromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'version': !exists(json, 'version') ? undefined : json['version'],
         'comment': !exists(json, 'comment') ? undefined : json['comment'],
+        'topics': !exists(json, 'topics') ? undefined : json['topics'],
     };
 }
 
@@ -59,6 +66,7 @@ export function InlineObject7ToJSON(value?: InlineObject7 | null): any {
         
         'version': value.version,
         'comment': value.comment,
+        'topics': value.topics,
     };
 }
 

--- a/openapi/models/InlineResponse2005Release.ts
+++ b/openapi/models/InlineResponse2005Release.ts
@@ -37,6 +37,12 @@ export interface InlineResponse2005Release {
      * @memberof InlineResponse2005Release
      */
     comment?: string;
+    /**
+     * 
+     * @type {Array<number>}
+     * @memberof InlineResponse2005Release
+     */
+    topics?: Array<number>;
 }
 
 export function InlineResponse2005ReleaseFromJSON(json: any): InlineResponse2005Release {
@@ -52,6 +58,7 @@ export function InlineResponse2005ReleaseFromJSONTyped(json: any, ignoreDiscrimi
         'releasedAt': !exists(json, 'releasedAt') ? undefined : (new Date(json['releasedAt'])),
         'version': !exists(json, 'version') ? undefined : json['version'],
         'comment': !exists(json, 'comment') ? undefined : json['comment'],
+        'topics': !exists(json, 'topics') ? undefined : json['topics'],
     };
 }
 
@@ -67,6 +74,7 @@ export function InlineResponse2005ReleaseToJSON(value?: InlineResponse2005Releas
         'releasedAt': value.releasedAt === undefined ? undefined : (value.releasedAt.toISOString()),
         'version': value.version,
         'comment': value.comment,
+        'topics': value.topics,
     };
 }
 

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -101,7 +101,11 @@ function Edit({ bookId, context }: Query) {
     });
   }
   async function handleRelease({ id }: Pick<BookSchema, "id">) {
-    return router.push(pagesPath.book.release.$url({ query: { bookId: id } }));
+    return router.push(
+      pagesPath.book.release.$url({
+        query: { bookId: id, ...(context && { context }) },
+      })
+    );
   }
   async function handleItemEditClick(bookId: BookSchema["id"]) {
     return router.push(pagesPath.book.edit.$url({ query: { bookId } }));

--- a/pages/book/release/index.tsx
+++ b/pages/book/release/index.tsx
@@ -16,12 +16,18 @@ function Release({ bookId, context }: Query) {
   const router = useRouter();
   async function handleSubmit(release: ReleaseProps) {
     if (!book) return;
-    const created = await createReleaseBook({ id: bookId, ...release });
-    return router.push(
-      pagesPath.book.edit.$url({
-        query: { bookId: created.id, ...(context && { context }) },
-      })
-    );
+    try {
+      const created = await createReleaseBook({ id: bookId, ...release });
+      return router.push(
+        pagesPath.book.edit.$url({
+          query: { bookId: created.id, ...(context && { context }) },
+        })
+      );
+    } catch (e) {
+      // @ts-expect-error TODO: Object is of type 'unknown'
+      console.log("createReleaseBook: error ", await e.json());
+    }
+    return;
   }
   const handlers = {
     onSubmit: handleSubmit,

--- a/server/models/book/release.ts
+++ b/server/models/book/release.ts
@@ -6,6 +6,7 @@ export const releasePropsSchema = {
   properties: {
     version: { type: "string" },
     comment: { type: "string" },
+    topics: { type: "array", items: { type: "integer" }, nullable: true },
   },
   additionalProperties: false,
 } as const;

--- a/server/models/book/release.ts
+++ b/server/models/book/release.ts
@@ -6,7 +6,7 @@ export const releasePropsSchema = {
   properties: {
     version: { type: "string" },
     comment: { type: "string" },
-    topics: { type: "array", items: { type: "integer" }, nullable: true },
+    topics: { type: "array", items: { type: "integer" } },
   },
   additionalProperties: false,
 } as const;

--- a/server/services/book/release/create.ts
+++ b/server/services/book/release/create.ts
@@ -44,10 +44,11 @@ export async function create({
   if (!found || found.release) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
+  const { topics: _topics, ...release } = body;
   const created = await cloneBook(found, session.user.id);
   if (!created) return { status: 500 };
 
-  const _ = await createRelease(created.id, body);
+  const _ = await createRelease(created.id, release);
   const book = await findBook(created.id, session.user.id);
 
   return {

--- a/server/services/book/release/create.ts
+++ b/server/services/book/release/create.ts
@@ -44,8 +44,8 @@ export async function create({
   if (!found || found.release) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
-  const { topics: _topics, ...release } = body;
-  const created = await cloneBook(found, session.user.id);
+  const { topics, ...release } = body;
+  const created = await cloneBook(found, session.user.id, topics);
   if (!created) return { status: 500 };
 
   const _ = await createRelease(created.id, release);

--- a/server/services/book/release/update.ts
+++ b/server/services/book/release/update.ts
@@ -42,7 +42,8 @@ export async function update({
   if (!found || !found.release) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
-  const updated = await updateRelease(params.book_id, body);
+  const { topics: _topics, ...release } = body;
+  const updated = await updateRelease(params.book_id, release);
 
   return {
     status: 201,


### PR DESCRIPTION
ブックをリリースするときに、トピックを選択できるようにしました。
- API 変更 (トピックのリストを受け取る)
- サーバ側動作の変更
- トピックを選択するUIの実装

他に、UI の動作を以下のように変更しています。
- リリース画面: リリース後遷移したブック編集画面から戻る context が未設定だった
  - ブック編集画面 -> リリース画面 -> ブック編集画面で context=books を保存

- トピック一覧で、トピックを選んでも[ブック作成]だけが表示される
  - 絞り込み条件によって表示するボタンを変えている
  - 仕様は暫定的

```
            これまで      版管理
---------------------------------------------------------------
ブック作成  常時          admin,edit
シェア      admin,self    admin,release
シェア解除  admin,self    admin,release
削除        admin,self    admin,edit,release
```