### PR TITLE
管理者がブック視聴画面で直前のリリース情報を見ることができる 他

### DIFF
--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -30,6 +30,7 @@ import type { ActivitySchema } from "$server/models/activity";
 import Chip from "@mui/material/Chip";
 import formatInterval from "$utils/formatInterval";
 import type { ReleaseItemSchema } from "$server/models/releaseResult";
+import License from "$atoms/License";
 
 const useStyles = makeStyles((theme) => ({
   header: {
@@ -190,6 +191,9 @@ export default function Book(props: Props) {
               (book?.timeRequired ?? 0) * 1000
             )}`}
           />
+          {book?.license && (
+            <License license={book?.license} clickable={false} />
+          )}
           {book?.release?.shared && <SharedIndicator />}
           {isInstructor &&
             book &&

--- a/server/services/book/release/show.ts
+++ b/server/services/book/release/show.ts
@@ -3,7 +3,7 @@ import { outdent } from "outdent";
 import type { BookParams } from "$server/validators/bookParams";
 import { bookParamsSchema } from "$server/validators/bookParams";
 import authUser from "$server/auth/authUser";
-import { isInstructor, isUsersOrAdmin } from "$server/utils/session";
+import { isAdministrator, isInstructor, isUsersOrAdmin } from "$server/utils/session";
 import findBook from "$server/utils/book/findBook";
 import { ReleaseResultSchema } from "$server/models/releaseResult";
 import type { BookWithRelease } from "$server/utils/book/release";
@@ -40,7 +40,7 @@ export async function show({
   let books: Array<BookWithRelease> = [];
 
   if (isUsersOrAdmin(session, book.authors) || (isInstructor(session) && book.release?.shared)) {
-    books = await findReleasedBooks(book, session.user.id);
+    books = await findReleasedBooks(book, session.user.id, isAdministrator(session));
   } else if (session.ltiResourceLink?.bookId === params.book_id) {
     books = await findParentBook(book);
   } else {

--- a/server/utils/book/release.ts
+++ b/server/utils/book/release.ts
@@ -58,11 +58,12 @@ export type BookWithRelease = Prisma.BookGetPayload<
 export async function findReleasedBooks(
   book: BookSchema,
   userId: number,
+  admin: boolean,
 ): Promise<Array<BookWithRelease>> {
   const filter: AuthorFilter = {
     type: "all",
     by: userId,
-    admin: false,
+    admin,
   };
   const ids = await findBookUniqueIds(book.id);
   if (!ids?.poid) return [];


### PR DESCRIPTION
リリース一覧API で管理者に対応しました。
以下の点が修正されています。

- 管理者がブック視聴画面で直前のリリース情報を見ることができる
- 管理者がブック編集画面で他人のブックのリリース一覧を見ることができる

また、視聴画面 ブックのライセンスロゴを学習時間の右に表示するようにしました。

このプルリクは、すぐに feat-vm2 にマージします。
