### PR TITLE
新シナリオ対応: 学習者が親追跡できる

### DIFF
--- a/components/organisms/BookInfo.tsx
+++ b/components/organisms/BookInfo.tsx
@@ -4,14 +4,18 @@ import type { BookSchema } from "$server/models/book";
 import KeywordChip from "$atoms/KeywordChip";
 import useCardStyle from "$styles/card";
 import { Box } from "@mui/material";
+import type { ReleaseItemSchema } from "$server/models/releaseResult";
+import DescriptionList from "$atoms/DescriptionList";
+import getLocaleDateString from "$utils/getLocaleDateString";
 
 type Props = {
   className?: string;
   id?: string;
   book: BookSchema;
+  parent?: ReleaseItemSchema;
 };
 
-export default function BookInfo({ className, id, book }: Props) {
+export default function BookInfo({ className, id, book, parent }: Props) {
   const cardClasses = useCardStyle();
 
   return (
@@ -30,6 +34,52 @@ export default function BookInfo({ className, id, book }: Props) {
         </Box>
       )}
       {book.description && <Markdown>{book.description}</Markdown>}
+      {parent?.release && (
+        <>
+          {"直前のリリース: "}
+          <Box
+            style={{
+              display: "flex",
+              alignItems: "left",
+              flexWrap: "wrap",
+              lineHeight: 2.5,
+            }}
+          >
+            <DescriptionList
+              nowrap
+              sx={{ mx: 2 }}
+              value={[
+                {
+                  key: "タイトル",
+                  value: parent.name || "",
+                },
+              ]}
+            />
+            <DescriptionList
+              nowrap
+              sx={{ mx: 2 }}
+              value={[
+                {
+                  key: "バージョン",
+                  value: parent.release?.version || "",
+                },
+              ]}
+            />
+            {parent.release.releasedAt && (
+              <DescriptionList
+                nowrap
+                sx={{ mx: 2 }}
+                value={[
+                  {
+                    key: "リリース日",
+                    value: getLocaleDateString(parent.release.releasedAt, "ja"),
+                  },
+                ]}
+              />
+            )}
+          </Box>
+        </>
+      )}
     </Card>
   );
 }

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -261,6 +261,9 @@ export default function ContentPreview({
                   value: getLocaleDateString(content.updatedAt, "ja"),
                 },
               ]),
+          ...(content.licenser
+            ? [{ key: "著作権者", value: content.licenser }]
+            : []),
           ...authors(content),
         ]}
       />

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -410,6 +410,9 @@ export default function Video({
               key: "更新日",
               value: getLocaleDateString(topic.updatedAt, "ja"),
             },
+            ...(topic.licenser
+              ? [{ key: "著作権者", value: topic.licenser }]
+              : []),
             ...authors(topic),
           ]}
         />

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -243,6 +243,9 @@ export default function Book(props: Props) {
                   key: "更新日",
                   value: getLocaleDateString(book.updatedAt, "ja"),
                 },
+                ...(book.licenser
+                  ? [{ key: "著作権者", value: book.licenser }]
+                  : []),
                 ...authors(book),
               ]}
             />

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -29,6 +29,7 @@ import sumPixels from "$utils/sumPixels";
 import type { ActivitySchema } from "$server/models/activity";
 import Chip from "@mui/material/Chip";
 import formatInterval from "$utils/formatInterval";
+import type { ReleaseItemSchema } from "$server/models/releaseResult";
 
 const useStyles = makeStyles((theme) => ({
   header: {
@@ -108,6 +109,7 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   linked?: boolean;
   book: BookSchema | null;
+  parent?: ReleaseItemSchema;
   bookActivity?: ActivitySchema[];
   index: ItemIndex;
   isPrivateBook?: boolean;
@@ -124,6 +126,7 @@ export default function Book(props: Props) {
   const {
     linked,
     book,
+    parent,
     bookActivity,
     index: [sectionIndex, topicIndex],
     isPrivateBook = false,
@@ -253,7 +256,12 @@ export default function Book(props: Props) {
             </Link>
           </div>
           <CollapsibleContent expanded={expanded}>
-            <BookInfo id="book-info" className={classes.info} book={book} />
+            <BookInfo
+              id="book-info"
+              className={classes.info}
+              book={book}
+              parent={parent}
+            />
           </CollapsibleContent>
         </>
       )}

--- a/pages/book/index.tsx
+++ b/pages/book/index.tsx
@@ -13,6 +13,7 @@ import type { ContentAuthors } from "$server/models/content";
 import { pagesPath } from "$utils/$path";
 import useBookActivity from "$utils/useBookActivity";
 import { useActivityTracking } from "$utils/activity";
+import useParentBookInfo from "$utils/useParentBookInfo";
 
 export type Query = { bookId: BookSchema["id"]; token?: string; zoom?: number };
 
@@ -39,6 +40,7 @@ function Show(query: Query) {
     session?.ltiResourceLink,
     query.token
   );
+  const parent = useParentBookInfo(query.bookId);
   const { data: bookActivity } = useBookActivity(book?.id);
   const { itemIndex, nextItemIndex, itemExists, updateItemIndex } =
     useBookAtom(book);
@@ -94,6 +96,7 @@ function Show(query: Query) {
   return (
     <Book
       book={book}
+      parent={parent}
       bookActivity={bookActivity}
       index={itemIndex}
       isPrivateBook={query.token === undefined}

--- a/server/utils/book/release.ts
+++ b/server/utils/book/release.ts
@@ -91,3 +91,24 @@ export function bookToReleaseItemSchema(
     release: release,
   };
 }
+
+export async function findParentBook(
+  book: BookSchema,
+): Promise<Array<BookWithRelease>> {
+  const ids = await findBookUniqueIds(book.id);
+  if (!ids?.pid) return [];
+
+  const where: Prisma.BookWhereInput = {
+    OR: [
+      { id: book.id },  // this book
+      { vid: ids.pid }  // parent book
+    ],
+    NOT: { release: null },
+  };
+  const found = await prisma.book.findMany({
+    ...bookIncludingArg,
+    where,
+  })
+  return found;
+}
+

--- a/utils/useParentBookInfo.ts
+++ b/utils/useParentBookInfo.ts
@@ -1,0 +1,15 @@
+import type { BookSchema } from "$server/models/book";
+import useReleaseBooks from "./useReleaseBooks";
+
+function useParentBookInfo(bookId: BookSchema["id"]) {
+  const { releases, error } = useReleaseBooks(bookId);
+
+  if (error) {
+    return undefined;
+  }
+  const self = releases?.find((e) => e.id === bookId);
+  const parent = releases?.find((e) => self?.pid && self?.pid === e.vid);
+  return parent;
+}
+
+export default useParentBookInfo;


### PR DESCRIPTION
視聴画面 ブック詳細で、親ブック情報を表示するように変更しました。

![image](https://github.com/user-attachments/assets/0ac58909-f31f-439b-8260-4520dccc88a4)

また、以下の場所で "著作権者" を表示するようにしました。
- ブック視聴画面
- ブック一覧画面
- トピックの詳細

このプルリクは、すぐに feat-vm2 にマージします。
