### PR TITLE
fix: すべてのトピックが見える

### DIFF
--- a/server/utils/displayableBook.ts
+++ b/server/utils/displayableBook.ts
@@ -2,7 +2,6 @@ import type { BookSchema } from "$server/models/book";
 import type { PublicBookSchema } from "$server/models/book/public";
 import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 import type { IsContentEditable } from "$server/models/content";
-import contentBy from "./contentBy";
 
 export function isDisplayableBook(
   book: Pick<BookSchema, "id" | "shared" | "authors" | "release">,
@@ -37,17 +36,5 @@ export function getDisplayableBook<
   )
     return;
 
-  const sections = book.sections.flatMap((section) => {
-    const topics = section.topics.filter(
-      (topic) =>
-        topic.shared ||
-        contentBy(topic, { id: ltiResourceLink?.creatorId }) ||
-        (publicBook && contentBy(topic, { id: publicBook.userId })) ||
-        isContentEditable?.(topic) ||
-        isInstructor
-    );
-    return topics.length > 0 ? [{ ...section, topics }] : [];
-  });
-
-  return { ...book, sections };
+  return book;
 }


### PR DESCRIPTION
https://github.com/npocccties/ChibiCHiLO-private/issues/312#issuecomment-2809699645 の手順で、Aだけが作成者のブックに Bだけが作成者のトピックが含まれる状態を作ったとき、Aがブックをリリースできてしまう問題に対処します。

server/utils/displayableBook.ts の関数 getDisplayableBook がtopic.shared を参照していて、次のように動作していました。
- topic.shared == true  -> 作成者によらず topic を book に含める
- topic.shared == false -> 作成者が同じときだけ topic を book に含める

Dec 27, 2024 に以下の変更を行なっています。

fix: シェア廃止 見えるブックに含まれるトピックはすべて見える
https://github.com/npocccties/chibichilo/commit/52b5d6c102c5365ab690f19961db5504cefe0954

Arp 5, 2025 に chibichilo feat-vm2 に master を merge したとき、以下のcommit と CONFLICT したのですが、私が CONFLICT を解消するときに間違ったようです。

fix: ダウンロードページでの表示可能ブックが教員向けになっていなかった
https://github.com/npocccties/chibichilo/commit/acda2fec1ba89d7b8e4f1772af3c394ca739e32a

master を merge した作業全体を見直して、このプルリク以外の変更は必要ないと判断しました。