### PR TITLE
リリースでトピックの作成者がブックの作成者であることをチェックする

### DIFF
--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -119,6 +119,20 @@ export default function BookEdit({
     onDelete(book, true);
   };
   const handleReleaseButtonClick = async () => {
+    const bookAuthors = book.authors.map((author) => author.id);
+    const canRelease = book.sections.every((sections) =>
+      sections.topics.every((topic) =>
+        topic.authors.some((author) => bookAuthors.includes(author.id))
+      )
+    );
+    if (!canRelease) {
+      await confirm({
+        title: `ブック「${book.name}」に他者のトピックが含まれているため、リリースすることができません。`,
+        hideCancelButton: true,
+        confirmationText: "OK",
+      });
+      return;
+    }
     await confirm({
       title: `ブック「${book.name}」をリリースします。よろしいですか？`,
       cancellationText: "キャンセル",


### PR DESCRIPTION
(課題1) トピックが複数のブックに含まれるとき の対応として、以下のように変更します。
- リリース時に、トピックの作成者がブックの作成者であることをチェックする
- ブックの作成者でない作成者のトピックが一つ以上ある場合は、リリース不可とする
- リリース不可の場合、UI でリリースボタンを押したときに以下のメッセージを表示する

![image](https://github.com/user-attachments/assets/f616b976-981c-414c-a325-661dfc908734)
