### PR TITLE
学習分析・ダウンロードページのCSVに未視聴データを追加

### DIFF
--- a/server/utils/activity/bookWithActivity.ts
+++ b/server/utils/activity/bookWithActivity.ts
@@ -1,5 +1,6 @@
 import type { UserSchema } from "$server/models/user";
 import type { BookActivitySchema } from "$server/models/bookActivity";
+import type { LearnerSchema } from "$server/models/learner";
 import type { CourseBookSchema } from "$server/models/courseBook";
 import type { ActivitySchema } from "$server/models/activity";
 import type { BookWithTopics } from "$server/utils/book/bookToBookSchema";
@@ -7,6 +8,7 @@ import { bookToBookSchema } from "$server/utils/book/bookToBookSchema";
 import { getDisplayableBook } from "$server/utils/displayableBook";
 import contentBy from "$server/utils/contentBy";
 import isCompleted from "./isCompleted";
+import type { LtiContextSchema } from "$server/models/ltiContext";
 
 function bookToCourseBook(user: Pick<UserSchema, "id">, book: BookWithTopics) {
   const courseBook = getDisplayableBook(bookToBookSchema(book), (content) =>
@@ -21,6 +23,9 @@ export function toSchema({
   user,
   books,
   activities,
+  learners,
+  ltiConsumerId,
+  ltiContext,
   isDownloadPage = false,
 }: {
   user: Pick<UserSchema, "id">;
@@ -31,6 +36,9 @@ export function toSchema({
       "learner" | "topic" | "totalTimeMs" | "createdAt" | "updatedAt"
     >
   >;
+  learners: Array<LearnerSchema>;
+  ltiConsumerId: string | undefined;
+  ltiContext: LtiContextSchema | undefined;
   isDownloadPage: boolean;
 }): {
   courseBooks: Array<CourseBookSchema>;
@@ -45,8 +53,8 @@ export function toSchema({
 
   const bookActivities = courseBooks.flatMap((book) =>
     book.sections.flatMap(({ topics }) =>
-      topics.flatMap((topic) =>
-        activities.flatMap((activity) => {
+      topics.flatMap((topic) => {
+        const watchedActivities = activities.flatMap((activity) => {
           if (activity.topic.id !== topic.id) return [];
 
           return [
@@ -58,8 +66,43 @@ export function toSchema({
                 : ("incompleted" as const),
             },
           ];
-        })
-      )
+        }) as Array<BookActivitySchema>;
+
+        const watchedLearnerIds = watchedActivities.flatMap(
+          (activity) => activity.learner.id
+        );
+        const unwatchedLearners = learners.filter(
+          (learner) => !watchedLearnerIds.find((id) => id === learner.id)
+        );
+        const unwatchedActivities = unwatchedLearners.flatMap((learner) => {
+          return {
+            id: 0,
+            topicId: topic.id,
+            learnerId: learner.id,
+            ltiConsumerId: ltiConsumerId,
+            ltiContextId: ltiContext?.id ?? "",
+            totalTimeMs: 0,
+            createdAt: undefined,
+            updatedAt: undefined,
+            ltiContext: ltiContext,
+            learner: {
+              id: learner.id,
+              name: learner.name,
+              email: learner.email,
+              ltiUserId: learner.ltiUserId,
+              ltiConsumerId: ltiConsumerId,
+            },
+            topic: {
+              id: topic.id,
+              name: topic.name,
+              timeRequired: topic.timeRequired,
+            },
+            book: { id: book.id, name: book.name },
+            status: "unopened",
+          };
+        }) as Array<BookActivitySchema>;
+        return watchedActivities.concat(unwatchedActivities);
+      })
     )
   );
 

--- a/utils/getActivitiesByBooks.ts
+++ b/utils/getActivitiesByBooks.ts
@@ -39,7 +39,9 @@ function getActivitiesByBooks({
         activitiesByLearner.every(({ status }) => status === "completed")
       ) {
         completedLearners.set(learnerId, activitiesByLearner);
-      } else {
+      } else if (
+        activitiesByLearner.every(({ status }) => status === "incompleted")
+      ) {
         incompletedLearners.set(learnerId, activitiesByLearner);
       }
     }


### PR DESCRIPTION
resolved: #1065 

学習分析・ダウンロードページの視聴分析データに未視聴者（未開封）の学習者のデータが含まれるようになりました。
