### PR TITLE
リリースの編集中の親が分かる

### DIFF
--- a/components/organisms/ReleaseItemList.stories.tsx
+++ b/components/organisms/ReleaseItemList.stories.tsx
@@ -16,6 +16,7 @@ const author1 = {
 };
 
 const item1: ReleaseItemSchema = {
+  id: 138,
   name: "数学I",
   createdAt: new Date("2024-09-03T23:22:00.593Z"),
   updatedAt: new Date("2024-09-14T04:41:03.563Z"),
@@ -25,9 +26,14 @@ const item1: ReleaseItemSchema = {
     version: "1.0",
     comment: "2022年度",
   },
+  poid: "xd76tqcjb5uts9pxf7wazalx",
+  oid: "xd76tqcjb5uts9pxf7wazalx",
+  pid: "",
+  vid: "ybbscmnc7vjj4ipngtytxj6y",
 };
 
 const item2: ReleaseItemSchema = {
+  id: 139,
   name: "数学I",
   createdAt: new Date("2024-09-03T23:22:00.593Z"),
   updatedAt: new Date("2024-09-14T04:41:03.563Z"),
@@ -37,9 +43,14 @@ const item2: ReleaseItemSchema = {
     version: "2.0",
     comment: "2023年度",
   },
+  poid: "xd76tqcjb5uts9pxf7wazalx",
+  oid: "xd76tqcjb5uts9pxf7wazalx",
+  pid: "ybbscmnc7vjj4ipngtytxj6y",
+  vid: "hijy2bi14nh6h55yypw76q4j",
 };
 
 const item3: ReleaseItemSchema = {
+  id: 140,
   name: "数学I",
   createdAt: new Date("2024-09-03T23:22:00.593Z"),
   updatedAt: new Date("2024-09-14T04:41:03.563Z"),
@@ -49,11 +60,16 @@ const item3: ReleaseItemSchema = {
     version: "3.0",
     comment: "2024年度",
   },
+  poid: "xd76tqcjb5uts9pxf7wazalx",
+  oid: "xd76tqcjb5uts9pxf7wazalx",
+  pid: "hijy2bi14nh6h55yypw76q4j",
+  vid: "w1rcge8n94zpgt39q901dp1r",
 };
 
 const releases: Array<ReleaseItemSchema> = [item1, item2, item3];
 
 const defaultProps = {
+  id: 140,
   releases,
 };
 

--- a/components/organisms/ReleaseItemList.tsx
+++ b/components/organisms/ReleaseItemList.tsx
@@ -113,7 +113,9 @@ function categorizeReleases(props: Props): CategorizedItems {
   let from;
   if (branch.length > 0) {
     const oldestPid = branch.slice(-1)[0].pid;
-    from = releases.filter((release) => release.vid === oldestPid)[0];
+    if (oldestPid) {
+      from = releases.filter((release) => release.vid === oldestPid)[0];
+    }
   }
   const to = releases
     .filter(

--- a/components/organisms/ReleaseItemList.tsx
+++ b/components/organisms/ReleaseItemList.tsx
@@ -103,24 +103,29 @@ function compareReleasedAt(a: ReleaseItemSchema, b: ReleaseItemSchema) {
   return bd.getTime() - ad.getTime();
 }
 
+function sameId(a: string | undefined, b: string | undefined) {
+  return a && a === b;
+}
+
 function categorizeReleases(props: Props): CategorizedItems {
   const { id, releases } = props;
   const self = releases.filter((release) => release.id === id)[0];
   const editing = releases.filter((release) => !release.release)[0];
   const branch = releases
-    .filter((release) => release.oid === self?.oid && release.release)
+    .filter((release) => sameId(self?.oid, release.oid) && release.release)
     .sort(compareReleasedAt);
   let from;
   if (branch.length > 0) {
     const oldestPid = branch.slice(-1)[0].pid;
     if (oldestPid) {
-      from = releases.filter((release) => release.vid === oldestPid)[0];
+      from = releases.filter((release) => sameId(release.vid, oldestPid))[0];
     }
   }
   const to = releases
     .filter(
       (release) =>
-        release.oid !== self?.oid && release.pid && release.pid === self?.vid
+        release.oid !== self?.oid &&
+        branch.some((b) => sameId(b.vid, release.pid))
     )
     .sort(compareReleasedAt);
   return { self, editing, branch, from, to };

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -196,6 +196,7 @@ export default function BookEdit({
             リリース一覧
           </Typography>
           <ReleaseItemList
+            id={book.id}
             releases={releases}
             onItemEditClick={handleItemEditClick}
           />

--- a/components/templates/BookEditReleased.tsx
+++ b/components/templates/BookEditReleased.tsx
@@ -125,6 +125,7 @@ export default function BookEditReleased({
             リリース一覧
           </Typography>
           <ReleaseItemList
+            id={book.id}
             releases={releases}
             onItemEditClick={handleItemEditClick}
           />

--- a/components/templates/TopicEdit.tsx
+++ b/components/templates/TopicEdit.tsx
@@ -147,6 +147,7 @@ export default function TopicEdit(props: Props) {
             リリース一覧
           </Typography>
           <ReleaseItemList
+            id={topic.id}
             releases={releases}
             onItemEditClick={handleItemEditClick}
           />

--- a/server/services/topic/release/show.ts
+++ b/server/services/topic/release/show.ts
@@ -8,6 +8,7 @@ import { isUsersOrAdmin } from "$utils/session";
 import authInstructor from "$server/auth/authInstructor";
 import { ReleaseResultSchema } from "$server/models/releaseResult";
 import { findReleasedTopics, topicToReleaseItemSchema } from "$server/utils/topic/release";
+import { findTopicUniqueIds } from "$server/utils/uniqueId";
 
 export const showSchema: FastifySchema = {
   summary: "トピックのリリース一覧取得",
@@ -36,8 +37,9 @@ export async function show({
   if (!topic) return { status: 404 };
   if (!isUsersOrAdmin(session, topic.authors)) return { status: 403 };
 
-  const topics = await findReleasedTopics(topic, session.user.id);
-  const releases = topics.map(topicToReleaseItemSchema).filter((e) => e);
+  const ids = await findTopicUniqueIds(topic.id);
+  const topics = await findReleasedTopics(ids, session.user.id);
+  const releases = topics.map((topic) => topicToReleaseItemSchema(ids, topic)).filter((e) => e);
   
   return {
     status: 200,


### PR DESCRIPTION
- 以下のページで表示するリリース一覧で関連するブック/トピックを表示する
  - ブックの編集
  - トピックの編集

- 表示内容(表示順)
  - 編集中 (oid が同じ系統で編集中、0,1個)
  - リリース (oid が同じ系統、リリース日の降順、0,1,複数)
  - 複製元 (同系統の最も古いリリースのpidをvidとして持つ直接の親、0,1個)
  - 複製先 (vidをpidとしてもつ、oid が異なる、0,1,複数)

- 表示されるブック/トピック
  - ブック/トピック一覧に表示されるものだけ
  - 他人が複製した編集中のブック/トピックは、リリース一覧に表示されない
    - リリースして共有されると「複製先」として表示される
  - 「複製先」の「複製先」は表示されない
    - 「複製先」のブック/トピックの編集画面に表示される

動作確認を実施して feat-vm2 にマージする。