### PR TITLE
(ウ,エ,カ) 「複製」の追加、フォークの廃止、再利用の廃止

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -167,7 +167,7 @@ export default function BookForm({
   };
   const { handleSubmit, register, setValue } =
     useForm<BookPropsWithSubmitOptions>({
-      defaultValues,
+      values: defaultValues,
     });
   const released = Boolean(book?.release);
 

--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -113,7 +113,7 @@ type Props = {
   linked?: boolean;
   hasLtiTargetLinkUri?: boolean;
   className?: string;
-  variant?: "create" | "update";
+  variant?: "create" | "update" | "other";
   onSubmit?: (book: BookPropsWithSubmitOptions) => void;
   onAuthorsUpdate(authors: AuthorSchema[]): void;
   onAuthorSubmit(author: Pick<AuthorSchema, "email">): void;
@@ -212,7 +212,7 @@ export default function BookForm({
         </div>
       )}
 
-      {released && (
+      {released && variant !== "other" && (
         <div>
           <InputLabel htmlFor="enable-public-book">
             ブックを公開する
@@ -339,6 +339,7 @@ export default function BookForm({
             select
             defaultValue={defaultValues.license}
             inputProps={{ displayEmpty: true, ...register("license") }}
+            disabled={variant === "other"}
           >
             <MenuItem value="">未設定</MenuItem>
             {Object.entries(licenses).map(([value, { name }]) => (
@@ -351,9 +352,11 @@ export default function BookForm({
       </Accordion>
 
       <Divider className={classes.divider} />
-      <Button variant="contained" color="primary" type="submit">
-        {label[variant].submit}
-      </Button>
+      {variant !== "other" && (
+        <Button variant="contained" color="primary" type="submit">
+          {label[variant].submit}
+        </Button>
+      )}
       {!linked && (
         <FormControlLabel
           className={classes.marginLeft}
@@ -363,7 +366,7 @@ export default function BookForm({
               ? "ツールURLが指定されているため、リンクの切り替えはできません"
               : "リンクを切り替える"
           }
-          disabled={hasLtiTargetLinkUri}
+          disabled={hasLtiTargetLinkUri || variant === "other"}
           control={
             <Checkbox
               id="submit-with-link"

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
   onReleaseUpdate: console.log,
   onRelease: console.log,
   onItemEditClick: console.log,
+  onClone: console.log,
 };
 
 export const Default = () => {

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -66,6 +66,7 @@ export type Props = {
   onReleaseUpdate(release: ReleaseProps): void;
   onRelease(book: BookSchema): void;
   onItemEditClick(id: BookSchema["id"]): void;
+  onClone(book: BookSchema): void;
 };
 
 export default function BookEdit({
@@ -85,6 +86,7 @@ export default function BookEdit({
   onOverwriteClick,
   onRelease,
   onItemEditClick,
+  onClone,
 }: Props) {
   const { session } = useSessionAtom();
   const classes = useStyles();
@@ -112,6 +114,14 @@ export default function BookEdit({
       confirmationText: "OK",
     });
     onRelease(book);
+  };
+  const handleCloneButtonClick = async () => {
+    await confirm({
+      title: `ブック「${book.name}」を複製します。よろしいですか？`,
+      cancellationText: "キャンセル",
+      confirmationText: "OK",
+    });
+    onClone(book);
   };
   const handleItemEditClick = async (index: number) => {
     const id = releases?.[index]?.id;
@@ -173,6 +183,10 @@ export default function BookEdit({
       <Button size="small" color="primary" onClick={handleReleaseButtonClick}>
         <PeopleOutlinedIcon />
         ブックをリリース
+      </Button>
+      <Button size="small" color="primary" onClick={handleCloneButtonClick}>
+        <PeopleOutlinedIcon />
+        ブックを複製
       </Button>
       <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
         <DeleteOutlinedIcon />

--- a/components/templates/BookEditReleased.stories.tsx
+++ b/components/templates/BookEditReleased.stories.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
   onReleaseUpdate: console.log,
   onRelease: console.log,
   onItemEditClick: console.log,
+  onClone: console.log,
 };
 
 export const Default = () => {

--- a/components/templates/BookEditReleased.tsx
+++ b/components/templates/BookEditReleased.tsx
@@ -57,6 +57,7 @@ export default function BookEditReleased({
     const id = releases?.[index]?.id;
     if (id) onItemEditClick(id);
   };
+  const editable = isContentEditable?.(book);
 
   return (
     <Container className={classes.container} maxWidth="md">
@@ -67,7 +68,10 @@ export default function BookEditReleased({
       <Typography className={classes.subtitle} variant="h5">
         リリース
       </Typography>
-      <ReleaseForm release={book.release} onSubmit={onReleaseUpdate} />
+      <ReleaseForm
+        release={book.release}
+        onSubmit={editable ? onReleaseUpdate : undefined}
+      />
       <Typography className={classes.subtitle} variant="h5">
         トピック
       </Typography>
@@ -91,7 +95,7 @@ export default function BookEditReleased({
         book={book}
         linked={linked}
         hasLtiTargetLinkUri={Boolean(session?.ltiTargetLinkUri)}
-        variant="update"
+        variant={editable ? "update" : "other"}
         onSubmit={onSubmit}
         onAuthorsUpdate={onAuthorsUpdate}
         onAuthorSubmit={onAuthorSubmit}
@@ -107,10 +111,12 @@ export default function BookEditReleased({
           />
         </>
       )}
-      <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
-        <DeleteOutlinedIcon />
-        ブックを削除
-      </Button>
+      {editable && (
+        <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
+          <DeleteOutlinedIcon />
+          ブックを削除
+        </Button>
+      )}
       {previewTopic && (
         <TopicPreviewDialog {...dialogProps} topic={previewTopic} />
       )}

--- a/components/templates/BookEditReleased.tsx
+++ b/components/templates/BookEditReleased.tsx
@@ -1,6 +1,7 @@
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
+import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import SectionsEdit from "$organisms/SectionsEdit";
 import BookForm from "$organisms/BookForm";
 import TopicPreviewDialog from "$organisms/TopicPreviewDialog";
@@ -32,6 +33,7 @@ export default function BookEditReleased({
   linked = false,
   onReleaseUpdate,
   onItemEditClick,
+  onClone,
 }: Props) {
   const { session } = useSessionAtom();
   const classes = useStyles();
@@ -51,6 +53,14 @@ export default function BookEditReleased({
       confirmationText: "OK",
     });
     onDelete(book);
+  };
+  const handleCloneButtonClick = async () => {
+    await confirm({
+      title: `ブック「${book.name}」を複製します。よろしいですか？`,
+      cancellationText: "キャンセル",
+      confirmationText: "OK",
+    });
+    onClone(book);
   };
   if (!book.release) return <Placeholder />;
   const handleItemEditClick = async (index: number) => {
@@ -111,6 +121,10 @@ export default function BookEditReleased({
           />
         </>
       )}
+      <Button size="small" color="primary" onClick={handleCloneButtonClick}>
+        <PeopleOutlinedIcon />
+        ブックを複製
+      </Button>
       {editable && (
         <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
           <DeleteOutlinedIcon />

--- a/components/templates/Books.tsx
+++ b/components/templates/Books.tsx
@@ -16,7 +16,6 @@ import type { ContentSchema } from "$server/models/content";
 import type { BookSchema } from "$server/models/book";
 import type { LinkedBook } from "$types/linkedBook";
 import { useSearchAtom } from "$store/search";
-import { useSessionAtom } from "$store/session";
 
 export type Props = {
   totalCount: number;
@@ -45,7 +44,6 @@ export default function Books(props: Props) {
     onBooksImportClick,
   } = props;
   const searchProps = useSearchAtom();
-  const { isContentEditable } = useSessionAtom();
   const handleBookNewClick = () => onBookNewClick();
   const handleBooksImportClick = () => onBooksImportClick();
 
@@ -93,9 +91,7 @@ export default function Books(props: Props) {
             content={content}
             linked={content.id === linkedBook?.id}
             onContentPreviewClick={onContentPreviewClick}
-            onContentEditClick={
-              isContentEditable(content) ? onContentEditClick : undefined
-            }
+            onContentEditClick={onContentEditClick}
             onContentLinkClick={onContentLinkClick}
             onLtiContextClick={searchProps.onLtiContextClick}
             onKeywordClick={searchProps.onKeywordClick}

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -199,6 +199,7 @@ export interface ApiV2BookBookIdImportPostRequest {
 
 export interface ApiV2BookBookIdPutRequest {
     bookId: number;
+    noclone?: boolean;
     body?: InlineObject2;
 }
 
@@ -739,6 +740,10 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
         const queryParameters: runtime.HTTPQuery = {};
+
+        if (requestParameters.noclone !== undefined) {
+            queryParameters['noclone'] = requestParameters.noclone;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -180,6 +180,10 @@ export interface ApiV2BookBookIdAuthorsPutRequest {
     body?: InlineObject4;
 }
 
+export interface ApiV2BookBookIdClonePostRequest {
+    bookId: number;
+}
+
 export interface ApiV2BookBookIdDeleteRequest {
     bookId: number;
 }
@@ -592,6 +596,38 @@ export class DefaultApi extends runtime.BaseAPI {
      */
     async apiV2BookBookIdAuthorsPut(requestParameters: ApiV2BookBookIdAuthorsPutRequest): Promise<Array<InlineResponse2003BookAuthors>> {
         const response = await this.apiV2BookBookIdAuthorsPutRaw(requestParameters);
+        return await response.value();
+    }
+
+    /**
+     * ブックを複製します。 教員または管理者でなければなりません。
+     * ブックの複製
+     */
+    async apiV2BookBookIdClonePostRaw(requestParameters: ApiV2BookBookIdClonePostRequest): Promise<runtime.ApiResponse<InlineResponse2006Books>> {
+        if (requestParameters.bookId === null || requestParameters.bookId === undefined) {
+            throw new runtime.RequiredError('bookId','Required parameter requestParameters.bookId was null or undefined when calling apiV2BookBookIdClonePost.');
+        }
+
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/api/v2/book/{book_id}/clone`.replace(`{${"book_id"}}`, encodeURIComponent(String(requestParameters.bookId))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        });
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2006BooksFromJSON(jsonValue));
+    }
+
+    /**
+     * ブックを複製します。 教員または管理者でなければなりません。
+     * ブックの複製
+     */
+    async apiV2BookBookIdClonePost(requestParameters: ApiV2BookBookIdClonePostRequest): Promise<InlineResponse2006Books> {
+        const response = await this.apiV2BookBookIdClonePostRaw(requestParameters);
         return await response.value();
     }
 

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -10,6 +10,7 @@ import BookEditReleased from "$templates/BookEditReleased";
 import Placeholder from "$templates/Placeholder";
 import BookNotFoundProblem from "$templates/BookNotFoundProblem";
 import {
+  cloneBook,
   destroyBook,
   updateBook,
   updateReleaseBook,
@@ -112,6 +113,14 @@ function Edit({ bookId, context }: Query) {
   async function handleItemEditClick(bookId: BookSchema["id"]) {
     return router.push(pagesPath.book.edit.$url({ query: { bookId } }));
   }
+  async function handleClone({ id }: Pick<BookSchema, "id">) {
+    const created = await cloneBook(id);
+    return router.push(
+      pagesPath.book.edit.$url({
+        query: { bookId: created.id, ...(context && { context }) },
+      })
+    );
+  }
   const handlers = {
     linked: bookId === session?.ltiResourceLink?.bookId,
     onSubmit: handleSubmit,
@@ -129,6 +138,7 @@ function Edit({ bookId, context }: Query) {
     onReleaseUpdate: handleReleaseUpdate,
     onRelease: handleRelease,
     onItemEditClick: handleItemEditClick,
+    onClone: handleClone,
   };
 
   if (error) return <BookNotFoundProblem />;

--- a/server/config/routes/book.ts
+++ b/server/config/routes/book.ts
@@ -27,6 +27,7 @@ export async function book(fastify: FastifyInstance) {
 
   fastify.put<{
     Params: service.Params;
+    Querystring: service.Query;
     Body: service.Props;
   }>(pathWithParams, { schema: method.put, ...hooks.put }, handler(update));
 

--- a/server/config/routes/book.ts
+++ b/server/config/routes/book.ts
@@ -8,6 +8,7 @@ import * as showPublicService from "$server/services/book/public";
 import * as showZoomService from "$server/services/book/zoom";
 import * as importService from "$server/services/bookImport";
 import * as releaseService from "$server/services/book/release";
+import * as cloneService from "$server/services/clone";
 
 const basePath = "/book";
 const pathWithParams = `${basePath}/:book_id`;
@@ -116,3 +117,15 @@ export async function bookRelease(fastify: FastifyInstance) {
     Body: releaseService.Props;
   }>(path, { schema: method.put, ...hooks.put }, handler(update));
 }
+
+export async function bookClone(fastify: FastifyInstance) {
+  const path = `${pathWithParams}/clone`;
+  const { cloneSchema, cloneHooks, clone } = cloneService;
+  const hooks = makeHooks(fastify, cloneHooks);
+
+  fastify.post<{
+    Params: service.Params;
+    Body: importService.Params;
+  }>(path, { schema: cloneSchema, ...hooks.post }, handler(clone));
+}
+

--- a/server/services/book/index.ts
+++ b/server/services/book/index.ts
@@ -4,9 +4,11 @@ import { showSchema, showHooks, show } from "./show";
 import { createSchema, createHooks, create } from "./create";
 import { updateSchema, updateHooks, update } from "./update";
 import { destroySchema, destroyHooks, destroy } from "./destroy";
+import type { BookQuery } from "$server/validators/bookQuery";
 
 export type Params = BookParams;
 export type Props = BookProps;
+export type Query = BookQuery;
 
 export const method = {
   get: showSchema,

--- a/server/services/book/release/create.ts
+++ b/server/services/book/release/create.ts
@@ -11,7 +11,7 @@ import { createRelease } from "$server/utils/book/release";
 import { bookSchema } from "$server/models/book";
 import findBook from "$server/utils/book/findBook";
 import cloneBook from "$server/utils/book/cloneBook";
-import { releaseBook, releaseTopic } from "$server/utils/uniqueId";
+import { releaseBookUniqueIds, releaseTopicUniqueIds } from "$server/utils/uniqueId";
 
 export const createSchema: FastifySchema = {
   summary: "ブックのリリースの作成",
@@ -46,7 +46,7 @@ export async function create({
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
   const { topics, ...release } = body;
-  const created = await cloneBook(found, session.user.id, topics, releaseBook, releaseTopic);
+  const created = await cloneBook(found, session.user.id, topics, releaseBookUniqueIds, releaseTopicUniqueIds);
   if (!created) return { status: 500 };
 
   const _ = await createRelease(created.id, release);

--- a/server/services/book/update.ts
+++ b/server/services/book/update.ts
@@ -7,9 +7,9 @@ import { bookParamsSchema } from "$server/validators/bookParams";
 import authUser from "$server/auth/authUser";
 import authInstructor from "$server/auth/authInstructor";
 import { isUsersOrAdmin } from "$server/utils/session";
-import bookExists from "$server/utils/book/bookExists";
 import updateBook from "$server/utils/book/updateBook";
 import { BookQuery } from "$server/validators/bookQuery";
+import findBook from "$server/utils/book/findBook";
 
 export const updateSchema: FastifySchema = {
   summary: "ブックの更新",
@@ -39,15 +39,15 @@ export async function update({
   params,
   query,
 }: FastifyRequest<{ Body: BookProps; Params: BookParams; Querystring: BookQuery; }>) {
-  const found = await bookExists(params.book_id);
-  console.log("@@@ BookUpdate: ", query);
+  const found = await findBook(params.book_id, session.user.id);
+
   if (!found) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
   const created = await updateBook(session.user.id, {
     ...body,
     id: params.book_id,
-  });
+  }, found, query.noclone);
 
   return {
     status: created == null ? 400 : 201,

--- a/server/services/book/update.ts
+++ b/server/services/book/update.ts
@@ -9,14 +9,17 @@ import authInstructor from "$server/auth/authInstructor";
 import { isUsersOrAdmin } from "$server/utils/session";
 import bookExists from "$server/utils/book/bookExists";
 import updateBook from "$server/utils/book/updateBook";
+import { BookQuery } from "$server/validators/bookQuery";
 
 export const updateSchema: FastifySchema = {
   summary: "ブックの更新",
   description: outdent`
     ブックを更新します。
     教員または管理者でなければなりません。
-    教員は自身の著作のブックでなければなりません。`,
+    教員は自身の著作のブックでなければなりません。
+    追加トピックは複製されます。noclone=true を指定するとトピックを複製しません。`,
   params: bookParamsSchema,
+  querystring: BookQuery,
   body: bookPropsSchema,
   response: {
     201: bookSchema,
@@ -34,9 +37,10 @@ export async function update({
   session,
   body,
   params,
-}: FastifyRequest<{ Body: BookProps; Params: BookParams }>) {
+  query,
+}: FastifyRequest<{ Body: BookProps; Params: BookParams; Querystring: BookQuery; }>) {
   const found = await bookExists(params.book_id);
-
+  console.log("@@@ BookUpdate: ", query);
   if (!found) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 

--- a/server/services/clone.ts
+++ b/server/services/clone.ts
@@ -1,0 +1,49 @@
+import type { FastifySchema, FastifyRequest } from "fastify";
+import { outdent } from "outdent";
+import type { BookParams } from "$server/validators/bookParams";
+import { bookParamsSchema } from "$server/validators/bookParams";
+import authUser from "$server/auth/authUser";
+import authInstructor from "$server/auth/authInstructor";
+import { isUsersOrAdmin } from "$server/utils/session";
+import { bookSchema } from "$server/models/book";
+import findBook from "$server/utils/book/findBook";
+import cloneBook from "$server/utils/book/cloneBook";
+import { releaseBook, releaseTopic } from "$server/utils/uniqueId";
+
+export const cloneSchema: FastifySchema = {
+  summary: "ブックの複製",
+  description: outdent`
+    ブックを複製します。
+    教員または管理者でなければなりません。`,
+  params: bookParamsSchema,
+  response: {
+    201: bookSchema,
+    403: {},
+    404: {},
+  },
+};
+
+export const cloneHooks = {
+  post: { auth: [authUser, authInstructor] },
+};
+
+export async function clone({
+  session,
+  params,
+}: FastifyRequest<{
+  Params: BookParams;
+}>) {
+  const found = await findBook(params.book_id, session.user.id);
+
+  if (!found) return { status: 404 };
+  // TODO 見えるブックは複製できる
+  if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
+
+  const created = await cloneBook(found, session.user.id, null, releaseBook, releaseTopic);
+  if (!created) return { status: 500 };
+
+  return {
+    status: 201,
+    body: created,
+  };
+}

--- a/server/services/clone.ts
+++ b/server/services/clone.ts
@@ -8,7 +8,7 @@ import { isUsersOrAdmin } from "$server/utils/session";
 import { bookSchema } from "$server/models/book";
 import findBook from "$server/utils/book/findBook";
 import cloneBook from "$server/utils/book/cloneBook";
-import { releaseBook, releaseTopic } from "$server/utils/uniqueId";
+import { cloneBookUniqueIds, cloneTopicUniqueIds } from "$server/utils/uniqueId";
 
 export const cloneSchema: FastifySchema = {
   summary: "ブックの複製",
@@ -39,7 +39,7 @@ export async function clone({
   // TODO 見えるブックは複製できる
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
-  const created = await cloneBook(found, session.user.id, null, releaseBook, releaseTopic);
+  const created = await cloneBook(found, session.user.id, null, cloneBookUniqueIds, cloneTopicUniqueIds);
   if (!created) return { status: 500 };
 
   return {

--- a/server/services/clone.ts
+++ b/server/services/clone.ts
@@ -39,7 +39,8 @@ export async function clone({
   // TODO 見えるブックは複製できる
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
-  const created = await cloneBook(found, session.user.id, null, cloneBookUniqueIds, cloneTopicUniqueIds);
+  const authors = [{ userId: session.user.id, roleId: 1 }];
+  const created = await cloneBook(found, session.user.id, null, cloneBookUniqueIds, cloneTopicUniqueIds, authors);
   if (!created) return { status: 500 };
 
   return {

--- a/server/utils/book/cloneSections.ts
+++ b/server/utils/book/cloneSections.ts
@@ -1,0 +1,26 @@
+import type { Prisma } from "$node_modules/@prisma/client";
+import type { SectionProps } from "$server/models/book/section";
+import prisma from "../prisma";
+import { cloneTopic } from "../topic/cloneTopic";
+import { cloneTopicUniqueIds } from "../uniqueId";
+
+export async function cloneSections(origTopics: number[], sections: SectionProps[], authors: Prisma.AuthorshipUncheckedCreateInput[]) {
+  for (const section of sections) {
+    for (const topic of section.topics) {
+      if (origTopics && origTopics.includes(topic.id)) continue;
+      const found = await prisma.topic.findUnique({
+        where: { id: topic.id },
+        include: { resource: true, keywords: true }
+      });
+      if (!found) continue;
+      const { id: _id, resourceId: _resourceId, ...orig } = found;
+      found.shared = false;
+      const cloned = await cloneTopic(topic.id, orig, authors);
+      if (cloned) {
+        await cloneTopicUniqueIds(topic.id, cloned.id);
+        topic.id = cloned.id;
+      }
+    }
+  }
+  return sections;
+}

--- a/server/utils/book/createBook.ts
+++ b/server/utils/book/createBook.ts
@@ -7,6 +7,7 @@ import sectionCreateInput from "./sectionCreateInput";
 import keywordsConnectOrCreateInput from "$server/utils/keyword/keywordsConnectOrCreateInput";
 import upsertPublicBooks from "$server/utils/publicBook/upsertPublicBooks";
 import type { Prisma } from "@prisma/client";
+import { cloneSections } from "./cloneSections";
 
 async function createBook(
   userId: UserSchema["id"],
@@ -14,11 +15,14 @@ async function createBook(
   authors?: Prisma.AuthorshipUncheckedCreateInput[]
 ): Promise<BookSchema | undefined> {
   const timeRequired = await aggregateTimeRequired(book);
-  const sectionsCreateInput = book.sections?.map(sectionCreateInput) ?? [];
 
   if (!authors) {
     authors = [{ userId, roleId: 1 }];
   }
+
+  const sections = book.sections? await cloneSections([], book.sections, authors):[];
+  const sectionsCreateInput = sections?.map(sectionCreateInput) ?? [];
+
   const { id } = await prisma.book.create({
     data: {
       ...book,

--- a/server/utils/book/updateBook.ts
+++ b/server/utils/book/updateBook.ts
@@ -1,4 +1,4 @@
-import type { Book, PrismaPromise, Prisma } from "@prisma/client";
+import type { Book, PrismaPromise } from "@prisma/client";
 import type { BookProps, BookSchema } from "$server/models/book";
 import type { SectionProps } from "$server/models/book/section";
 import type { PublicBookSchema } from "$server/models/book/public";
@@ -10,8 +10,7 @@ import cleanupSections from "./cleanupSections";
 import keywordsConnectOrCreateInput from "$server/utils/keyword/keywordsConnectOrCreateInput";
 import keywordsDisconnectInput from "$server/utils/keyword/keywordsDisconnectInput";
 import upsertPublicBooks from "$server/utils/publicBook/upsertPublicBooks";
-import { cloneTopic } from "../topic/cloneTopic";
-import { cloneTopicUniqueIds } from "../uniqueId";
+import { cloneSections } from "./cloneSections";
 
 function upsertSections(bookId: Book["id"], sections: SectionProps[]) {
   const sectionsCreateInput = sections.map(sectionCreateInput);
@@ -20,30 +19,6 @@ function upsertSections(bookId: Book["id"], sections: SectionProps[]) {
       data: { ...input, order, book: { connect: { id: bookId } } },
     });
   });
-}
-
-async function cloneSections(book: BookSchema, sections: SectionProps[], authors: Prisma.AuthorshipUncheckedCreateInput[]) {
-  const origTopics = (book?.sections || [])
-    .flatMap((section) => section.topics)
-    .map((topic) => topic.id);
-  for (const section of sections) {
-    for (const topic of section.topics) {
-      if (origTopics.includes(topic.id)) continue;
-      const found = await prisma.topic.findUnique({
-        where: { id: topic.id },
-        include: { resource: true, keywords: true }
-      });
-      if (!found) continue;
-      const { id: _id, resourceId: _resourceId, ...orig } = found;
-      found.shared = false;
-      const cloned = await cloneTopic(topic.id, orig, authors);
-      if (cloned) {
-        await cloneTopicUniqueIds(topic.id, cloned.id);
-        topic.id = cloned.id;
-      }
-    }
-  }
-  return sections;
 }
 
 async function updateBook(
@@ -62,7 +37,10 @@ async function updateBook(
   if (sections != null) {
     if (!noclone) {
       const authors = [{ userId: userId, roleId: 1 }];
-      sections = await cloneSections(origBook, sections, authors);
+      const origTopics = (origBook?.sections || [])
+        .flatMap((section) => section.topics)
+        .map((topic) => topic.id);
+      sections = await cloneSections(origTopics, sections, authors);
     }
     const cleanup = cleanupSections(id);
     const upsert = upsertSections(id, sections);

--- a/server/utils/topic/cloneTopic.ts
+++ b/server/utils/topic/cloneTopic.ts
@@ -1,4 +1,4 @@
-import type { Topic } from "@prisma/client";
+import type { Prisma, Topic } from "@prisma/client";
 import type { TopicProps } from "$server/models/topic";
 import prisma from "$server/utils/prisma";
 import topicInput from "./topicInput";
@@ -8,11 +8,14 @@ import keywordsConnectOrCreateInput from "$server/utils/keyword/keywordsConnectO
 export async function cloneTopic(
   topicId: Topic["id"],
   topic : TopicProps,
+  authors?: Prisma.AuthorshipUncheckedCreateInput[]
 ): Promise<Topic | undefined> {
-  const authors = await prisma.authorship.findMany({
-    where: { topicId },
-    select: { userId: true, roleId: true },
-  });
+  if (!authors) {
+    authors = await prisma.authorship.findMany({
+      where: { topicId },
+      select: { userId: true, roleId: true },
+    });
+  }
 
   const created = await prisma.topic.create({
     data: {

--- a/server/utils/uniqueId.ts
+++ b/server/utils/uniqueId.ts
@@ -29,6 +29,16 @@ function releaseUniqueIds(orig: UniqueIds, release: UniqueIds) {
   orig.pid = release.vid;
 }
 
+function cloneUniqueIds(orig: UniqueIds, release: UniqueIds) {
+  if (!orig.poid) {
+    generateUniqueIds(orig);
+  }
+  release.poid = orig.poid;
+  release.oid = createId();
+  release.pid = orig.vid;
+  release.vid = "";
+}
+
 export async function findBookUniqueIds(
   bookId: Book["id"]
 ): Promise<UniqueIds | undefined> {
@@ -50,7 +60,7 @@ async function updateBookUniqueIds(
   });
 }
 
-export async function releaseBook(
+export async function releaseBookUniqueIds(
   origId: Book["id"],
   releaseId: Book["id"]
 ): Promise<void> {
@@ -62,6 +72,20 @@ export async function releaseBook(
 
   await updateBookUniqueIds(origId, orig);
   await updateBookUniqueIds(releaseId, release);
+
+  return;
+}
+
+export async function cloneBookUniqueIds(
+  origId: Book["id"],
+  cloneId: Book["id"]
+): Promise<void> {
+  const orig = await findBookUniqueIds(origId);
+  const clone = await findBookUniqueIds(cloneId);
+  if (!orig || !clone) return;
+
+  cloneUniqueIds(orig, clone);
+  await updateBookUniqueIds(cloneId, clone);
 
   return;
 }
@@ -87,7 +111,7 @@ async function updateTopicUniqueIds(
   });
 }
 
-export async function releaseTopic(
+export async function releaseTopicUniqueIds(
   origId: Topic["id"],
   releaseId: Topic["id"]
 ): Promise<void> {
@@ -99,6 +123,20 @@ export async function releaseTopic(
 
   await updateTopicUniqueIds(origId, orig);
   await updateTopicUniqueIds(releaseId, release);
+
+  return;
+}
+
+export async function cloneTopicUniqueIds(
+  origId: Topic["id"],
+  cloneId: Topic["id"]
+): Promise<void> {
+  const orig = await findTopicUniqueIds(origId);
+  const clone = await findTopicUniqueIds(cloneId);
+  if (!orig || !clone) return;
+
+  cloneUniqueIds(orig, clone);
+  await updateTopicUniqueIds(cloneId, clone);
 
   return;
 }

--- a/server/utils/uniqueId.ts
+++ b/server/utils/uniqueId.ts
@@ -85,6 +85,8 @@ export async function cloneBookUniqueIds(
   if (!orig || !clone) return;
 
   cloneUniqueIds(orig, clone);
+
+  await updateBookUniqueIds(origId, orig);
   await updateBookUniqueIds(cloneId, clone);
 
   return;
@@ -136,6 +138,8 @@ export async function cloneTopicUniqueIds(
   if (!orig || !clone) return;
 
   cloneUniqueIds(orig, clone);
+
+  await updateTopicUniqueIds(origId, orig);
   await updateTopicUniqueIds(cloneId, clone);
 
   return;

--- a/server/validators/bookQuery.ts
+++ b/server/validators/bookQuery.ts
@@ -1,0 +1,12 @@
+import type { FromSchema } from "json-schema-to-ts";
+
+export const BookQuery = {
+  type: "object",
+  properties: {
+    /** トピックを追加するとき、複製を行わないことを指示するオプションパラメータ */
+    noclone: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+export type BookQuery = FromSchema<typeof BookQuery>;

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -140,3 +140,8 @@ export async function createReleaseBook({
   const res = await api.apiV2BookBookIdReleasePost({ bookId: id, body });
   return res as BookSchema;
 }
+
+export async function cloneBook(id: BookSchema["id"]): Promise<BookSchema> {
+  const res = await api.apiV2BookBookIdClonePost({ bookId: id });
+  return res as BookSchema;
+}

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -75,10 +75,13 @@ export async function createBook(body: BookProps): Promise<BookSchema> {
 
 export async function updateBook({
   id,
+  noclone,
   ...body
-}: BookProps & { id: BookSchema["id"] }): Promise<BookSchema> {
+}: BookProps & { id: BookSchema["id"] } & {
+  noclone?: boolean;
+}): Promise<BookSchema> {
   // @ts-expect-error NOTE: body.sections[].topics[].name のUnion型に null 含むか否か異なる
-  const res = await api.apiV2BookBookIdPut({ bookId: id, body });
+  const res = await api.apiV2BookBookIdPut({ bookId: id, body, noclone });
   await mutate({ key, bookId: res.id }, res);
   return res as BookSchema;
 }
@@ -91,7 +94,7 @@ export async function addTopicToBook(
     ...book.sections,
     { name: null, topics: [{ id: topic.id }] },
   ];
-  return updateBook({ ...book, sections });
+  return updateBook({ ...book, sections, noclone: true });
 }
 
 export async function replaceTopicInBook(


### PR DESCRIPTION
以下のケースで、再利用するトピックを複製する機能を実装した。

- ブックの複製
- ブックへのトピックの追加
- トピック一覧からブック作成

いくつか課題が残っていて、テストも充分とはいえないが、現状のコードを feat-vm2 ブランチにマージする。
