### PR TITLE
fix: markdown内の長いURLの改行問題を解決

### DIFF
--- a/components/organisms/Video/index.tsx
+++ b/components/organisms/Video/index.tsx
@@ -64,6 +64,11 @@ const skipButton = css({
   lineHeight: 1,
 });
 
+const markdownContainerStyle = css({
+  wordBreak: "break-word",
+  overflowWrap: "break-word",
+});
+
 function SkipButton(props: ButtonProps) {
   return (
     <Button {...props} className={skipButton} size="small" color="secondary">
@@ -386,7 +391,7 @@ export default function Video({
         )}
       </Box>
       <TabPanel value={tabIndex} index={0}>
-        <article>
+        <article className={markdownContainerStyle}>
           <Markdown>{topic.description}</Markdown>
         </article>
       </TabPanel>


### PR DESCRIPTION
topic.descriptionに長いURLが含まれる際のレイアウト崩れを修正