### PR TITLE
UI: 著作権者

### DIFF
--- a/components/atoms/DescriptionList.tsx
+++ b/components/atoms/DescriptionList.tsx
@@ -69,7 +69,7 @@ export default function DescriptionList({
     >
       {value.map(({ key, value }, index) => (
         <div key={index} className="item">
-          <dt>{key}</dt>
+          {key && <dt>{key}</dt>}
           <dd>{value}</dd>
         </div>
       ))}

--- a/components/organisms/ContentPreview.tsx
+++ b/components/organisms/ContentPreview.tsx
@@ -261,9 +261,7 @@ export default function ContentPreview({
                   value: getLocaleDateString(content.updatedAt, "ja"),
                 },
               ]),
-          ...(content.licenser
-            ? [{ key: "著作権者", value: content.licenser }]
-            : []),
+          ...(content.licenser ? [{ key: "", value: content.licenser }] : []),
           ...authors(content),
         ]}
       />

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -27,7 +27,7 @@ import License from "$atoms/License";
 import DescriptionList from "$atoms/DescriptionList";
 import formatInterval from "$utils/formatInterval";
 import getLocaleDateString from "$utils/getLocaleDateString";
-import { authors } from "$utils/descriptionList";
+import { authors } from "$utils/authorList";
 import TagList from "$molecules/TagList";
 import { useBookmarksByTopicId } from "$utils/bookmark/useBookmarks";
 
@@ -447,8 +447,11 @@ export default function Video({
               key: "更新日",
               value: getLocaleDateString(topic.updatedAt, "ja"),
             },
-            ...(topic.licenser ? [{ key: "", value: topic.licenser }] : []),
-            ...authors(topic),
+            // 著作権者または作成者
+            {
+              key: "",
+              value: topic.licenser ? topic.licenser : authors(topic),
+            },
           ]}
         />
         {topic.keywords && (

--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -447,9 +447,7 @@ export default function Video({
               key: "更新日",
               value: getLocaleDateString(topic.updatedAt, "ja"),
             },
-            ...(topic.licenser
-              ? [{ key: "著作権者", value: topic.licenser }]
-              : []),
+            ...(topic.licenser ? [{ key: "", value: topic.licenser }] : []),
             ...authors(topic),
           ]}
         />

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -245,9 +245,7 @@ export default function Book(props: Props) {
                   key: "更新日",
                   value: getLocaleDateString(book.updatedAt, "ja"),
                 },
-                ...(book.licenser
-                  ? [{ key: "著作権者", value: book.licenser }]
-                  : []),
+                ...(book.licenser ? [{ key: "", value: book.licenser }] : []),
                 ...authors(book),
               ]}
             />

--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -23,7 +23,7 @@ import { useSessionAtom } from "$store/session";
 import useSticky from "$utils/useSticky";
 import useAppBarOffset from "$utils/useAppBarOffset";
 import getLocaleDateString from "$utils/getLocaleDateString";
-import { authors } from "$utils/descriptionList";
+import { authors } from "$utils/authorList";
 import extractNumberFromPx from "$utils/extractNumberFromPx";
 import sumPixels from "$utils/sumPixels";
 import type { ActivitySchema } from "$server/models/activity";
@@ -245,8 +245,11 @@ export default function Book(props: Props) {
                   key: "更新日",
                   value: getLocaleDateString(book.updatedAt, "ja"),
                 },
-                ...(book.licenser ? [{ key: "", value: book.licenser }] : []),
-                ...authors(book),
+                // 著作権者または作成者
+                {
+                  key: "",
+                  value: book.licenser ? book.licenser : authors(book),
+                },
               ]}
             />
             <Link

--- a/utils/authorList.ts
+++ b/utils/authorList.ts
@@ -1,0 +1,9 @@
+import getLocaleListString from "$utils/getLocaleListString";
+import type { ContentAuthors } from "$server/models/content";
+
+export function authors(content: ContentAuthors): string {
+  return getLocaleListString(
+    content.authors.map((author) => author.name),
+    "ja"
+  );
+}


### PR DESCRIPTION
以下の変更を行います
- ブック一覧や視聴画面で，著作権者の前の「著作権者：」は表示しない
- DB 著作権者が空欄のとき、UI で代わりに作成者を表示する
- 作成者が複数の場合は、"、" をはさんですべて表示する

ブック一覧
![image](https://github.com/user-attachments/assets/a729355b-5f6c-4790-80fc-59dd7383d2b3)

視聴画面で著作権者が設定されている場合
![image](https://github.com/user-attachments/assets/e65b07f6-07ad-450e-819c-397336f75a4e)

視聴画面で著作権者が設定されていない場合
![image](https://github.com/user-attachments/assets/d46f2823-364a-4b6e-a4d5-cbe7c658e5ee)

