### PR TITLE
fix: リリースしているトピックを削除しない

### DIFF
--- a/components/templates/Topics.tsx
+++ b/components/templates/Topics.tsx
@@ -106,9 +106,7 @@ export default function Topics(props: Props) {
   const enableBookNewButton = true;
   const enableShareButton = false;
   const enableDeleteButton =
-    isAdministrator ||
-    searchProps.query.filter === "edit" ||
-    searchProps.query.filter === "release";
+    isAdministrator || searchProps.query.filter === "edit";
 
   return (
     <Container twoColumns maxWidth="xl">

--- a/pages/topics/index.tsx
+++ b/pages/topics/index.tsx
@@ -7,6 +7,7 @@ import useTopics from "$utils/useTopics";
 import { destroyTopic, updateTopic } from "$utils/topic";
 import { useSearchAtom } from "$store/search";
 import { revalidateContents } from "$utils/useContents";
+import { getReleaseFromRelatedBooks } from "$utils/release";
 
 const Topics = (
   props: Omit<
@@ -41,7 +42,10 @@ function Index() {
   }
   async function handleTopicsDeleteClick(topics: TopicSchema[]) {
     for (const topic of topics) {
-      if (isContentEditable(topic)) {
+      if (
+        isContentEditable(topic) &&
+        !getReleaseFromRelatedBooks(topic.relatedBooks)
+      ) {
         await destroyTopic(topic.id);
       }
     }


### PR DESCRIPTION
トピック一覧画面の動作を以下のように変更しました。

- 絞り込みでリリースを選択しているとき、削除ボタンを表示しない
- 削除ボタンを押したとき、リリースしたブックに含まれるトピックを削除しない

このプルリクは、すぐに feat-vm2 ブランチにマージします。
