### PR TITLE
fix: ブックのCCロゴから公式ページに移動する

### DIFF
--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -191,9 +191,7 @@ export default function Book(props: Props) {
               (book?.timeRequired ?? 0) * 1000
             )}`}
           />
-          {book?.license && (
-            <License license={book?.license} clickable={false} />
-          )}
+          {book?.license && <License license={book?.license} />}
           {book?.release?.shared && <SharedIndicator />}
           {isInstructor &&
             book &&


### PR DESCRIPTION
学習時間の右側に表示したCCライセンスのロゴをクリックすると、
CC公式のライセンスページに移動するように変更しました。

このプルリクは、すぐに feat-vm2 にマージします。
