### PR TITLE
学習分析データにLMS情報を追加

### DIFF
--- a/openapi/models/InlineResponse20014BookActivities.ts
+++ b/openapi/models/InlineResponse20014BookActivities.ts
@@ -30,6 +30,10 @@ import {
     InlineResponse2008TopicFromJSON,
     InlineResponse2008TopicFromJSONTyped,
     InlineResponse2008TopicToJSON,
+    LTIContext,
+    LTIContextFromJSON,
+    LTIContextFromJSONTyped,
+    LTIContextToJSON,
 } from './';
 
 /**
@@ -50,6 +54,12 @@ export interface InlineResponse20014BookActivities {
      * @memberof InlineResponse20014BookActivities
      */
     learner: InlineResponse2008Learner;
+    /**
+     * 
+     * @type {LTIContext}
+     * @memberof InlineResponse20014BookActivities
+     */
+    ltiContext?: LTIContext;
     /**
      * 
      * @type {InlineResponse2008Topic}
@@ -112,6 +122,7 @@ export function InlineResponse20014BookActivitiesFromJSONTyped(json: any, ignore
         
         'id': !exists(json, 'id') ? undefined : json['id'],
         'learner': InlineResponse2008LearnerFromJSON(json['learner']),
+        'ltiContext': !exists(json, 'ltiContext') ? undefined : LTIContextFromJSON(json['ltiContext']),
         'topic': InlineResponse2008TopicFromJSON(json['topic']),
         'completed': !exists(json, 'completed') ? undefined : json['completed'],
         'totalTimeMs': !exists(json, 'totalTimeMs') ? undefined : json['totalTimeMs'],
@@ -134,6 +145,7 @@ export function InlineResponse20014BookActivitiesToJSON(value?: InlineResponse20
         
         'id': value.id,
         'learner': InlineResponse2008LearnerToJSON(value.learner),
+        'ltiContext': LTIContextToJSON(value.ltiContext),
         'topic': InlineResponse2008TopicToJSON(value.topic),
         'completed': value.completed,
         'totalTimeMs': value.totalTimeMs,

--- a/openapi/models/InlineResponse2008Activity.ts
+++ b/openapi/models/InlineResponse2008Activity.ts
@@ -26,6 +26,10 @@ import {
     InlineResponse2008TopicFromJSON,
     InlineResponse2008TopicFromJSONTyped,
     InlineResponse2008TopicToJSON,
+    LTIContext,
+    LTIContextFromJSON,
+    LTIContextFromJSONTyped,
+    LTIContextToJSON,
 } from './';
 
 /**
@@ -46,6 +50,12 @@ export interface InlineResponse2008Activity {
      * @memberof InlineResponse2008Activity
      */
     learner: InlineResponse2008Learner;
+    /**
+     * 
+     * @type {LTIContext}
+     * @memberof InlineResponse2008Activity
+     */
+    ltiContext?: LTIContext;
     /**
      * 
      * @type {InlineResponse2008Topic}
@@ -96,6 +106,7 @@ export function InlineResponse2008ActivityFromJSONTyped(json: any, ignoreDiscrim
         
         'id': json['id'],
         'learner': InlineResponse2008LearnerFromJSON(json['learner']),
+        'ltiContext': !exists(json, 'ltiContext') ? undefined : LTIContextFromJSON(json['ltiContext']),
         'topic': InlineResponse2008TopicFromJSON(json['topic']),
         'completed': json['completed'],
         'totalTimeMs': json['totalTimeMs'],
@@ -116,6 +127,7 @@ export function InlineResponse2008ActivityToJSON(value?: InlineResponse2008Activ
         
         'id': value.id,
         'learner': InlineResponse2008LearnerToJSON(value.learner),
+        'ltiContext': LTIContextToJSON(value.ltiContext),
         'topic': InlineResponse2008TopicToJSON(value.topic),
         'completed': value.completed,
         'totalTimeMs': value.totalTimeMs,

--- a/openapi/models/InlineResponse2008Learner.ts
+++ b/openapi/models/InlineResponse2008Learner.ts
@@ -37,6 +37,18 @@ export interface InlineResponse2008Learner {
      * @memberof InlineResponse2008Learner
      */
     email: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2008Learner
+     */
+    ltiConsumerId?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2008Learner
+     */
+    ltiUserId?: string;
 }
 
 export function InlineResponse2008LearnerFromJSON(json: any): InlineResponse2008Learner {
@@ -52,6 +64,8 @@ export function InlineResponse2008LearnerFromJSONTyped(json: any, ignoreDiscrimi
         'id': json['id'],
         'name': json['name'],
         'email': json['email'],
+        'ltiConsumerId': !exists(json, 'ltiConsumerId') ? undefined : json['ltiConsumerId'],
+        'ltiUserId': !exists(json, 'ltiUserId') ? undefined : json['ltiUserId'],
     };
 }
 
@@ -67,6 +81,8 @@ export function InlineResponse2008LearnerToJSON(value?: InlineResponse2008Learne
         'id': value.id,
         'name': value.name,
         'email': value.email,
+        'ltiConsumerId': value.ltiConsumerId,
+        'ltiUserId': value.ltiUserId,
     };
 }
 

--- a/server/models/activity.ts
+++ b/server/models/activity.ts
@@ -1,6 +1,7 @@
 import type { FromSchema } from "json-schema-to-ts";
 import { ActivityTimeRangeSchema } from "./activityTimeRange";
 import { LearnerSchema } from "./learner";
+import { LtiContextSchema } from "./ltiContext";
 
 /** 学習活動 */
 export const ActivitySchema = {
@@ -8,6 +9,7 @@ export const ActivitySchema = {
   properties: {
     id: { type: "integer" },
     learner: LearnerSchema,
+    ltiContext: LtiContextSchema,
     topic: {
       type: "object",
       properties: {

--- a/server/models/learner.ts
+++ b/server/models/learner.ts
@@ -9,6 +9,10 @@ export const LearnerSchema = {
     name: { type: "string" },
     /** メールアドレス ("" は無効値) */
     email: { type: "string" },
+    /** LMSクライアントID ("" は無効値) */
+    ltiConsumerId: { type: "string" },
+    /** LMSユーザID ("" は無効値) */
+    ltiUserId: { type: "string" },
   },
   required: ["id", "name", "email"],
   additionalProperties: false,

--- a/server/utils/activity/findAllActivity.ts
+++ b/server/utils/activity/findAllActivity.ts
@@ -47,7 +47,16 @@ async function findLtiMembers(
           },
         },
         include: {
-          learner: { select: { id: true, name: true, email: true } },
+          ltiContext: { select: { id: true, title: true, label: true } },
+          learner: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              ltiUserId: true,
+              ltiConsumerId: true,
+            },
+          },
           topic: {
             select: { id: true, name: true, timeRequired: true },
           },

--- a/utils/bookLearningActivity/getLocaleEntries.ts
+++ b/utils/bookLearningActivity/getLocaleEntries.ts
@@ -5,11 +5,13 @@ import type { BookActivitySchema } from "$server/models/bookActivity";
 import type { SessionSchema } from "$server/models/session";
 
 export const keyOrder = [
+  "learner.ltiConsumerId",
+  "ltiContext.id",
+  "ltiContext.title",
+  "learner.ltiUserId",
   "learner.id",
   "learner.name",
   "learner.email",
-  "ltiContext.label",
-  "ltiContext.title",
   "book.id",
   "book.name",
   "topic.id",
@@ -23,11 +25,13 @@ export const keyOrder = [
 ] as const;
 
 export const label: Readonly<{ [key in (typeof keyOrder)[number]]: string }> = {
+  "learner.ltiConsumerId": "LMSクライアントID",
+  "ltiContext.id": "LMSコースID",
+  "ltiContext.title": "LMSコース名",
+  "learner.ltiUserId": "LMSユーザID",
   "learner.id": "ユーザID",
   "learner.name": "ユーザ名",
   "learner.email": "メールアドレス",
-  "ltiContext.label": "コースID",
-  "ltiContext.title": "コース名",
   "book.id": "ブックID",
   "book.name": "ブック名",
   "topic.id": "トピックID",


### PR DESCRIPTION
resolved: #1064

学習分析データの項目を以下の通りとする。
（以下の1~4が新規追加分）

**1. LMSのクライアントID(LtiConsumer.id)（追加）
2. LMSのコースID (LtiContext.id)（追加）
3. LMSのコース名 (LtiContext.title)（追加）
4. LMSのユーザID(User.ltiUserId)（追加）**
5. ユーザID（既存）
6. ユーザ名（既存）
7. メールアドレス（既存）
8. ブックID（既存）
9. ブック名（既存）
10. トピックID（既存）
11. トピック名（既存）
12. 動画の長さ（既存）
13. ユニーク視聴時間（既存）
14. 学習状況（既存）
15. 学習完了率（既存）
16. 初回アクセス（既存）
17. 最終アクセス（既存）

影響範囲は以下の2箇所。
- 学習者タブのマウスオーバー時の吹き出し
  - ![image](https://github.com/user-attachments/assets/0681a8e4-497e-43bd-841c-e76ada11bc15)
- 「視聴分析データをダウンロード」から入手できるCSVファイル


※ #1066 においても同様の「視聴分析データをダウンロード」形式となるようにする予定（本Issueは上の2つのみがスコープとする）