### PR TITLE
feat-vm2 の修正

### DIFF
--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -731,7 +731,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * ブックを更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックを更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。 追加トピックは複製されます。noclone=true を指定するとトピックを複製しません。
      * ブックの更新
      */
     async apiV2BookBookIdPutRaw(requestParameters: ApiV2BookBookIdPutRequest): Promise<runtime.ApiResponse<InlineResponse2006Books>> {
@@ -761,7 +761,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * ブックを更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックを更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。 追加トピックは複製されます。noclone=true を指定するとトピックを複製しません。
      * ブックの更新
      */
     async apiV2BookBookIdPut(requestParameters: ApiV2BookBookIdPutRequest): Promise<InlineResponse2006Books> {

--- a/openapi/models/InlineResponse2005Release.ts
+++ b/openapi/models/InlineResponse2005Release.ts
@@ -43,12 +43,6 @@ export interface InlineResponse2005Release {
      * @memberof InlineResponse2005Release
      */
     shared?: boolean;
-    /**
-     * 
-     * @type {Array<number>}
-     * @memberof InlineResponse2005Release
-     */
-    topics?: Array<number>;
 }
 
 export function InlineResponse2005ReleaseFromJSON(json: any): InlineResponse2005Release {
@@ -65,7 +59,6 @@ export function InlineResponse2005ReleaseFromJSONTyped(json: any, ignoreDiscrimi
         'version': !exists(json, 'version') ? undefined : json['version'],
         'comment': !exists(json, 'comment') ? undefined : json['comment'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'topics': !exists(json, 'topics') ? undefined : json['topics'],
     };
 }
 
@@ -82,7 +75,6 @@ export function InlineResponse2005ReleaseToJSON(value?: InlineResponse2005Releas
         'version': value.version,
         'comment': value.comment,
         'shared': value.shared,
-        'topics': value.topics,
     };
 }
 

--- a/server/models/book/release.ts
+++ b/server/models/book/release.ts
@@ -14,11 +14,13 @@ export const releasePropsSchema = {
 
 export type ReleaseProps = FromSchema<typeof releasePropsSchema>;
 
+const {topics: _topics, ...releaseSchemaProps} = releasePropsSchema.properties;
+
 export const releaseSchema = {
   type: "object",
   properties: {
     releasedAt: { type: "string", format: "date-time" },
-    ...releasePropsSchema.properties,
+    ...releaseSchemaProps,
   },
   additionalProperties: false,
 } as const;

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -38,7 +38,7 @@ async function seed() {
   }
 
   const createdBooks = (await Promise.all(
-    books.map((book) => createBook(creatorId, book))
+    books.map((book) => createBook(creatorId, book, [{ userId: creatorId, roleId: 1 }]))
   )) as BookSchema[];
 
   // TODO: upsert時の一意性の問題が解決したら `Promise.all()` 等に修正して。

--- a/server/services/book/create.ts
+++ b/server/services/book/create.ts
@@ -5,6 +5,7 @@ import { bookPropsSchema, bookSchema } from "$server/models/book";
 import authUser from "$server/auth/authUser";
 import authInstructor from "$server/auth/authInstructor";
 import createBook from "$server/utils/book/createBook";
+import { cloneSections } from "$server/utils/book/cloneSections";
 
 export const createSchema: FastifySchema = {
   summary: "ブックの作成",
@@ -26,7 +27,11 @@ export async function create({
   session,
   body,
 }: FastifyRequest<{ Body: BookProps }>) {
-  const created = await createBook(session.user.id, body);
+  const authors = [{ userId: session.user.id, roleId: 1 }];
+  if (body.sections) {
+    body.sections = await cloneSections([], body.sections, authors);
+  }
+  const created = await createBook(session.user.id, body, authors);
 
   return {
     status: created == null ? 400 : 201,

--- a/server/services/book/release/create.ts
+++ b/server/services/book/release/create.ts
@@ -10,8 +10,7 @@ import { isUsersOrAdmin } from "$server/utils/session";
 import { createRelease } from "$server/utils/book/release";
 import { bookSchema } from "$server/models/book";
 import findBook from "$server/utils/book/findBook";
-import { cloneBook } from "$server/utils/book/cloneBook";
-import { releaseBookUniqueIds, releaseTopicUniqueIds } from "$server/utils/uniqueId";
+import { cloneRelease } from "$server/utils/book/cloneBook";
 
 export const createSchema: FastifySchema = {
   summary: "ブックのリリースの作成",
@@ -46,11 +45,11 @@ export async function create({
   if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
 
   const { topics, ...release } = body;
-  const created = await cloneBook(found, session.user.id, topics, releaseBookUniqueIds, releaseTopicUniqueIds);
-  if (!created) return { status: 500 };
+  const released = await cloneRelease(found, session.user.id, topics);
+  if (!released) return { status: 500 };
 
-  const _ = await createRelease(created.id, release);
-  const book = await findBook(created.id, session.user.id);
+  const _ = await createRelease(released.id, release);
+  const book = await findBook(released.id, session.user.id);
 
   return {
     status: 201,

--- a/server/services/book/release/create.ts
+++ b/server/services/book/release/create.ts
@@ -10,7 +10,7 @@ import { isUsersOrAdmin } from "$server/utils/session";
 import { createRelease } from "$server/utils/book/release";
 import { bookSchema } from "$server/models/book";
 import findBook from "$server/utils/book/findBook";
-import cloneBook from "$server/utils/book/cloneBook";
+import { cloneBook } from "$server/utils/book/cloneBook";
 import { releaseBookUniqueIds, releaseTopicUniqueIds } from "$server/utils/uniqueId";
 
 export const createSchema: FastifySchema = {

--- a/server/services/clone.ts
+++ b/server/services/clone.ts
@@ -8,7 +8,6 @@ import { isUsersOrAdmin } from "$server/utils/session";
 import { bookSchema } from "$server/models/book";
 import findBook from "$server/utils/book/findBook";
 import { cloneBook } from "$server/utils/book/cloneBook";
-import { cloneBookUniqueIds, cloneTopicUniqueIds } from "$server/utils/uniqueId";
 
 export const cloneSchema: FastifySchema = {
   summary: "ブックの複製",
@@ -38,8 +37,7 @@ export async function clone({
   if (!found) return { status: 404 };
   if (!isUsersOrAdmin(session, found.authors) && !found.release?.shared) return { status: 403 };
 
-  const authors = [{ userId: session.user.id, roleId: 1 }];
-  const created = await cloneBook(found, session.user.id, null, cloneBookUniqueIds, cloneTopicUniqueIds, authors);
+  const created = await cloneBook(found, session.user.id);
   if (!created) return { status: 500 };
 
   return {

--- a/server/services/clone.ts
+++ b/server/services/clone.ts
@@ -7,7 +7,7 @@ import authInstructor from "$server/auth/authInstructor";
 import { isUsersOrAdmin } from "$server/utils/session";
 import { bookSchema } from "$server/models/book";
 import findBook from "$server/utils/book/findBook";
-import cloneBook from "$server/utils/book/cloneBook";
+import { cloneBook } from "$server/utils/book/cloneBook";
 import { cloneBookUniqueIds, cloneTopicUniqueIds } from "$server/utils/uniqueId";
 
 export const cloneSchema: FastifySchema = {

--- a/server/utils/book/createBook.ts
+++ b/server/utils/book/createBook.ts
@@ -7,21 +7,14 @@ import sectionCreateInput from "./sectionCreateInput";
 import keywordsConnectOrCreateInput from "$server/utils/keyword/keywordsConnectOrCreateInput";
 import upsertPublicBooks from "$server/utils/publicBook/upsertPublicBooks";
 import type { Prisma } from "@prisma/client";
-import { cloneSections } from "./cloneSections";
 
 async function createBook(
   userId: UserSchema["id"],
   { publicBooks, ...book }: BookProps,
-  authors?: Prisma.AuthorshipUncheckedCreateInput[]
+  authors: Prisma.AuthorshipUncheckedCreateInput[]
 ): Promise<BookSchema | undefined> {
   const timeRequired = await aggregateTimeRequired(book);
-
-  if (!authors) {
-    authors = [{ userId, roleId: 1 }];
-  }
-
-  const sections = book.sections? await cloneSections([], book.sections, authors):[];
-  const sectionsCreateInput = sections?.map(sectionCreateInput) ?? [];
+  const sectionsCreateInput = book.sections?.map(sectionCreateInput) ?? [];
 
   const { id } = await prisma.book.create({
     data: {

--- a/server/utils/book/updateBook.ts
+++ b/server/utils/book/updateBook.ts
@@ -12,7 +12,7 @@ import keywordsDisconnectInput from "$server/utils/keyword/keywordsDisconnectInp
 import upsertPublicBooks from "$server/utils/publicBook/upsertPublicBooks";
 import { cloneSections } from "./cloneSections";
 
-function upsertSections(bookId: Book["id"], sections: SectionProps[]) {
+export function upsertSections(bookId: Book["id"], sections: SectionProps[]) {
   const sectionsCreateInput = sections.map(sectionCreateInput);
   return sectionsCreateInput.map((input, order) => {
     return prisma.section.create({


### PR DESCRIPTION
feat-vm2 ブランチを、以下のように変更しました。

- リリースとブックの複製でトピックを 2回複製していたのを 1回だけにした
- 元ブック+複製トピックをリリース、複製ブック+元トピックを編集中にする
- ReleaseSchema の不要な topics を削除
- server/prisma/seed.ts で createBook 呼び出しの引数を追加

このプルリクは、すぐに feat-vm2 ブランチにマージします。
