### PR TITLE
fix: リリースで複製した他人のトピックが、トピック一覧に表示されない

### DIFF
--- a/server/utils/search/createScopes.ts
+++ b/server/utils/search/createScopes.ts
@@ -60,7 +60,8 @@ export function createScopesTopic(
 ): Array<Prisma.TopicWhereInput> {
   const scopes = {
     sharedScope: { topicSection: { some: { section: { book: { release: { shared: true }}}}}},
-    selfScope: { authors: { some: { userId: filter.by } } },
+    selfScope: { OR: [{ authors: { some: { userId: filter.by } } },
+                      { topicSection: { some: { section: { book: { release: { isNot: null}, authors: { some: { userId: filter.by }}}}}}}]},
     editScope: { topicSection: { every: { section: { book: { release: null }}}}},
   };
   return createScopes<Prisma.TopicWhereInput>(filter, scopes);

--- a/server/utils/uniqueId.ts
+++ b/server/utils/uniqueId.ts
@@ -29,14 +29,14 @@ function releaseUniqueIds(orig: UniqueIds, release: UniqueIds) {
   orig.pid = release.vid;
 }
 
-function cloneUniqueIds(orig: UniqueIds, release: UniqueIds) {
+function cloneUniqueIds(orig: UniqueIds, clone: UniqueIds) {
   if (!orig.poid) {
     generateUniqueIds(orig);
   }
-  release.poid = orig.poid;
-  release.oid = createId();
-  release.pid = orig.vid;
-  release.vid = "";
+  clone.poid = orig.poid;
+  clone.oid = createId();
+  clone.pid = orig.vid;
+  clone.vid = "";
 }
 
 export async function findBookUniqueIds(


### PR DESCRIPTION
リリースで複製した他人のトピックが、トピック一覧に表示されるように修正しました。

詳細は、https://github.com/npocccties/chibichilo-db-refactoring/issues/63#issuecomment-2590043112 に記載しています。

このプルリクは、すぐに feat-vm2 にマージします。
