### PR TITLE
(イ) 著作権者の正式な取扱い、(ケ) ブックからのトピック一括削除 の実装

### DIFF
--- a/components/organisms/BookForm.tsx
+++ b/components/organisms/BookForm.tsx
@@ -4,7 +4,6 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
 import Divider from "@mui/material/Divider";
 import Button from "@mui/material/Button";
-import MenuItem from "@mui/material/MenuItem";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import Alert from "@mui/material/Alert";
@@ -36,10 +35,8 @@ import type { PublicBookSchema } from "$server/models/book/public";
 import type { BookPropsWithSubmitOptions } from "$types/bookPropsWithSubmitOptions";
 import type { AuthorSchema } from "$server/models/author";
 import { useAuthorsAtom } from "store/authors";
-import languages from "$utils/languages";
 import useKeywordsInput from "$utils/useKeywordsInput";
 import useDomainsInput from "$utils/useDomainsInput";
-import licenses from "$utils/licenses";
 
 const useStyles = makeStyles((theme) => ({
   margin: {
@@ -156,8 +153,6 @@ export default function BookForm({
     name: book?.name ?? "",
     description: book?.description ?? "",
     shared: Boolean(book?.shared),
-    language: book?.language ?? Object.getOwnPropertyNames(languages)[0],
-    license: book?.license ?? "",
     sections: book?.sections,
     authors: book?.authors ?? [],
     keywords: book?.keywords ?? [],
@@ -321,33 +316,6 @@ export default function BookForm({
             {` `}
             に一部準拠しています
           </Typography>
-          <TextField
-            label="教材の主要な言語"
-            select
-            defaultValue={defaultValues.language}
-            inputProps={register("language")}
-            disabled={released}
-          >
-            {Object.entries(languages).map(([value, label]) => (
-              <MenuItem key={value} value={value}>
-                {label}
-              </MenuItem>
-            ))}
-          </TextField>
-          <TextField
-            label="ライセンス"
-            select
-            defaultValue={defaultValues.license}
-            inputProps={{ displayEmpty: true, ...register("license") }}
-            disabled={variant === "other"}
-          >
-            <MenuItem value="">未設定</MenuItem>
-            {Object.entries(licenses).map(([value, { name }]) => (
-              <MenuItem key={value} value={value}>
-                {name}
-              </MenuItem>
-            ))}
-          </TextField>
         </AccordionDetails>
       </Accordion>
 

--- a/components/organisms/MetainfoForm.tsx
+++ b/components/organisms/MetainfoForm.tsx
@@ -18,7 +18,7 @@ export default function MetainfoForm({
   metainfo,
   onSubmit,
 }: MetainfoFormProps) {
-  const { register, handleSubmit } = useForm<MetainfoProps>({
+  const { register, handleSubmit, formState } = useForm<MetainfoProps>({
     values: metainfo,
   });
   const cardClasses = useCardStyles();
@@ -70,7 +70,12 @@ export default function MetainfoForm({
         <>
           <Divider sx={{ mx: "-50%" }} />
           <div className="release-form-row">
-            <Button variant="contained" color="primary" type="submit">
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              disabled={!formState.isDirty}
+            >
               更新
             </Button>
           </div>

--- a/components/organisms/MetainfoForm.tsx
+++ b/components/organisms/MetainfoForm.tsx
@@ -1,0 +1,81 @@
+import Card from "@mui/material/Card";
+import Divider from "@mui/material/Divider";
+import Button from "@mui/material/Button";
+import { useForm } from "react-hook-form";
+import TextField from "$atoms/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import useCardStyles from "styles/card";
+import languages from "$utils/languages";
+import licenses from "$utils/licenses";
+import type { MetainfoProps } from "$server/models/metainfo";
+
+export type MetainfoFormProps = {
+  metainfo: MetainfoProps;
+  onSubmit?(metainfo: MetainfoProps): void;
+};
+
+export default function MetainfoForm({
+  metainfo,
+  onSubmit,
+}: MetainfoFormProps) {
+  const { register, handleSubmit } = useForm<MetainfoProps>({
+    values: metainfo,
+  });
+  const cardClasses = useCardStyles();
+  const update = Boolean(onSubmit);
+  if (!onSubmit) {
+    onSubmit = () => {};
+  }
+  return (
+    <Card
+      classes={cardClasses}
+      sx={
+        {
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "start",
+          rowGap: 2.5,
+        } as const
+      }
+      component="form"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <TextField
+        label="教材の主要な言語"
+        select
+        defaultValue={metainfo.language}
+        inputProps={register("language")}
+      >
+        {Object.entries(languages).map(([value, label]) => (
+          <MenuItem key={value} value={value}>
+            {label}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField
+        label="ライセンス"
+        select
+        defaultValue={metainfo.license}
+        inputProps={{ displayEmpty: true, ...register("license") }}
+      >
+        <MenuItem value="">未設定</MenuItem>
+        {Object.entries(licenses).map(([value, { name }]) => (
+          <MenuItem key={value} value={value}>
+            {name}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField inputProps={register("licenser")} label="著作権者" fullWidth />
+      {update && (
+        <>
+          <Divider sx={{ mx: "-50%" }} />
+          <div className="release-form-row">
+            <Button variant="contained" color="primary" type="submit">
+              更新
+            </Button>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/components/organisms/ReleaseForm.tsx
+++ b/components/organisms/ReleaseForm.tsx
@@ -26,9 +26,11 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ReleaseForm({ release, onSubmit }: ReleaseFormProps) {
-  const { register, handleSubmit, setValue } = useForm<ReleaseProps>({
-    values: release,
-  });
+  const { register, handleSubmit, setValue, formState } = useForm<ReleaseProps>(
+    {
+      values: release,
+    }
+  );
   const cardClasses = useCardStyles();
   const releasedAt = release.releasedAt
     ? getLocaleDateString(release.releasedAt, "ja")
@@ -111,7 +113,12 @@ export default function ReleaseForm({ release, onSubmit }: ReleaseFormProps) {
         <>
           <Divider sx={{ mx: "-50%" }} />
           <div className="release-form-row">
-            <Button variant="contained" color="primary" type="submit">
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              disabled={!formState.isDirty}
+            >
               {release.version ? "更新" : "作成"}
             </Button>
           </div>

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -43,7 +43,6 @@ import type {
   VideoTrackSchema,
 } from "$server/models/videoTrack";
 import { useSessionAtom } from "$store/session";
-import languages from "$utils/languages";
 import providers from "$utils/providers";
 import useVideoResourceProps from "$utils/useVideoResourceProps";
 import usePaused from "$utils/video/usePaused";
@@ -210,8 +209,6 @@ export default function TopicForm(props: Props) {
     name: topic?.name,
     description: topic?.description ?? "",
     shared: Boolean(topic?.shared),
-    language: topic?.language ?? Object.getOwnPropertyNames(languages)[0],
-    license: topic?.license ?? "",
     timeRequired: topic?.timeRequired,
     startTime: topic?.startTime,
     stopTime: topic?.stopTime,

--- a/components/organisms/TopicForm.tsx
+++ b/components/organisms/TopicForm.tsx
@@ -44,7 +44,6 @@ import type {
 } from "$server/models/videoTrack";
 import { useSessionAtom } from "$store/session";
 import languages from "$utils/languages";
-import licenses from "$utils/licenses";
 import providers from "$utils/providers";
 import useVideoResourceProps from "$utils/useVideoResourceProps";
 import usePaused from "$utils/video/usePaused";
@@ -609,39 +608,6 @@ export default function TopicForm(props: Props) {
           {` `}
           に一部準拠しています
         </Typography>
-        <Accordion>
-          <AccordionSummary>
-            <Typography>詳細を設定する</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <TextField
-              label="教材の主要な言語"
-              select
-              defaultValue={defaultValues.language}
-              inputProps={register("language")}
-              disabled={released}
-            >
-              {Object.entries(languages).map(([value, label]) => (
-                <MenuItem key={value} value={value}>
-                  {label}
-                </MenuItem>
-              ))}
-            </TextField>
-            <TextField
-              label="ライセンス"
-              select
-              defaultValue={defaultValues.license}
-              inputProps={{ displayEmpty: true, ...register("license") }}
-            >
-              <MenuItem value="">未設定</MenuItem>
-              {Object.entries(licenses).map(([value, { name }]) => (
-                <MenuItem key={value} value={value}>
-                  {name}
-                </MenuItem>
-              ))}
-            </TextField>
-          </AccordionDetails>
-        </Accordion>
         <Divider className={classes.divider} />
         <Button variant="contained" color="primary" type="submit">
           {label[variant]}

--- a/components/templates/BookEdit.stories.tsx
+++ b/components/templates/BookEdit.stories.tsx
@@ -25,6 +25,7 @@ const defaultProps = {
   onRelease: console.log,
   onItemEditClick: console.log,
   onClone: console.log,
+  onMetainfoUpdate: console.log,
 };
 
 export const Default = () => {

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -22,6 +22,8 @@ import AddIcon from "@mui/icons-material/Add";
 import type { ReleaseProps } from "$server/models/book/release";
 import useReleaseBooks from "$utils/useReleaseBooks";
 import ReleaseItemList from "$organisms/ReleaseItemList";
+import type { MetainfoProps } from "$server/models/metainfo";
+import MetainfoForm from "$organisms/MetainfoForm";
 
 export const useStyles = makeStyles((theme) => ({
   container: {
@@ -67,6 +69,7 @@ export type Props = {
   onRelease(book: BookSchema): void;
   onItemEditClick(id: BookSchema["id"]): void;
   onClone(book: BookSchema): void;
+  onMetainfoUpdate(metainfo: MetainfoProps): void;
 };
 
 export default function BookEdit({
@@ -87,6 +90,7 @@ export default function BookEdit({
   onRelease,
   onItemEditClick,
   onClone,
+  onMetainfoUpdate,
 }: Props) {
   const { session } = useSessionAtom();
   const classes = useStyles();
@@ -169,6 +173,10 @@ export default function BookEdit({
         onAuthorsUpdate={onAuthorsUpdate}
         onAuthorSubmit={onAuthorSubmit}
       />
+      <Typography className={classes.subtitle} variant="h5">
+        メタ情報
+      </Typography>
+      <MetainfoForm metainfo={book} onSubmit={onMetainfoUpdate} />
       {releases && (
         <>
           <Typography className={classes.subtitle} variant="h5">

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -53,7 +53,7 @@ export const useStyles = makeStyles((theme) => ({
 export type Props = {
   book: BookSchema;
   onSubmit(book: BookPropsWithSubmitOptions): void;
-  onDelete(book: BookSchema): void;
+  onDelete(book: BookSchema, withtopic?: boolean): void;
   onCancel(): void;
   onSectionsUpdate(sections: SectionProps[]): void;
   onTopicImportClick(): void;

--- a/components/templates/BookEditReleased.stories.tsx
+++ b/components/templates/BookEditReleased.stories.tsx
@@ -25,6 +25,7 @@ const defaultProps = {
   onRelease: console.log,
   onItemEditClick: console.log,
   onClone: console.log,
+  onMetainfoUpdate: console.log,
 };
 
 export const Default = () => {

--- a/components/templates/BookEditReleased.tsx
+++ b/components/templates/BookEditReleased.tsx
@@ -16,6 +16,7 @@ import Placeholder from "./Placeholder";
 import { useStyles, type Props } from "./BookEdit";
 import useReleaseBooks from "$utils/useReleaseBooks";
 import ReleaseItemList from "$organisms/ReleaseItemList";
+import MetainfoForm from "$organisms/MetainfoForm";
 
 export default function BookEditReleased({
   book,
@@ -34,6 +35,7 @@ export default function BookEditReleased({
   onReleaseUpdate,
   onItemEditClick,
   onClone,
+  onMetainfoUpdate,
 }: Props) {
   const { session } = useSessionAtom();
   const classes = useStyles();
@@ -110,6 +112,10 @@ export default function BookEditReleased({
         onAuthorsUpdate={onAuthorsUpdate}
         onAuthorSubmit={onAuthorSubmit}
       />
+      <Typography className={classes.subtitle} variant="h5">
+        メタ情報
+      </Typography>
+      <MetainfoForm metainfo={book} onSubmit={onMetainfoUpdate} />
       {releases && (
         <>
           <Typography className={classes.subtitle} variant="h5">

--- a/components/templates/BookEditReleased.tsx
+++ b/components/templates/BookEditReleased.tsx
@@ -50,11 +50,11 @@ export default function BookEditReleased({
     setPreviewTopic(topic);
   const handleDeleteButtonClick = async () => {
     await confirm({
-      title: `ブック「${book.name}」を削除します。よろしいですか？`,
+      title: `ブック「${book.name}」と、ブックに含まれるトピックを削除します。よろしいですか？`,
       cancellationText: "キャンセル",
       confirmationText: "OK",
     });
-    onDelete(book);
+    onDelete(book, true);
   };
   const handleCloneButtonClick = async () => {
     await confirm({
@@ -134,7 +134,7 @@ export default function BookEditReleased({
       {editable && (
         <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
           <DeleteOutlinedIcon />
-          ブックを削除
+          ブック/トピックを削除
         </Button>
       )}
       {previewTopic && (

--- a/components/templates/TopicEdit.tsx
+++ b/components/templates/TopicEdit.tsx
@@ -18,10 +18,15 @@ import { getReleaseFromRelatedBooks } from "$utils/release";
 import useReleaseTopics from "$utils/useReleaseTopics";
 import ReleaseItemList from "$organisms/ReleaseItemList";
 import ReleaseForm from "$organisms/ReleaseForm";
+import MetainfoForm from "$organisms/MetainfoForm";
+import type { MetainfoProps } from "$server/models/metainfo";
 
 const useStyles = makeStyles((theme) => ({
   container: {
     marginTop: theme.spacing(1),
+    "& > :not($title):not($content)": {
+      marginBottom: theme.spacing(2),
+    },
   },
   title: {
     marginBottom: theme.spacing(4),
@@ -37,6 +42,16 @@ const useStyles = makeStyles((theme) => ({
   form: {
     marginBottom: theme.spacing(2),
   },
+  subtitle: {
+    "& span": {
+      verticalAlign: "middle",
+    },
+    "& .RequiredDot": {
+      marginRight: theme.spacing(0.5),
+      marginBottom: theme.spacing(0.75),
+      marginLeft: theme.spacing(2),
+    },
+  },
 }));
 
 type Props = {
@@ -51,6 +66,7 @@ type Props = {
   onAuthorSubmit(author: Pick<AuthorSchema, "email">): void;
   onImportClick(): void;
   onItemEditClick(id: TopicSchema["id"]): void;
+  onMetainfoUpdate(metainfo: MetainfoProps): void;
 };
 
 export default function TopicEdit(props: Props) {
@@ -66,6 +82,7 @@ export default function TopicEdit(props: Props) {
     onAuthorSubmit,
     onImportClick,
     onItemEditClick,
+    onMetainfoUpdate,
   } = props;
   const classes = useStyles();
   const confirm = useConfirm();
@@ -106,6 +123,9 @@ export default function TopicEdit(props: Props) {
         </Typography>
       )}
       {release && <ReleaseForm release={release} />}
+      <Typography className={classes.subtitle} variant="h5">
+        基本情報
+      </Typography>
       <TopicForm
         className={classes.form}
         topic={topic}
@@ -117,9 +137,13 @@ export default function TopicEdit(props: Props) {
         onAuthorsUpdate={onAuthorsUpdate}
         onAuthorSubmit={onAuthorSubmit}
       />
+      <Typography className={classes.subtitle} variant="h5">
+        メタ情報
+      </Typography>
+      <MetainfoForm metainfo={topic} onSubmit={onMetainfoUpdate} />
       {releases && (
         <>
-          <Typography className={classes.title} variant="h5">
+          <Typography className={classes.subtitle} variant="h5">
             リリース一覧
           </Typography>
           <ReleaseItemList

--- a/components/templates/TopicEdit.tsx
+++ b/components/templates/TopicEdit.tsx
@@ -128,10 +128,12 @@ export default function TopicEdit(props: Props) {
           />
         </>
       )}
-      <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
-        <DeleteOutlinedIcon />
-        トピックを削除
-      </Button>
+      {!release && (
+        <Button size="small" color="primary" onClick={handleDeleteButtonClick}>
+          <DeleteOutlinedIcon />
+          トピックを削除
+        </Button>
+      )}
     </Container>
   );
 }

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -48,6 +48,12 @@ import {
     InlineObject17,
     InlineObject17FromJSON,
     InlineObject17ToJSON,
+    InlineObject18,
+    InlineObject18FromJSON,
+    InlineObject18ToJSON,
+    InlineObject19,
+    InlineObject19FromJSON,
+    InlineObject19ToJSON,
     InlineObject2,
     InlineObject2FromJSON,
     InlineObject2ToJSON,
@@ -197,6 +203,11 @@ export interface ApiV2BookBookIdImportPostRequest {
     body?: InlineObject5;
 }
 
+export interface ApiV2BookBookIdMetainfoPutRequest {
+    bookId: number;
+    body?: InlineObject6;
+}
+
 export interface ApiV2BookBookIdPutRequest {
     bookId: number;
     noclone?: boolean;
@@ -209,12 +220,12 @@ export interface ApiV2BookBookIdReleaseGetRequest {
 
 export interface ApiV2BookBookIdReleasePostRequest {
     bookId: number;
-    body?: InlineObject7;
+    body?: InlineObject8;
 }
 
 export interface ApiV2BookBookIdReleasePutRequest {
     bookId: number;
-    body?: InlineObject6;
+    body?: InlineObject7;
 }
 
 export interface ApiV2BookPostRequest {
@@ -236,15 +247,15 @@ export interface ApiV2BookmarkIdDeleteRequest {
 
 export interface ApiV2BookmarkMemoContentIdPutRequest {
     id: number;
-    body?: InlineObject17;
+    body?: InlineObject19;
 }
 
 export interface ApiV2BookmarkMemoContentPostRequest {
-    body?: InlineObject16;
+    body?: InlineObject18;
 }
 
 export interface ApiV2BookmarkPostRequest {
-    body?: InlineObject15;
+    body?: InlineObject17;
 }
 
 export interface ApiV2BookmarkStatsGetRequest {
@@ -265,7 +276,7 @@ export interface ApiV2BooksGetRequest {
 }
 
 export interface ApiV2BooksImportPostRequest {
-    body?: InlineObject8;
+    body?: InlineObject9;
 }
 
 export interface ApiV2EventPostRequest {
@@ -353,7 +364,7 @@ export interface ApiV2ResourceResourceIdOembedGetRequest {
 
 export interface ApiV2ResourceResourceIdVideoTrackPostRequest {
     resourceId: number;
-    body?: InlineObject14;
+    body?: InlineObject16;
 }
 
 export interface ApiV2ResourceResourceIdVideoTrackVideoTrackIdDeleteRequest {
@@ -383,18 +394,18 @@ export interface ApiV2SearchGetRequest {
 }
 
 export interface ApiV2TopicPostRequest {
-    body?: InlineObject10;
+    body?: InlineObject11;
 }
 
 export interface ApiV2TopicTopicIdActivityPutRequest {
     topicId: number;
     currentLtiContextOnly?: boolean;
-    body?: InlineObject11;
+    body?: InlineObject12;
 }
 
 export interface ApiV2TopicTopicIdAuthorsPutRequest {
     topicId: number;
-    body?: InlineObject12;
+    body?: InlineObject13;
 }
 
 export interface ApiV2TopicTopicIdDeleteRequest {
@@ -407,12 +418,17 @@ export interface ApiV2TopicTopicIdGetRequest {
 
 export interface ApiV2TopicTopicIdImportPostRequest {
     topicId: number;
-    body?: InlineObject13;
+    body?: InlineObject14;
+}
+
+export interface ApiV2TopicTopicIdMetainfoPutRequest {
+    topicId: number;
+    body?: InlineObject15;
 }
 
 export interface ApiV2TopicTopicIdPutRequest {
     topicId: number;
-    body?: InlineObject9;
+    body?: InlineObject10;
 }
 
 export interface ApiV2TopicTopicIdReleaseGetRequest {
@@ -731,6 +747,41 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
+     * ブックのメタ情報を更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックのメタ情報の更新
+     */
+    async apiV2BookBookIdMetainfoPutRaw(requestParameters: ApiV2BookBookIdMetainfoPutRequest): Promise<runtime.ApiResponse<{ [key: string]: object; }>> {
+        if (requestParameters.bookId === null || requestParameters.bookId === undefined) {
+            throw new runtime.RequiredError('bookId','Required parameter requestParameters.bookId was null or undefined when calling apiV2BookBookIdMetainfoPut.');
+        }
+
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        const response = await this.request({
+            path: `/api/v2/book/{book_id}/metainfo`.replace(`{${"book_id"}}`, encodeURIComponent(String(requestParameters.bookId))),
+            method: 'PUT',
+            headers: headerParameters,
+            query: queryParameters,
+            body: InlineObject6ToJSON(requestParameters.body),
+        });
+
+        return new runtime.JSONApiResponse<any>(response);
+    }
+
+    /**
+     * ブックのメタ情報を更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックのメタ情報の更新
+     */
+    async apiV2BookBookIdMetainfoPut(requestParameters: ApiV2BookBookIdMetainfoPutRequest): Promise<{ [key: string]: object; }> {
+        const response = await this.apiV2BookBookIdMetainfoPutRaw(requestParameters);
+        return await response.value();
+    }
+
+    /**
      * ブックを更新します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。 追加トピックは複製されます。noclone=true を指定するとトピックを複製しません。
      * ブックの更新
      */
@@ -821,7 +872,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject7ToJSON(requestParameters.body),
+            body: InlineObject8ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2006BooksFromJSON(jsonValue));
@@ -856,7 +907,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject6ToJSON(requestParameters.body),
+            body: InlineObject7ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse<any>(response);
@@ -1021,7 +1072,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject17ToJSON(requestParameters.body),
+            body: InlineObject19ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse<any>(response);
@@ -1052,7 +1103,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject16ToJSON(requestParameters.body),
+            body: InlineObject18ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse<any>(response);
@@ -1083,7 +1134,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject15ToJSON(requestParameters.body),
+            body: InlineObject17ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse<any>(response);
@@ -1260,7 +1311,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject8ToJSON(requestParameters.body),
+            body: InlineObject9ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2011FromJSON(jsonValue));
@@ -2036,7 +2087,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject14ToJSON(requestParameters.body),
+            body: InlineObject16ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2005ResourceTracksFromJSON(jsonValue));
@@ -2274,7 +2325,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject10ToJSON(requestParameters.body),
+            body: InlineObject11ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2005TopicsFromJSON(jsonValue));
@@ -2313,7 +2364,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject11ToJSON(requestParameters.body),
+            body: InlineObject12ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse<any>(response);
@@ -2348,7 +2399,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject12ToJSON(requestParameters.body),
+            body: InlineObject13ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(InlineResponse2003BookAuthorsFromJSON));
@@ -2446,7 +2497,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject13ToJSON(requestParameters.body),
+            body: InlineObject14ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2011FromJSON(jsonValue));
@@ -2458,6 +2509,41 @@ export class DefaultApi extends runtime.BaseAPI {
      */
     async apiV2TopicTopicIdImportPost(requestParameters: ApiV2TopicTopicIdImportPostRequest): Promise<InlineResponse2011> {
         const response = await this.apiV2TopicTopicIdImportPostRaw(requestParameters);
+        return await response.value();
+    }
+
+    /**
+     * トピックのメタ情報を更新します。 教員または管理者でなければなりません。 教員は自身の著作のトピックでなければなりません。
+     * トピックのメタ情報の更新
+     */
+    async apiV2TopicTopicIdMetainfoPutRaw(requestParameters: ApiV2TopicTopicIdMetainfoPutRequest): Promise<runtime.ApiResponse<{ [key: string]: object; }>> {
+        if (requestParameters.topicId === null || requestParameters.topicId === undefined) {
+            throw new runtime.RequiredError('topicId','Required parameter requestParameters.topicId was null or undefined when calling apiV2TopicTopicIdMetainfoPut.');
+        }
+
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        const response = await this.request({
+            path: `/api/v2/topic/{topic_id}/metainfo`.replace(`{${"topic_id"}}`, encodeURIComponent(String(requestParameters.topicId))),
+            method: 'PUT',
+            headers: headerParameters,
+            query: queryParameters,
+            body: InlineObject15ToJSON(requestParameters.body),
+        });
+
+        return new runtime.JSONApiResponse<any>(response);
+    }
+
+    /**
+     * トピックのメタ情報を更新します。 教員または管理者でなければなりません。 教員は自身の著作のトピックでなければなりません。
+     * トピックのメタ情報の更新
+     */
+    async apiV2TopicTopicIdMetainfoPut(requestParameters: ApiV2TopicTopicIdMetainfoPutRequest): Promise<{ [key: string]: object; }> {
+        const response = await this.apiV2TopicTopicIdMetainfoPutRaw(requestParameters);
         return await response.value();
     }
 
@@ -2481,7 +2567,7 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
-            body: InlineObject9ToJSON(requestParameters.body),
+            body: InlineObject10ToJSON(requestParameters.body),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse2005TopicsFromJSON(jsonValue));

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -192,6 +192,7 @@ export interface ApiV2BookBookIdClonePostRequest {
 
 export interface ApiV2BookBookIdDeleteRequest {
     bookId: number;
+    withtopic?: boolean;
 }
 
 export interface ApiV2BookBookIdGetRequest {
@@ -649,7 +650,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * ブックを削除します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックを削除します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。 withtopic=trueを指定すると、ブックに含まれるトピックも同時に削除します。
      * ブックの削除
      */
     async apiV2BookBookIdDeleteRaw(requestParameters: ApiV2BookBookIdDeleteRequest): Promise<runtime.ApiResponse<void>> {
@@ -658,6 +659,10 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
         const queryParameters: runtime.HTTPQuery = {};
+
+        if (requestParameters.withtopic !== undefined) {
+            queryParameters['withtopic'] = requestParameters.withtopic;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -672,7 +677,7 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * ブックを削除します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。
+     * ブックを削除します。 教員または管理者でなければなりません。 教員は自身の著作のブックでなければなりません。 withtopic=trueを指定すると、ブックに含まれるトピックも同時に削除します。
      * ブックの削除
      */
     async apiV2BookBookIdDelete(requestParameters: ApiV2BookBookIdDeleteRequest): Promise<void> {

--- a/openapi/models/InlineObject10.ts
+++ b/openapi/models/InlineObject10.ts
@@ -38,12 +38,6 @@ export interface InlineObject10 {
     name?: string;
     /**
      * 
-     * @type {string}
-     * @memberof InlineObject10
-     */
-    language?: string;
-    /**
-     * 
      * @type {number}
      * @memberof InlineObject10
      */
@@ -66,12 +60,6 @@ export interface InlineObject10 {
      * @memberof InlineObject10
      */
     shared?: boolean;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject10
-     */
-    license?: string;
     /**
      * 
      * @type {string}
@@ -103,12 +91,10 @@ export function InlineObject10FromJSONTyped(json: any, ignoreDiscriminator: bool
     return {
         
         'name': !exists(json, 'name') ? undefined : json['name'],
-        'language': !exists(json, 'language') ? undefined : json['language'],
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'startTime': !exists(json, 'startTime') ? undefined : json['startTime'],
         'stopTime': !exists(json, 'stopTime') ? undefined : json['stopTime'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'license': !exists(json, 'license') ? undefined : json['license'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'resource': !exists(json, 'resource') ? undefined : ApiV2TopicTopicIdResourceFromJSON(json['resource']),
         'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
@@ -125,12 +111,10 @@ export function InlineObject10ToJSON(value?: InlineObject10 | null): any {
     return {
         
         'name': value.name,
-        'language': value.language,
         'timeRequired': value.timeRequired,
         'startTime': value.startTime,
         'stopTime': value.stopTime,
         'shared': value.shared,
-        'license': value.license,
         'description': value.description,
         'resource': ApiV2TopicTopicIdResourceToJSON(value.resource),
         'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),

--- a/openapi/models/InlineObject11.ts
+++ b/openapi/models/InlineObject11.ts
@@ -14,10 +14,14 @@
 
 import { exists, mapValues } from '../runtime';
 import {
-    ApiV2TopicTopicIdActivityTimeRanges,
-    ApiV2TopicTopicIdActivityTimeRangesFromJSON,
-    ApiV2TopicTopicIdActivityTimeRangesFromJSONTyped,
-    ApiV2TopicTopicIdActivityTimeRangesToJSON,
+    ApiV2BookBookIdKeywords,
+    ApiV2BookBookIdKeywordsFromJSON,
+    ApiV2BookBookIdKeywordsFromJSONTyped,
+    ApiV2BookBookIdKeywordsToJSON,
+    ApiV2TopicTopicIdResource,
+    ApiV2TopicTopicIdResourceFromJSON,
+    ApiV2TopicTopicIdResourceFromJSONTyped,
+    ApiV2TopicTopicIdResourceToJSON,
 } from './';
 
 /**
@@ -28,10 +32,64 @@ import {
 export interface InlineObject11 {
     /**
      * 
-     * @type {Array<ApiV2TopicTopicIdActivityTimeRanges>}
+     * @type {string}
      * @memberof InlineObject11
      */
-    timeRanges: Array<ApiV2TopicTopicIdActivityTimeRanges>;
+    name?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject11
+     */
+    language?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof InlineObject11
+     */
+    timeRequired?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof InlineObject11
+     */
+    startTime?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof InlineObject11
+     */
+    stopTime?: number;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof InlineObject11
+     */
+    shared?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject11
+     */
+    license?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject11
+     */
+    description?: string;
+    /**
+     * 
+     * @type {ApiV2TopicTopicIdResource}
+     * @memberof InlineObject11
+     */
+    resource?: ApiV2TopicTopicIdResource;
+    /**
+     * 
+     * @type {Array<ApiV2BookBookIdKeywords>}
+     * @memberof InlineObject11
+     */
+    keywords?: Array<ApiV2BookBookIdKeywords>;
 }
 
 export function InlineObject11FromJSON(json: any): InlineObject11 {
@@ -44,7 +102,16 @@ export function InlineObject11FromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'timeRanges': ((json['timeRanges'] as Array<any>).map(ApiV2TopicTopicIdActivityTimeRangesFromJSON)),
+        'name': !exists(json, 'name') ? undefined : json['name'],
+        'language': !exists(json, 'language') ? undefined : json['language'],
+        'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
+        'startTime': !exists(json, 'startTime') ? undefined : json['startTime'],
+        'stopTime': !exists(json, 'stopTime') ? undefined : json['stopTime'],
+        'shared': !exists(json, 'shared') ? undefined : json['shared'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
+        'description': !exists(json, 'description') ? undefined : json['description'],
+        'resource': !exists(json, 'resource') ? undefined : ApiV2TopicTopicIdResourceFromJSON(json['resource']),
+        'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
     };
 }
 
@@ -57,7 +124,16 @@ export function InlineObject11ToJSON(value?: InlineObject11 | null): any {
     }
     return {
         
-        'timeRanges': ((value.timeRanges as Array<any>).map(ApiV2TopicTopicIdActivityTimeRangesToJSON)),
+        'name': value.name,
+        'language': value.language,
+        'timeRequired': value.timeRequired,
+        'startTime': value.startTime,
+        'stopTime': value.stopTime,
+        'shared': value.shared,
+        'license': value.license,
+        'description': value.description,
+        'resource': ApiV2TopicTopicIdResourceToJSON(value.resource),
+        'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),
     };
 }
 

--- a/openapi/models/InlineObject11.ts
+++ b/openapi/models/InlineObject11.ts
@@ -38,12 +38,6 @@ export interface InlineObject11 {
     name?: string;
     /**
      * 
-     * @type {string}
-     * @memberof InlineObject11
-     */
-    language?: string;
-    /**
-     * 
      * @type {number}
      * @memberof InlineObject11
      */
@@ -66,12 +60,6 @@ export interface InlineObject11 {
      * @memberof InlineObject11
      */
     shared?: boolean;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject11
-     */
-    license?: string;
     /**
      * 
      * @type {string}
@@ -103,12 +91,10 @@ export function InlineObject11FromJSONTyped(json: any, ignoreDiscriminator: bool
     return {
         
         'name': !exists(json, 'name') ? undefined : json['name'],
-        'language': !exists(json, 'language') ? undefined : json['language'],
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'startTime': !exists(json, 'startTime') ? undefined : json['startTime'],
         'stopTime': !exists(json, 'stopTime') ? undefined : json['stopTime'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'license': !exists(json, 'license') ? undefined : json['license'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'resource': !exists(json, 'resource') ? undefined : ApiV2TopicTopicIdResourceFromJSON(json['resource']),
         'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
@@ -125,12 +111,10 @@ export function InlineObject11ToJSON(value?: InlineObject11 | null): any {
     return {
         
         'name': value.name,
-        'language': value.language,
         'timeRequired': value.timeRequired,
         'startTime': value.startTime,
         'stopTime': value.stopTime,
         'shared': value.shared,
-        'license': value.license,
         'description': value.description,
         'resource': ApiV2TopicTopicIdResourceToJSON(value.resource),
         'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),

--- a/openapi/models/InlineObject12.ts
+++ b/openapi/models/InlineObject12.ts
@@ -14,10 +14,10 @@
 
 import { exists, mapValues } from '../runtime';
 import {
-    ApiV2BookBookIdAuthorsAuthors,
-    ApiV2BookBookIdAuthorsAuthorsFromJSON,
-    ApiV2BookBookIdAuthorsAuthorsFromJSONTyped,
-    ApiV2BookBookIdAuthorsAuthorsToJSON,
+    ApiV2TopicTopicIdActivityTimeRanges,
+    ApiV2TopicTopicIdActivityTimeRangesFromJSON,
+    ApiV2TopicTopicIdActivityTimeRangesFromJSONTyped,
+    ApiV2TopicTopicIdActivityTimeRangesToJSON,
 } from './';
 
 /**
@@ -28,10 +28,10 @@ import {
 export interface InlineObject12 {
     /**
      * 
-     * @type {Array<ApiV2BookBookIdAuthorsAuthors>}
+     * @type {Array<ApiV2TopicTopicIdActivityTimeRanges>}
      * @memberof InlineObject12
      */
-    authors: Array<ApiV2BookBookIdAuthorsAuthors>;
+    timeRanges: Array<ApiV2TopicTopicIdActivityTimeRanges>;
 }
 
 export function InlineObject12FromJSON(json: any): InlineObject12 {
@@ -44,7 +44,7 @@ export function InlineObject12FromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'authors': ((json['authors'] as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsFromJSON)),
+        'timeRanges': ((json['timeRanges'] as Array<any>).map(ApiV2TopicTopicIdActivityTimeRangesFromJSON)),
     };
 }
 
@@ -57,7 +57,7 @@ export function InlineObject12ToJSON(value?: InlineObject12 | null): any {
     }
     return {
         
-        'authors': ((value.authors as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsToJSON)),
+        'timeRanges': ((value.timeRanges as Array<any>).map(ApiV2TopicTopicIdActivityTimeRangesToJSON)),
     };
 }
 

--- a/openapi/models/InlineObject13.ts
+++ b/openapi/models/InlineObject13.ts
@@ -32,30 +32,6 @@ export interface InlineObject13 {
      * @memberof InlineObject13
      */
     authors: Array<ApiV2BookBookIdAuthorsAuthors>;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject13
-     */
-    provider: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject13
-     */
-    wowzaBaseUrl: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject13
-     */
-    json?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject13
-     */
-    file?: string;
 }
 
 export function InlineObject13FromJSON(json: any): InlineObject13 {
@@ -69,10 +45,6 @@ export function InlineObject13FromJSONTyped(json: any, ignoreDiscriminator: bool
     return {
         
         'authors': ((json['authors'] as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsFromJSON)),
-        'provider': json['provider'],
-        'wowzaBaseUrl': json['wowzaBaseUrl'],
-        'json': !exists(json, 'json') ? undefined : json['json'],
-        'file': !exists(json, 'file') ? undefined : json['file'],
     };
 }
 
@@ -86,10 +58,6 @@ export function InlineObject13ToJSON(value?: InlineObject13 | null): any {
     return {
         
         'authors': ((value.authors as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsToJSON)),
-        'provider': value.provider,
-        'wowzaBaseUrl': value.wowzaBaseUrl,
-        'json': value.json,
-        'file': value.file,
     };
 }
 

--- a/openapi/models/InlineObject14.ts
+++ b/openapi/models/InlineObject14.ts
@@ -13,6 +13,13 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import {
+    ApiV2BookBookIdAuthorsAuthors,
+    ApiV2BookBookIdAuthorsAuthorsFromJSON,
+    ApiV2BookBookIdAuthorsAuthorsFromJSONTyped,
+    ApiV2BookBookIdAuthorsAuthorsToJSON,
+} from './';
+
 /**
  * 
  * @export
@@ -21,16 +28,34 @@ import { exists, mapValues } from '../runtime';
 export interface InlineObject14 {
     /**
      * 
-     * @type {string}
+     * @type {Array<ApiV2BookBookIdAuthorsAuthors>}
      * @memberof InlineObject14
      */
-    language?: string;
+    authors: Array<ApiV2BookBookIdAuthorsAuthors>;
     /**
      * 
      * @type {string}
      * @memberof InlineObject14
      */
-    content?: string;
+    provider: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject14
+     */
+    wowzaBaseUrl: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject14
+     */
+    json?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject14
+     */
+    file?: string;
 }
 
 export function InlineObject14FromJSON(json: any): InlineObject14 {
@@ -43,8 +68,11 @@ export function InlineObject14FromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'language': !exists(json, 'language') ? undefined : json['language'],
-        'content': !exists(json, 'content') ? undefined : json['content'],
+        'authors': ((json['authors'] as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsFromJSON)),
+        'provider': json['provider'],
+        'wowzaBaseUrl': json['wowzaBaseUrl'],
+        'json': !exists(json, 'json') ? undefined : json['json'],
+        'file': !exists(json, 'file') ? undefined : json['file'],
     };
 }
 
@@ -57,8 +85,11 @@ export function InlineObject14ToJSON(value?: InlineObject14 | null): any {
     }
     return {
         
-        'language': value.language,
-        'content': value.content,
+        'authors': ((value.authors as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsToJSON)),
+        'provider': value.provider,
+        'wowzaBaseUrl': value.wowzaBaseUrl,
+        'json': value.json,
+        'file': value.file,
     };
 }
 

--- a/openapi/models/InlineObject15.ts
+++ b/openapi/models/InlineObject15.ts
@@ -21,16 +21,22 @@ import { exists, mapValues } from '../runtime';
 export interface InlineObject15 {
     /**
      * 
-     * @type {number}
+     * @type {string}
      * @memberof InlineObject15
      */
-    tagId?: number;
+    language?: string;
     /**
      * 
-     * @type {number}
+     * @type {string}
      * @memberof InlineObject15
      */
-    topicId?: number;
+    license?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineObject15
+     */
+    licenser?: string;
 }
 
 export function InlineObject15FromJSON(json: any): InlineObject15 {
@@ -43,8 +49,9 @@ export function InlineObject15FromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'tagId': !exists(json, 'tagId') ? undefined : json['tagId'],
-        'topicId': !exists(json, 'topicId') ? undefined : json['topicId'],
+        'language': !exists(json, 'language') ? undefined : json['language'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
+        'licenser': !exists(json, 'licenser') ? undefined : json['licenser'],
     };
 }
 
@@ -57,8 +64,9 @@ export function InlineObject15ToJSON(value?: InlineObject15 | null): any {
     }
     return {
         
-        'tagId': value.tagId,
-        'topicId': value.topicId,
+        'language': value.language,
+        'license': value.license,
+        'licenser': value.licenser,
     };
 }
 

--- a/openapi/models/InlineObject17.ts
+++ b/openapi/models/InlineObject17.ts
@@ -21,10 +21,10 @@ import { exists, mapValues } from '../runtime';
 export interface InlineObject17 {
     /**
      * 
-     * @type {string}
+     * @type {number}
      * @memberof InlineObject17
      */
-    memoContent?: string;
+    tagId?: number;
     /**
      * 
      * @type {number}
@@ -43,7 +43,7 @@ export function InlineObject17FromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'memoContent': !exists(json, 'memoContent') ? undefined : json['memoContent'],
+        'tagId': !exists(json, 'tagId') ? undefined : json['tagId'],
         'topicId': !exists(json, 'topicId') ? undefined : json['topicId'],
     };
 }
@@ -57,7 +57,7 @@ export function InlineObject17ToJSON(value?: InlineObject17 | null): any {
     }
     return {
         
-        'memoContent': value.memoContent,
+        'tagId': value.tagId,
         'topicId': value.topicId,
     };
 }

--- a/openapi/models/InlineObject18.ts
+++ b/openapi/models/InlineObject18.ts
@@ -16,39 +16,39 @@ import { exists, mapValues } from '../runtime';
 /**
  * 
  * @export
- * @interface InlineObject16
+ * @interface InlineObject18
  */
-export interface InlineObject16 {
+export interface InlineObject18 {
     /**
      * 
      * @type {string}
-     * @memberof InlineObject16
+     * @memberof InlineObject18
      */
-    language?: string;
+    memoContent?: string;
     /**
      * 
-     * @type {string}
-     * @memberof InlineObject16
+     * @type {number}
+     * @memberof InlineObject18
      */
-    content?: string;
+    topicId?: number;
 }
 
-export function InlineObject16FromJSON(json: any): InlineObject16 {
-    return InlineObject16FromJSONTyped(json, false);
+export function InlineObject18FromJSON(json: any): InlineObject18 {
+    return InlineObject18FromJSONTyped(json, false);
 }
 
-export function InlineObject16FromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineObject16 {
+export function InlineObject18FromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineObject18 {
     if ((json === undefined) || (json === null)) {
         return json;
     }
     return {
         
-        'language': !exists(json, 'language') ? undefined : json['language'],
-        'content': !exists(json, 'content') ? undefined : json['content'],
+        'memoContent': !exists(json, 'memoContent') ? undefined : json['memoContent'],
+        'topicId': !exists(json, 'topicId') ? undefined : json['topicId'],
     };
 }
 
-export function InlineObject16ToJSON(value?: InlineObject16 | null): any {
+export function InlineObject18ToJSON(value?: InlineObject18 | null): any {
     if (value === undefined) {
         return undefined;
     }
@@ -57,8 +57,8 @@ export function InlineObject16ToJSON(value?: InlineObject16 | null): any {
     }
     return {
         
-        'language': value.language,
-        'content': value.content,
+        'memoContent': value.memoContent,
+        'topicId': value.topicId,
     };
 }
 

--- a/openapi/models/InlineObject19.ts
+++ b/openapi/models/InlineObject19.ts
@@ -16,39 +16,39 @@ import { exists, mapValues } from '../runtime';
 /**
  * 
  * @export
- * @interface InlineObject16
+ * @interface InlineObject19
  */
-export interface InlineObject16 {
+export interface InlineObject19 {
     /**
      * 
      * @type {string}
-     * @memberof InlineObject16
+     * @memberof InlineObject19
      */
-    language?: string;
+    memoContent?: string;
     /**
      * 
-     * @type {string}
-     * @memberof InlineObject16
+     * @type {number}
+     * @memberof InlineObject19
      */
-    content?: string;
+    topicId?: number;
 }
 
-export function InlineObject16FromJSON(json: any): InlineObject16 {
-    return InlineObject16FromJSONTyped(json, false);
+export function InlineObject19FromJSON(json: any): InlineObject19 {
+    return InlineObject19FromJSONTyped(json, false);
 }
 
-export function InlineObject16FromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineObject16 {
+export function InlineObject19FromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineObject19 {
     if ((json === undefined) || (json === null)) {
         return json;
     }
     return {
         
-        'language': !exists(json, 'language') ? undefined : json['language'],
-        'content': !exists(json, 'content') ? undefined : json['content'],
+        'memoContent': !exists(json, 'memoContent') ? undefined : json['memoContent'],
+        'topicId': !exists(json, 'topicId') ? undefined : json['topicId'],
     };
 }
 
-export function InlineObject16ToJSON(value?: InlineObject16 | null): any {
+export function InlineObject19ToJSON(value?: InlineObject19 | null): any {
     if (value === undefined) {
         return undefined;
     }
@@ -57,8 +57,8 @@ export function InlineObject16ToJSON(value?: InlineObject16 | null): any {
     }
     return {
         
-        'language': value.language,
-        'content': value.content,
+        'memoContent': value.memoContent,
+        'topicId': value.topicId,
     };
 }
 

--- a/openapi/models/InlineObject2.ts
+++ b/openapi/models/InlineObject2.ts
@@ -48,22 +48,10 @@ export interface InlineObject2 {
     description?: string;
     /**
      * 
-     * @type {string}
-     * @memberof InlineObject2
-     */
-    language?: string;
-    /**
-     * 
      * @type {boolean}
      * @memberof InlineObject2
      */
     shared?: boolean;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject2
-     */
-    license?: string;
     /**
      * 
      * @type {Array<ApiV2BookBookIdSections>}
@@ -96,9 +84,7 @@ export function InlineObject2FromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'name': !exists(json, 'name') ? undefined : json['name'],
         'description': !exists(json, 'description') ? undefined : json['description'],
-        'language': !exists(json, 'language') ? undefined : json['language'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'license': !exists(json, 'license') ? undefined : json['license'],
         'sections': !exists(json, 'sections') ? undefined : ((json['sections'] as Array<any>).map(ApiV2BookBookIdSectionsFromJSON)),
         'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
         'publicBooks': !exists(json, 'publicBooks') ? undefined : ((json['publicBooks'] as Array<any>).map(InlineResponse2005PublicBooksFromJSON)),
@@ -116,9 +102,7 @@ export function InlineObject2ToJSON(value?: InlineObject2 | null): any {
         
         'name': value.name,
         'description': value.description,
-        'language': value.language,
         'shared': value.shared,
-        'license': value.license,
         'sections': value.sections === undefined ? undefined : ((value.sections as Array<any>).map(ApiV2BookBookIdSectionsToJSON)),
         'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),
         'publicBooks': value.publicBooks === undefined ? undefined : ((value.publicBooks as Array<any>).map(InlineResponse2005PublicBooksToJSON)),

--- a/openapi/models/InlineObject3.ts
+++ b/openapi/models/InlineObject3.ts
@@ -48,22 +48,10 @@ export interface InlineObject3 {
     description?: string;
     /**
      * 
-     * @type {string}
-     * @memberof InlineObject3
-     */
-    language?: string;
-    /**
-     * 
      * @type {boolean}
      * @memberof InlineObject3
      */
     shared?: boolean;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject3
-     */
-    license?: string;
     /**
      * 
      * @type {Array<ApiV2BookBookIdSections>}
@@ -96,9 +84,7 @@ export function InlineObject3FromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'name': !exists(json, 'name') ? undefined : json['name'],
         'description': !exists(json, 'description') ? undefined : json['description'],
-        'language': !exists(json, 'language') ? undefined : json['language'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'license': !exists(json, 'license') ? undefined : json['license'],
         'sections': !exists(json, 'sections') ? undefined : ((json['sections'] as Array<any>).map(ApiV2BookBookIdSectionsFromJSON)),
         'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
         'publicBooks': !exists(json, 'publicBooks') ? undefined : ((json['publicBooks'] as Array<any>).map(InlineResponse2005PublicBooksFromJSON)),
@@ -116,9 +102,7 @@ export function InlineObject3ToJSON(value?: InlineObject3 | null): any {
         
         'name': value.name,
         'description': value.description,
-        'language': value.language,
         'shared': value.shared,
-        'license': value.license,
         'sections': value.sections === undefined ? undefined : ((value.sections as Array<any>).map(ApiV2BookBookIdSectionsToJSON)),
         'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),
         'publicBooks': value.publicBooks === undefined ? undefined : ((value.publicBooks as Array<any>).map(InlineResponse2005PublicBooksToJSON)),

--- a/openapi/models/InlineObject6.ts
+++ b/openapi/models/InlineObject6.ts
@@ -24,25 +24,19 @@ export interface InlineObject6 {
      * @type {string}
      * @memberof InlineObject6
      */
-    version?: string;
+    language?: string;
     /**
      * 
      * @type {string}
      * @memberof InlineObject6
      */
-    comment?: string;
+    license?: string;
     /**
      * 
-     * @type {boolean}
+     * @type {string}
      * @memberof InlineObject6
      */
-    shared?: boolean;
-    /**
-     * 
-     * @type {Array<number>}
-     * @memberof InlineObject6
-     */
-    topics?: Array<number>;
+    licenser?: string;
 }
 
 export function InlineObject6FromJSON(json: any): InlineObject6 {
@@ -55,10 +49,9 @@ export function InlineObject6FromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
-        'version': !exists(json, 'version') ? undefined : json['version'],
-        'comment': !exists(json, 'comment') ? undefined : json['comment'],
-        'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'topics': !exists(json, 'topics') ? undefined : json['topics'],
+        'language': !exists(json, 'language') ? undefined : json['language'],
+        'license': !exists(json, 'license') ? undefined : json['license'],
+        'licenser': !exists(json, 'licenser') ? undefined : json['licenser'],
     };
 }
 
@@ -71,10 +64,9 @@ export function InlineObject6ToJSON(value?: InlineObject6 | null): any {
     }
     return {
         
-        'version': value.version,
-        'comment': value.comment,
-        'shared': value.shared,
-        'topics': value.topics,
+        'language': value.language,
+        'license': value.license,
+        'licenser': value.licenser,
     };
 }
 

--- a/openapi/models/InlineObject8.ts
+++ b/openapi/models/InlineObject8.ts
@@ -13,13 +13,6 @@
  */
 
 import { exists, mapValues } from '../runtime';
-import {
-    ApiV2BookBookIdAuthorsAuthors,
-    ApiV2BookBookIdAuthorsAuthorsFromJSON,
-    ApiV2BookBookIdAuthorsAuthorsFromJSONTyped,
-    ApiV2BookBookIdAuthorsAuthorsToJSON,
-} from './';
-
 /**
  * 
  * @export
@@ -28,34 +21,28 @@ import {
 export interface InlineObject8 {
     /**
      * 
-     * @type {Array<ApiV2BookBookIdAuthorsAuthors>}
+     * @type {string}
      * @memberof InlineObject8
      */
-    authors: Array<ApiV2BookBookIdAuthorsAuthors>;
+    version?: string;
     /**
      * 
      * @type {string}
      * @memberof InlineObject8
      */
-    provider: string;
+    comment?: string;
     /**
      * 
-     * @type {string}
+     * @type {boolean}
      * @memberof InlineObject8
      */
-    wowzaBaseUrl: string;
+    shared?: boolean;
     /**
      * 
-     * @type {string}
+     * @type {Array<number>}
      * @memberof InlineObject8
      */
-    json?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof InlineObject8
-     */
-    file?: string;
+    topics?: Array<number>;
 }
 
 export function InlineObject8FromJSON(json: any): InlineObject8 {
@@ -68,11 +55,10 @@ export function InlineObject8FromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
-        'authors': ((json['authors'] as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsFromJSON)),
-        'provider': json['provider'],
-        'wowzaBaseUrl': json['wowzaBaseUrl'],
-        'json': !exists(json, 'json') ? undefined : json['json'],
-        'file': !exists(json, 'file') ? undefined : json['file'],
+        'version': !exists(json, 'version') ? undefined : json['version'],
+        'comment': !exists(json, 'comment') ? undefined : json['comment'],
+        'shared': !exists(json, 'shared') ? undefined : json['shared'],
+        'topics': !exists(json, 'topics') ? undefined : json['topics'],
     };
 }
 
@@ -85,11 +71,10 @@ export function InlineObject8ToJSON(value?: InlineObject8 | null): any {
     }
     return {
         
-        'authors': ((value.authors as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsToJSON)),
-        'provider': value.provider,
-        'wowzaBaseUrl': value.wowzaBaseUrl,
-        'json': value.json,
-        'file': value.file,
+        'version': value.version,
+        'comment': value.comment,
+        'shared': value.shared,
+        'topics': value.topics,
     };
 }
 

--- a/openapi/models/InlineObject9.ts
+++ b/openapi/models/InlineObject9.ts
@@ -14,14 +14,10 @@
 
 import { exists, mapValues } from '../runtime';
 import {
-    ApiV2BookBookIdKeywords,
-    ApiV2BookBookIdKeywordsFromJSON,
-    ApiV2BookBookIdKeywordsFromJSONTyped,
-    ApiV2BookBookIdKeywordsToJSON,
-    ApiV2TopicTopicIdResource,
-    ApiV2TopicTopicIdResourceFromJSON,
-    ApiV2TopicTopicIdResourceFromJSONTyped,
-    ApiV2TopicTopicIdResourceToJSON,
+    ApiV2BookBookIdAuthorsAuthors,
+    ApiV2BookBookIdAuthorsAuthorsFromJSON,
+    ApiV2BookBookIdAuthorsAuthorsFromJSONTyped,
+    ApiV2BookBookIdAuthorsAuthorsToJSON,
 } from './';
 
 /**
@@ -32,64 +28,34 @@ import {
 export interface InlineObject9 {
     /**
      * 
-     * @type {string}
+     * @type {Array<ApiV2BookBookIdAuthorsAuthors>}
      * @memberof InlineObject9
      */
-    name?: string;
+    authors: Array<ApiV2BookBookIdAuthorsAuthors>;
     /**
      * 
      * @type {string}
      * @memberof InlineObject9
      */
-    language?: string;
-    /**
-     * 
-     * @type {number}
-     * @memberof InlineObject9
-     */
-    timeRequired?: number;
-    /**
-     * 
-     * @type {number}
-     * @memberof InlineObject9
-     */
-    startTime?: number;
-    /**
-     * 
-     * @type {number}
-     * @memberof InlineObject9
-     */
-    stopTime?: number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof InlineObject9
-     */
-    shared?: boolean;
+    provider: string;
     /**
      * 
      * @type {string}
      * @memberof InlineObject9
      */
-    license?: string;
+    wowzaBaseUrl: string;
     /**
      * 
      * @type {string}
      * @memberof InlineObject9
      */
-    description?: string;
+    json?: string;
     /**
      * 
-     * @type {ApiV2TopicTopicIdResource}
+     * @type {string}
      * @memberof InlineObject9
      */
-    resource?: ApiV2TopicTopicIdResource;
-    /**
-     * 
-     * @type {Array<ApiV2BookBookIdKeywords>}
-     * @memberof InlineObject9
-     */
-    keywords?: Array<ApiV2BookBookIdKeywords>;
+    file?: string;
 }
 
 export function InlineObject9FromJSON(json: any): InlineObject9 {
@@ -102,16 +68,11 @@ export function InlineObject9FromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
-        'language': !exists(json, 'language') ? undefined : json['language'],
-        'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
-        'startTime': !exists(json, 'startTime') ? undefined : json['startTime'],
-        'stopTime': !exists(json, 'stopTime') ? undefined : json['stopTime'],
-        'shared': !exists(json, 'shared') ? undefined : json['shared'],
-        'license': !exists(json, 'license') ? undefined : json['license'],
-        'description': !exists(json, 'description') ? undefined : json['description'],
-        'resource': !exists(json, 'resource') ? undefined : ApiV2TopicTopicIdResourceFromJSON(json['resource']),
-        'keywords': !exists(json, 'keywords') ? undefined : ((json['keywords'] as Array<any>).map(ApiV2BookBookIdKeywordsFromJSON)),
+        'authors': ((json['authors'] as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsFromJSON)),
+        'provider': json['provider'],
+        'wowzaBaseUrl': json['wowzaBaseUrl'],
+        'json': !exists(json, 'json') ? undefined : json['json'],
+        'file': !exists(json, 'file') ? undefined : json['file'],
     };
 }
 
@@ -124,16 +85,11 @@ export function InlineObject9ToJSON(value?: InlineObject9 | null): any {
     }
     return {
         
-        'name': value.name,
-        'language': value.language,
-        'timeRequired': value.timeRequired,
-        'startTime': value.startTime,
-        'stopTime': value.stopTime,
-        'shared': value.shared,
-        'license': value.license,
-        'description': value.description,
-        'resource': ApiV2TopicTopicIdResourceToJSON(value.resource),
-        'keywords': value.keywords === undefined ? undefined : ((value.keywords as Array<any>).map(ApiV2BookBookIdKeywordsToJSON)),
+        'authors': ((value.authors as Array<any>).map(ApiV2BookBookIdAuthorsAuthorsToJSON)),
+        'provider': value.provider,
+        'wowzaBaseUrl': value.wowzaBaseUrl,
+        'json': value.json,
+        'file': value.file,
     };
 }
 

--- a/openapi/models/InlineResponse2005Contents.ts
+++ b/openapi/models/InlineResponse2005Contents.ts
@@ -113,6 +113,12 @@ export interface InlineResponse2005Contents {
      * @type {string}
      * @memberof InlineResponse2005Contents
      */
+    licenser?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2005Contents
+     */
     description?: string;
     /**
      * 
@@ -207,6 +213,7 @@ export function InlineResponse2005ContentsFromJSONTyped(json: any, ignoreDiscrim
         'stopTime': !exists(json, 'stopTime') ? undefined : json['stopTime'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
         'license': !exists(json, 'license') ? undefined : json['license'],
+        'licenser': !exists(json, 'licenser') ? undefined : json['licenser'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
         'updatedAt': !exists(json, 'updatedAt') ? undefined : (new Date(json['updatedAt'])),
@@ -241,6 +248,7 @@ export function InlineResponse2005ContentsToJSON(value?: InlineResponse2005Conte
         'stopTime': value.stopTime,
         'shared': value.shared,
         'license': value.license,
+        'licenser': value.licenser,
         'description': value.description,
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),
         'updatedAt': value.updatedAt === undefined ? undefined : (value.updatedAt.toISOString()),

--- a/openapi/models/InlineResponse2005Topics.ts
+++ b/openapi/models/InlineResponse2005Topics.ts
@@ -91,6 +91,12 @@ export interface InlineResponse2005Topics {
      * @type {string}
      * @memberof InlineResponse2005Topics
      */
+    licenser?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2005Topics
+     */
     description?: string;
     /**
      * 
@@ -154,6 +160,7 @@ export function InlineResponse2005TopicsFromJSONTyped(json: any, ignoreDiscrimin
         'stopTime': !exists(json, 'stopTime') ? undefined : json['stopTime'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
         'license': !exists(json, 'license') ? undefined : json['license'],
+        'licenser': !exists(json, 'licenser') ? undefined : json['licenser'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
         'updatedAt': !exists(json, 'updatedAt') ? undefined : (new Date(json['updatedAt'])),
@@ -182,6 +189,7 @@ export function InlineResponse2005TopicsToJSON(value?: InlineResponse2005Topics 
         'stopTime': value.stopTime,
         'shared': value.shared,
         'license': value.license,
+        'licenser': value.licenser,
         'description': value.description,
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),
         'updatedAt': value.updatedAt === undefined ? undefined : (value.updatedAt.toISOString()),

--- a/openapi/models/InlineResponse2006Books.ts
+++ b/openapi/models/InlineResponse2006Books.ts
@@ -90,6 +90,12 @@ export interface InlineResponse2006Books {
     license?: string;
     /**
      * 
+     * @type {string}
+     * @memberof InlineResponse2006Books
+     */
+    licenser?: string;
+    /**
+     * 
      * @type {Date}
      * @memberof InlineResponse2006Books
      */
@@ -167,6 +173,7 @@ export function InlineResponse2006BooksFromJSONTyped(json: any, ignoreDiscrimina
         'timeRequired': !exists(json, 'timeRequired') ? undefined : json['timeRequired'],
         'shared': !exists(json, 'shared') ? undefined : json['shared'],
         'license': !exists(json, 'license') ? undefined : json['license'],
+        'licenser': !exists(json, 'licenser') ? undefined : json['licenser'],
         'publishedAt': !exists(json, 'publishedAt') ? undefined : (new Date(json['publishedAt'])),
         'createdAt': !exists(json, 'createdAt') ? undefined : (new Date(json['createdAt'])),
         'updatedAt': !exists(json, 'updatedAt') ? undefined : (new Date(json['updatedAt'])),
@@ -196,6 +203,7 @@ export function InlineResponse2006BooksToJSON(value?: InlineResponse2006Books | 
         'timeRequired': value.timeRequired,
         'shared': value.shared,
         'license': value.license,
+        'licenser': value.licenser,
         'publishedAt': value.publishedAt === undefined ? undefined : (value.publishedAt.toISOString()),
         'createdAt': value.createdAt === undefined ? undefined : (value.createdAt.toISOString()),
         'updatedAt': value.updatedAt === undefined ? undefined : (value.updatedAt.toISOString()),

--- a/openapi/models/index.ts
+++ b/openapi/models/index.ts
@@ -16,6 +16,8 @@ export * from './InlineObject14';
 export * from './InlineObject15';
 export * from './InlineObject16';
 export * from './InlineObject17';
+export * from './InlineObject18';
+export * from './InlineObject19';
 export * from './InlineObject2';
 export * from './InlineObject3';
 export * from './InlineObject4';

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -58,8 +58,11 @@ function Edit({ bookId, context }: Query) {
     if (submitWithLink) await onBookLinking?.({ id: bookId });
     return back();
   }
-  async function handleDelete({ id }: Pick<BookSchema, "id">) {
-    await destroyBook(id);
+  async function handleDelete(
+    { id }: Pick<BookSchema, "id">,
+    withtopic: boolean
+  ) {
+    await destroyBook(id, withtopic);
     switch (context) {
       case "books":
       case "topics":

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -12,7 +12,9 @@ import BookNotFoundProblem from "$templates/BookNotFoundProblem";
 import {
   cloneBook,
   destroyBook,
+  revalidateBook,
   updateBook,
+  updateMetainfoBook,
   updateReleaseBook,
   useBook,
 } from "$utils/book";
@@ -21,6 +23,7 @@ import useBookLinkingHandlers from "$utils/useBookLinkingHandlers";
 import useAuthorsHandler from "$utils/useAuthorsHandler";
 import type { ReleaseProps } from "$server/models/book/release";
 import { mutateReleasebooks } from "$utils/useReleaseBooks";
+import type { MetainfoProps } from "$server/models/metainfo";
 
 export type Query = {
   bookId: BookSchema["id"];
@@ -121,6 +124,13 @@ function Edit({ bookId, context }: Query) {
       })
     );
   }
+  async function handleMetainfoUpdate(metainfo: MetainfoProps) {
+    console.log(metainfo);
+    if (book) {
+      const _res = await updateMetainfoBook(book.id, metainfo);
+      await revalidateBook(book.id);
+    }
+  }
   const handlers = {
     linked: bookId === session?.ltiResourceLink?.bookId,
     onSubmit: handleSubmit,
@@ -139,6 +149,7 @@ function Edit({ bookId, context }: Query) {
     onRelease: handleRelease,
     onItemEditClick: handleItemEditClick,
     onClone: handleClone,
+    onMetainfoUpdate: handleMetainfoUpdate,
   };
 
   if (error) return <BookNotFoundProblem />;

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -125,7 +125,6 @@ function Edit({ bookId, context }: Query) {
     );
   }
   async function handleMetainfoUpdate(metainfo: MetainfoProps) {
-    console.log(metainfo);
     if (book) {
       const _res = await updateMetainfoBook(book.id, metainfo);
       await revalidateBook(book.id);

--- a/pages/topics/edit.tsx
+++ b/pages/topics/edit.tsx
@@ -13,11 +13,18 @@ import TopicEdit from "$templates/TopicEdit";
 import TopicNotFoundProblem from "$templates/TopicNotFoundProblem";
 import BookNotFoundProblem from "$templates/BookNotFoundProblem";
 import { useVideoTrackAtom } from "$store/videoTrack";
-import { destroyTopic, updateTopic, useTopic } from "$utils/topic";
+import {
+  destroyTopic,
+  revalidateTopic,
+  updateMetainfoTopic,
+  updateTopic,
+  useTopic,
+} from "$utils/topic";
 import { destroyVideoTrack, uploadVideoTrack } from "$utils/videoTrack";
 import useAuthorsHandler from "$utils/useAuthorsHandler";
 import { useWowzaUpload } from "$utils/wowza/useWowzaUplooad";
 import { pagesPath } from "$utils/$path";
+import type { MetainfoProps } from "$server/models/metainfo";
 
 export type Query =
   | { topicId: TopicSchema["id"] }
@@ -89,6 +96,12 @@ function Edit({ topicId, back }: EditProps) {
   const handleItemEditClick = async (topicId: TopicSchema["id"]) => {
     return router.push(pagesPath.topics.edit.$url({ query: { topicId } }));
   };
+  async function handleMetainfoUpdate(metainfo: MetainfoProps) {
+    if (topic) {
+      const _res = await updateMetainfoTopic(topic.id, metainfo);
+      await revalidateTopic(topic.id);
+    }
+  }
   const handlers = {
     onSubmit: handleSubmit,
     onDelete: handleDelete,
@@ -99,6 +112,7 @@ function Edit({ topicId, back }: EditProps) {
     onAuthorSubmit: handleAuthorSubmit,
     onImportClick: handleImportClick,
     onItemEditClick: handleItemEditClick,
+    onMetainfoUpdate: handleMetainfoUpdate,
   };
 
   if (!topic) return <Placeholder />;

--- a/samples/book.ts
+++ b/samples/book.ts
@@ -10,6 +10,7 @@ const book = {
   timeRequired: null,
   shared: true,
   license: "",
+  licenser: "",
   zoomMeetingId: null,
   authors: [{ ...user, roleName: "作成者" }],
   keywords: [],

--- a/samples/topic.ts
+++ b/samples/topic.ts
@@ -37,6 +37,7 @@ const topic = {
   shared: true,
   language: "ja",
   license: "",
+  licenser: "",
   resource,
   bookmarks: [bookmark],
 };

--- a/server/config/routes/book.ts
+++ b/server/config/routes/book.ts
@@ -9,6 +9,7 @@ import * as showZoomService from "$server/services/book/zoom";
 import * as importService from "$server/services/bookImport";
 import * as releaseService from "$server/services/book/release";
 import * as cloneService from "$server/services/clone";
+import * as metainfoService from "$server/services/book/metainfo";
 
 const basePath = "/book";
 const pathWithParams = `${basePath}/:book_id`;
@@ -126,7 +127,16 @@ export async function bookClone(fastify: FastifyInstance) {
 
   fastify.post<{
     Params: service.Params;
-    Body: importService.Params;
   }>(path, { schema: cloneSchema, ...hooks.post }, handler(clone));
 }
 
+export async function bookMetainfo(fastify: FastifyInstance) {
+  const path = `${pathWithParams}/metainfo`;
+  const { method, update } = metainfoService;
+  const hooks = makeHooks(fastify, metainfoService.hooks);
+
+  fastify.put<{
+    Params: metainfoService.Params;
+    Body: metainfoService.Props;
+  }>(path, { schema: method.put, ...hooks.put }, handler(update));
+}

--- a/server/config/routes/book.ts
+++ b/server/config/routes/book.ts
@@ -28,12 +28,13 @@ export async function book(fastify: FastifyInstance) {
 
   fastify.put<{
     Params: service.Params;
-    Querystring: service.Query;
+    Querystring: service.UpdateQuery;
     Body: service.Props;
   }>(pathWithParams, { schema: method.put, ...hooks.put }, handler(update));
 
   fastify.delete<{
     Params: service.Params;
+    Querystring: service.DestroyQuery;
   }>(
     pathWithParams,
     { schema: method.delete, ...hooks.delete },

--- a/server/config/routes/topic.ts
+++ b/server/config/routes/topic.ts
@@ -6,6 +6,7 @@ import * as activityService from "$server/services/topic/activity";
 import * as authorsService from "$server/services/topic/authors";
 import * as importService from "$server/services/topicImport";
 import * as releaseService from "$server/services/topic/release";
+import * as metainfoService from "$server/services/topic/metainfo";
 
 const basePath = "/topic";
 const pathWithParams = `${basePath}/:topic_id`;
@@ -78,4 +79,15 @@ export async function topicRelease(fastify: FastifyInstance) {
   fastify.get<{
     Params: releaseService.Params;
   }>(path, { schema: method.get, ...hooks.get }, handler(show));
+}
+
+export async function topicMetainfo(fastify: FastifyInstance) {
+  const path = `${pathWithParams}/metainfo`;
+  const { method, update } = metainfoService;
+  const hooks = makeHooks(fastify, metainfoService.hooks);
+
+  fastify.put<{
+    Params: metainfoService.Params;
+    Body: metainfoService.Props;
+  }>(path, { schema: method.put, ...hooks.put }, handler(update));
 }

--- a/server/models/author.ts
+++ b/server/models/author.ts
@@ -9,7 +9,6 @@ const _roleNames = {
   author: "作成者",
   "co-author": "共同作成者",
   collaborator: "協力者",
-  "original-author": "原著者",
   administrator: "管理者",
 } as const;
 

--- a/server/models/book.ts
+++ b/server/models/book.ts
@@ -13,9 +13,7 @@ import { releaseSchema } from "./book/release";
 export type BookProps = {
   name: string;
   description?: string;
-  language?: string;
   shared?: boolean;
-  license?: string;
   sections?: SectionProps[];
   keywords?: KeywordPropSchema[];
   publicBooks?: PublicBookSchema[];
@@ -35,9 +33,7 @@ export const bookPropsSchema = {
   properties: {
     name: { type: "string" },
     description: { type: "string" },
-    language: { type: "string", nullable: true },
     shared: { type: "boolean", nullable: true },
-    license: { type: "string" },
     sections: {
       type: "array",
       items: sectionPropsSchema,

--- a/server/models/book.ts
+++ b/server/models/book.ts
@@ -63,6 +63,7 @@ export const bookSchema = {
     timeRequired: { type: "integer", nullable: true },
     shared: { type: "boolean" },
     license: { type: "string" },
+    licenser: { type: "string" },
     publishedAt: { type: "string", format: "date-time" },
     createdAt: { type: "string", format: "date-time" },
     updatedAt: { type: "string", format: "date-time" },

--- a/server/models/metainfo.ts
+++ b/server/models/metainfo.ts
@@ -1,0 +1,14 @@
+import type { FromSchema } from "json-schema-to-ts";
+
+/** メタ情報の更新のためのリクエストパラメータ */
+export const metainfoProps = {
+  type: "object",
+  properties: {
+    language: { type: "string" },
+    license: { type: "string" },
+    licenser: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+export type MetainfoProps = FromSchema<typeof metainfoProps>;

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -89,6 +89,7 @@ export const topicSchema = {
     stopTime: { type: "number", nullable: true },
     shared: { type: "boolean" },
     license: { type: "string" },
+    licenser: { type: "string" },
     description: { type: "string" },
     createdAt: { type: "string", format: "date-time" },
     updatedAt: { type: "string", format: "date-time" },

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -39,12 +39,10 @@ export type RelatedBook = FromSchema<
 export type TopicProps = Pick<
   Prisma.TopicCreateInput,
   | "name"
-  | "language"
   | "timeRequired"
   | "startTime"
   | "stopTime"
   | "shared"
-  | "license"
   | "description"
 > & {
   resource: ResourceProps;
@@ -63,12 +61,10 @@ export const TopicProps = {
   type: "object",
   properties: {
     name: { type: "string" },
-    language: { type: "string" },
     timeRequired: { type: "integer" },
     startTime: { type: "number" },
     stopTime: { type: "number", nullable: true },
     shared: { type: "boolean" },
-    license: { type: "string", format: "license" },
     description: { type: "string" },
     resource: resourcePropsSchema,
     keywords: {

--- a/server/prisma/migrations/20250109125319_add_licenser/migration.sql
+++ b/server/prisma/migrations/20250109125319_add_licenser/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "books" ADD COLUMN     "licenser" TEXT NOT NULL DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "topics" ADD COLUMN     "licenser" TEXT NOT NULL DEFAULT '';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -104,6 +104,8 @@ model Topic {
   authors      Authorship[]
   /// ライセンス (https://spdx.org/licenses/ に準拠するもの, "" は無効)
   license      String       @default("")
+  /// 著作権者
+  licenser     String       @default("")
   /// 作成日
   createdAt    DateTime     @default(now()) @map("created_at")
   /// 更新日
@@ -237,6 +239,8 @@ model Book {
   authors          Authorship[]
   /// ライセンス (https://spdx.org/licenses/ に準拠するもの, "" は無効)
   license          String            @default("")
+  /// 著作権者
+  licenser         String            @default("")
   /// zoomミーティングid
   zoomMeetingId    BigInt?           @map("zoom_meeting_id")
   /// 公開日

--- a/server/services/book/destroy.ts
+++ b/server/services/book/destroy.ts
@@ -1,21 +1,23 @@
-import type { FastifySchema } from "fastify";
+import type { FastifyRequest, FastifySchema } from "fastify";
 import { outdent } from "outdent";
 import type { BookParams } from "$server/validators/bookParams";
 import { bookParamsSchema } from "$server/validators/bookParams";
-import type { SessionSchema } from "$server/models/session";
 import authUser from "$server/auth/authUser";
 import authInstructor from "$server/auth/authInstructor";
 import { isUsersOrAdmin } from "$server/utils/session";
 import bookExists from "$server/utils/book/bookExists";
 import destroyBook from "$server/utils/book/destroyBook";
+import { BookDestroyQuery } from "$server/validators/bookQuery";
 
 export const destroySchema: FastifySchema = {
   summary: "ブックの削除",
   description: outdent`
     ブックを削除します。
     教員または管理者でなければなりません。
-    教員は自身の著作のブックでなければなりません。`,
+    教員は自身の著作のブックでなければなりません。
+    withtopic=trueを指定すると、ブックに含まれるトピックも同時に削除します。`,
   params: bookParamsSchema,
+  querystring: BookDestroyQuery,
   response: {
     204: { type: "null", description: "成功" },
     403: {},
@@ -30,10 +32,9 @@ export const destroyHooks = {
 export async function destroy({
   session,
   params,
-}: {
-  session: SessionSchema;
-  params: BookParams;
-}) {
+  query,
+}: FastifyRequest<{ Params: BookParams; Querystring: BookDestroyQuery; }>) {
+  console.log(JSON.stringify(query));
   const found = await bookExists(params.book_id);
 
   if (!found) return { status: 404 };

--- a/server/services/book/index.ts
+++ b/server/services/book/index.ts
@@ -4,11 +4,12 @@ import { showSchema, showHooks, show } from "./show";
 import { createSchema, createHooks, create } from "./create";
 import { updateSchema, updateHooks, update } from "./update";
 import { destroySchema, destroyHooks, destroy } from "./destroy";
-import type { BookQuery } from "$server/validators/bookQuery";
+import type { BookUpdateQuery, BookDestroyQuery } from "$server/validators/bookQuery";
 
 export type Params = BookParams;
 export type Props = BookProps;
-export type Query = BookQuery;
+export type UpdateQuery = BookUpdateQuery;
+export type DestroyQuery = BookDestroyQuery;
 
 export const method = {
   get: showSchema,

--- a/server/services/book/metainfo/index.ts
+++ b/server/services/book/metainfo/index.ts
@@ -1,0 +1,16 @@
+import type { MetainfoProps } from "$server/models/metainfo";
+import type { BookParams } from "$server/validators/bookParams";
+import { updateSchema, updateHooks, update } from "./update";
+
+export type Params = BookParams;
+export type Props = MetainfoProps;
+
+export const method = {
+  put: updateSchema,
+};
+
+export const hooks = {
+  put: updateHooks,
+};
+
+export { update };

--- a/server/services/book/metainfo/update.ts
+++ b/server/services/book/metainfo/update.ts
@@ -1,0 +1,51 @@
+import type { FastifySchema, FastifyRequest } from "fastify";
+import { outdent } from "outdent";
+import type { BookParams } from "$server/validators/bookParams";
+import { bookParamsSchema } from "$server/validators/bookParams";
+import authUser from "$server/auth/authUser";
+import authInstructor from "$server/auth/authInstructor";
+import { isUsersOrAdmin } from "$server/utils/session";
+import findBook from "$server/utils/book/findBook";
+import type { MetainfoProps } from "$server/models/metainfo";
+import { metainfoProps } from "$server/models/metainfo";
+import { updateBookMetainfo } from "$server/utils/metainfo";
+
+export const updateSchema: FastifySchema = {
+  summary: "ブックのメタ情報の更新",
+  description: outdent`
+    ブックのメタ情報を更新します。
+    教員または管理者でなければなりません。
+    教員は自身の著作のブックでなければなりません。`,
+  params: bookParamsSchema,
+  body: metainfoProps,
+  response: {
+    201: metainfoProps,
+    403: {},
+    404: {},
+  },
+};
+
+export const updateHooks = {
+  auth: [authUser, authInstructor],
+};
+
+export async function update({
+  session,
+  body,
+  params,
+}: FastifyRequest<{
+  Body: MetainfoProps;
+  Params: BookParams;
+}>) {
+  const found = await findBook(params.book_id, session.user.id);
+
+  if (!found) return { status: 404 };
+  if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
+
+  const updated = await updateBookMetainfo(params.book_id, body);
+
+  return {
+    status: 201,
+    body: updated,
+  };
+}

--- a/server/services/book/update.ts
+++ b/server/services/book/update.ts
@@ -8,7 +8,7 @@ import authUser from "$server/auth/authUser";
 import authInstructor from "$server/auth/authInstructor";
 import { isUsersOrAdmin } from "$server/utils/session";
 import updateBook from "$server/utils/book/updateBook";
-import { BookQuery } from "$server/validators/bookQuery";
+import { BookUpdateQuery } from "$server/validators/bookQuery";
 import findBook from "$server/utils/book/findBook";
 
 export const updateSchema: FastifySchema = {
@@ -19,7 +19,7 @@ export const updateSchema: FastifySchema = {
     教員は自身の著作のブックでなければなりません。
     追加トピックは複製されます。noclone=true を指定するとトピックを複製しません。`,
   params: bookParamsSchema,
-  querystring: BookQuery,
+  querystring: BookUpdateQuery,
   body: bookPropsSchema,
   response: {
     201: bookSchema,
@@ -38,7 +38,7 @@ export async function update({
   body,
   params,
   query,
-}: FastifyRequest<{ Body: BookProps; Params: BookParams; Querystring: BookQuery; }>) {
+}: FastifyRequest<{ Body: BookProps; Params: BookParams; Querystring: BookUpdateQuery; }>) {
   const found = await findBook(params.book_id, session.user.id);
 
   if (!found) return { status: 404 };

--- a/server/services/topic/metainfo/index.ts
+++ b/server/services/topic/metainfo/index.ts
@@ -1,0 +1,16 @@
+import type { MetainfoProps } from "$server/models/metainfo";
+import type { TopicParams } from "$server/validators/topicParams";
+import { updateSchema, updateHooks, update } from "./update";
+
+export type Params = TopicParams;
+export type Props = MetainfoProps;
+
+export const method = {
+  put: updateSchema,
+};
+
+export const hooks = {
+  put: updateHooks,
+};
+
+export { update };

--- a/server/services/topic/metainfo/update.ts
+++ b/server/services/topic/metainfo/update.ts
@@ -1,0 +1,51 @@
+import type { FastifySchema, FastifyRequest } from "fastify";
+import { outdent } from "outdent";
+import authUser from "$server/auth/authUser";
+import authInstructor from "$server/auth/authInstructor";
+import { isUsersOrAdmin } from "$server/utils/session";
+import type { MetainfoProps } from "$server/models/metainfo";
+import { metainfoProps } from "$server/models/metainfo";
+import { updateTopicMetainfo } from "$server/utils/metainfo";
+import type { TopicParams } from "$server/validators/topicParams";
+import { topicParamsSchema } from "$server/validators/topicParams";
+import findTopic from "$server/utils/topic/findTopic";
+
+export const updateSchema: FastifySchema = {
+  summary: "トピックのメタ情報の更新",
+  description: outdent`
+    トピックのメタ情報を更新します。
+    教員または管理者でなければなりません。
+    教員は自身の著作のトピックでなければなりません。`,
+  params: topicParamsSchema,
+  body: metainfoProps,
+  response: {
+    201: metainfoProps,
+    403: {},
+    404: {},
+  },
+};
+
+export const updateHooks = {
+  auth: [authUser, authInstructor],
+};
+
+export async function update({
+  session,
+  body,
+  params,
+}: FastifyRequest<{
+  Body: MetainfoProps;
+  Params: TopicParams;
+}>) {
+  const found = await findTopic(params.topic_id);
+
+  if (!found) return { status: 404 };
+  if (!isUsersOrAdmin(session, found.authors)) return { status: 403 };
+
+  const updated = await updateTopicMetainfo(params.topic_id, body);
+
+  return {
+    status: 201,
+    body: updated,
+  };
+}

--- a/server/utils/book/importBooksUtil.ts
+++ b/server/utils/book/importBooksUtil.ts
@@ -217,7 +217,7 @@ class ImportBooksUtil {
 
   async updateBook(
     id: number,
-    { sections: _sections, publicBooks: _publicBooks, ...book }: BookProps
+    { sections: _sections, publicBooks: _publicBooks, ...book }: BookProps & Pick<Book, "language">
   ) {
     const keywordsBeforeUpdate = await prisma.keyword.findMany({
       where: { books: { some: { id } } },

--- a/server/utils/metainfo.ts
+++ b/server/utils/metainfo.ts
@@ -5,8 +5,8 @@ import type { MetainfoProps } from '$server/models/metainfo';
 export async function updateBookMetainfo(
   bookId: Book["id"],
   metainfo: MetainfoProps
-): Promise<void> {
-  const _updated = await prisma.book.update({
+): Promise<MetainfoProps> {
+  return await prisma.book.update({
     where: { id: bookId},
     data: metainfo,
   });
@@ -15,8 +15,8 @@ export async function updateBookMetainfo(
 export async function updateTopicMetainfo(
   topicId: Topic["id"],
   metainfo: MetainfoProps
-): Promise<void> {
-  const _updated = await prisma.topic.update({
+): Promise<MetainfoProps> {
+  return await prisma.topic.update({
     where: { id: topicId},
     data: metainfo,
   });

--- a/server/utils/metainfo.ts
+++ b/server/utils/metainfo.ts
@@ -1,0 +1,23 @@
+import type { Book, Topic } from '@prisma/client';
+import prisma from './prisma';
+import type { MetainfoProps } from '$server/models/metainfo';
+
+export async function updateBookMetainfo(
+  bookId: Book["id"],
+  metainfo: MetainfoProps
+): Promise<void> {
+  const _updated = await prisma.book.update({
+    where: { id: bookId},
+    data: metainfo,
+  });
+}
+
+export async function updateTopicMetainfo(
+  topicId: Topic["id"],
+  metainfo: MetainfoProps
+): Promise<void> {
+  const _updated = await prisma.topic.update({
+    where: { id: topicId},
+    data: metainfo,
+  });
+}

--- a/server/validators/bookQuery.ts
+++ b/server/validators/bookQuery.ts
@@ -1,6 +1,6 @@
 import type { FromSchema } from "json-schema-to-ts";
 
-export const BookQuery = {
+export const BookUpdateQuery = {
   type: "object",
   properties: {
     /** トピックを追加するとき、複製を行わないことを指示するオプションパラメータ */
@@ -9,4 +9,15 @@ export const BookQuery = {
   additionalProperties: false,
 } as const;
 
-export type BookQuery = FromSchema<typeof BookQuery>;
+export type BookUpdateQuery = FromSchema<typeof BookUpdateQuery>;
+
+export const BookDestroyQuery = {
+  type: "object",
+  properties: {
+    /** ブックを削除するとき、トピックを同時に削除することを指示するオプションパラメータ */
+    withtopic: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+export type BookDestroyQuery = FromSchema<typeof BookDestroyQuery>;

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -10,6 +10,7 @@ import { revalidateSession } from "./session";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 import { getDisplayableBook } from "./displayableBook";
 import type { ReleaseProps, ReleaseSchema } from "$server/models/book/release";
+import type { MetainfoProps } from "$server/models/metainfo";
 
 const key = "/api/v2/book/{book_id}";
 
@@ -147,4 +148,12 @@ export async function createReleaseBook({
 export async function cloneBook(id: BookSchema["id"]): Promise<BookSchema> {
   const res = await api.apiV2BookBookIdClonePost({ bookId: id });
   return res as BookSchema;
+}
+
+export async function updateMetainfoBook(
+  id: BookSchema["id"],
+  body: MetainfoProps
+): Promise<MetainfoProps> {
+  const res = await api.apiV2BookBookIdMetainfoPut({ bookId: id, body });
+  return res as MetainfoProps;
 }

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -113,8 +113,8 @@ export async function replaceTopicInBook(
   return updateBook({ ...book, sections });
 }
 
-export async function destroyBook(id: BookSchema["id"]) {
-  await api.apiV2BookBookIdDelete({ bookId: id });
+export async function destroyBook(id: BookSchema["id"], withtopic: boolean) {
+  await api.apiV2BookBookIdDelete({ bookId: id, withtopic });
   await revalidateSession();
 }
 

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -1,6 +1,7 @@
 import useSWR, { mutate } from "swr";
 import type { TopicProps, TopicSchema } from "$server/models/topic";
 import { api } from "./api";
+import type { MetainfoProps } from "$server/models/metainfo";
 
 const key = "/api/v2/topic/{topic_id}";
 
@@ -58,4 +59,12 @@ export function revalidateTopic(
   res?: TopicSchema
 ): Promise<TopicSchema | void> {
   return mutate({ key, topicId: id }, res);
+}
+
+export async function updateMetainfoTopic(
+  id: TopicSchema["id"],
+  body: MetainfoProps
+): Promise<MetainfoProps> {
+  const res = await api.apiV2TopicTopicIdMetainfoPut({ topicId: id, body });
+  return res as MetainfoProps;
 }


### PR DESCRIPTION
以下の作業を行いました。

- ブック、トピックの作成者から "原著者" を削除する
- (イ) 著作権者の正式な取扱い
- リリース、メタ情報の編集で、変更したときだけ[更新]ボタンを有効にする
- (ケ) リリースしたブックのトピック一括削除

このプルリクも、すぐ feat-vm2 にマージします。
