### PR TITLE
ブックの複製、シェア廃止に伴うトピック表示問題の改良

### DIFF
--- a/server/services/book/release/show.ts
+++ b/server/services/book/release/show.ts
@@ -34,7 +34,7 @@ export async function show({
   const book = await findBook(params.book_id, session.user.id);
 
   if (!book) return { status: 404 };
-  if (!isUsersOrAdmin(session, book.authors)) return { status: 403 };
+  if (!isUsersOrAdmin(session, book.authors) && !book.release?.shared) return { status: 403 };
 
   const books = await findReleasedBooks(book, session.user.id);
   const releases = books.map(bookToReleaseItemSchema);

--- a/server/services/clone.ts
+++ b/server/services/clone.ts
@@ -36,8 +36,7 @@ export async function clone({
   const found = await findBook(params.book_id, session.user.id);
 
   if (!found) return { status: 404 };
-  // TODO 見えるブックは複製できる
-  if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
+  if (!isUsersOrAdmin(session, found.authors) && !found.release?.shared) return { status: 403 };
 
   const authors = [{ userId: session.user.id, roleId: 1 }];
   const created = await cloneBook(found, session.user.id, null, cloneBookUniqueIds, cloneTopicUniqueIds, authors);

--- a/server/utils/displayableBook.ts
+++ b/server/utils/displayableBook.ts
@@ -2,7 +2,6 @@ import type { BookSchema } from "$server/models/book";
 import type { PublicBookSchema } from "$server/models/book/public";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 import type { IsContentEditable } from "$server/models/content";
-import contentBy from "./contentBy";
 
 export function isDisplayableBook(
   book: Pick<BookSchema, "id" | "shared" | "authors" | "release">,
@@ -28,15 +27,5 @@ export function getDisplayableBook<
   if (!isDisplayableBook(book, isContentEditable, ltiResourceLink, publicBook))
     return;
 
-  const sections = book.sections.flatMap((section) => {
-    const topics = section.topics.filter(
-      (topic) =>
-        contentBy(topic, { id: ltiResourceLink?.creatorId }) ||
-        (publicBook && contentBy(topic, { id: publicBook.userId })) ||
-        isContentEditable?.(topic)
-    );
-    return topics.length > 0 ? [{ ...section, topics }] : [];
-  });
-
-  return { ...book, sections };
+  return book;
 }


### PR DESCRIPTION
https://github.com/npocccties/chibichilo-db-refactoring/issues/58
で課題になっていた、以下の件について対応しました。

- ブックの複製
  - 共有されたリリースのリリース一覧が取得できない
  - 共有されたリリースのブックが複製できない
- (オ)シェア廃止 に伴うブック編集ページでのトピック表示問題

ブックの複製については、予定どおり、共有リリースのブックに対する API の使用を許可するように変更しました。
トピック表示問題については、「(変更案2)見えるブックに含まれるトピックは見えることにする」を実装しました。

このプルリクは、すぐ feat-vm2 にマージします。