### PR TITLE
UI: リリース(共有)、シェア廃止関連

### DIFF
--- a/components/atoms/AuthorFilter.tsx
+++ b/components/atoms/AuthorFilter.tsx
@@ -12,7 +12,7 @@ const options: ReadonlyArray<{
 }> = [
   { value: "edit", label: "編集中" },
   { value: "release", label: "リリース" },
-  { value: "other-release", label: "共有されたリリース" },
+  { value: "release-shared", label: "リリース(共有)" },
 ];
 
 type Props = {

--- a/components/molecules/SectionsTree.tsx
+++ b/components/molecules/SectionsTree.tsx
@@ -1,20 +1,12 @@
 import type { ReactNode, MouseEvent } from "react";
 import TreeItem from "@mui/lab/TreeItem";
 import Checkbox from "@mui/material/Checkbox";
-import makeStyles from "@mui/styles/makeStyles";
 import PreviewButton from "$atoms/PreviewButton";
 import EditButton from "$atoms/EditButton";
-import SharedIndicator from "$atoms/SharedIndicator";
 import useTreeItemStyle from "$styles/treeItem";
 import type { SectionSchema } from "$server/models/book/section";
 import type { IsContentEditable } from "$server/models/content";
 import { isNamedSection, getOutlineNumber } from "$utils/outline";
-
-const useStyles = makeStyles((theme) => ({
-  shared: {
-    margin: theme.spacing(0, 0.5),
-  },
-}));
 
 type SectionProps = {
   bookId: number;
@@ -92,7 +84,6 @@ export default function SectionsTree(props: Props) {
     selectedIndexes,
     isContentEditable,
   } = props;
-  const classes = useStyles();
   const treeItemClasses = useTreeItemStyle();
   return (
     <>
@@ -135,9 +126,6 @@ export default function SectionsTree(props: Props) {
                     )}
                     {getOutlineNumber(section, sectionIndex, topicIndex) + " "}
                     {topic.name}
-                    {topic.shared && (
-                      <SharedIndicator className={classes.shared} />
-                    )}
                     {onItemPreviewClick && (
                       <PreviewButton
                         variant="topic"

--- a/openapi/apis/DefaultApi.ts
+++ b/openapi/apis/DefaultApi.ts
@@ -3185,7 +3185,7 @@ export enum ApiV2SearchGetFilterEnum {
     other = 'other',
     edit = 'edit',
     release = 'release',
-    other_release = 'other-release'
+    release_shared = 'release-shared'
 }
 /**
     * @export

--- a/server/models/authorFilter.ts
+++ b/server/models/authorFilter.ts
@@ -41,8 +41,8 @@ export type AuthorFilter =
       admin: boolean;
     }
   | {
-      /** 他者のリリース */
-      type: "other-release";
+      /** リリース(共有) */
+      type: "release-shared";
       /** 利用者 */
       by: UserSchema["id"];
       /** 利用者が管理者であるか否か (管理者: true、それ以外: false) */

--- a/server/models/booksImportParams.ts
+++ b/server/models/booksImportParams.ts
@@ -177,7 +177,7 @@ export class ImportTopic {
   timeRequired = 0;
 
   @IsBoolean({ message: "真偽値ではないか未設定です。" })
-  shared = true;
+  shared = false;
 
   @IsISO8601({}, { message: "ISO8601形式の日時ではないか未設定です。" })
   createdAt = new Date().toISOString();
@@ -251,7 +251,7 @@ export class ImportBook {
   language = "ja";
 
   @IsBoolean({ message: "真偽値ではないか未設定です。" })
-  shared = true;
+  shared = false;
 
   @IsISO8601({}, { message: "ISO8601形式の日時ではないか未設定です。" })
   publishedAt = new Date().toISOString();

--- a/server/utils/book/cloneBook.ts
+++ b/server/utils/book/cloneBook.ts
@@ -71,6 +71,7 @@ export async function cloneRelease(
     ltiResourceLinks: _link,
     authors: _authors,
     release: _release,
+    shared: _shared,
     ...book
   } = structuredClone(parentBook);
 
@@ -103,6 +104,7 @@ export async function cloneBook(
     ltiResourceLinks: _link,
     authors: _authors,
     release: _release,
+    shared: _shared,
     ...book
   } = structuredClone(parentBook);
 

--- a/server/utils/search/createScopes.ts
+++ b/server/utils/search/createScopes.ts
@@ -15,7 +15,7 @@ function defaultScopes<T>(
     case "other": return [sharedScope, { NOT: selfScope }];
     case "edit": return [selfScope, editScope];
     case "release": return [selfScope, { NOT: editScope }];
-    case "other-release": return [sharedScope, { NOT: selfScope }, { NOT: editScope }];
+    case "release-shared": return [sharedScope, { NOT: selfScope }, { NOT: editScope }];
     default: return [];
   }
 }
@@ -30,7 +30,7 @@ function adminScopes<T>(
     case "other": return [{ NOT: selfScope }];
     case "edit": return [editScope];
     case "release": return [{ NOT: editScope }];
-    case "other-release": return [{ NOT: selfScope }, { NOT: editScope }];
+    case "release-shared": return [{ NOT: selfScope }, { NOT: editScope }];
     default: return [];
   }
 }

--- a/server/utils/search/createScopes.ts
+++ b/server/utils/search/createScopes.ts
@@ -15,14 +15,14 @@ function defaultScopes<T>(
     case "other": return [sharedScope, { NOT: selfScope }];
     case "edit": return [selfScope, editScope];
     case "release": return [selfScope, { NOT: editScope }];
-    case "release-shared": return [sharedScope, { NOT: selfScope }, { NOT: editScope }];
+    case "release-shared": return [sharedScope, { NOT: editScope }];
     default: return [];
   }
 }
 
 function adminScopes<T>(
   filter: AuthorFilter,
-  { selfScope, editScope }: Scopes<T>
+  { sharedScope, selfScope, editScope }: Scopes<T>
 ){
   switch(filter?.type) {
     case "all": return [];
@@ -30,7 +30,7 @@ function adminScopes<T>(
     case "other": return [{ NOT: selfScope }];
     case "edit": return [editScope];
     case "release": return [{ NOT: editScope }];
-    case "release-shared": return [{ NOT: selfScope }, { NOT: editScope }];
+    case "release-shared": return [sharedScope, { NOT: editScope }];
     default: return [];
   }
 }

--- a/server/utils/topic/cloneTopic.ts
+++ b/server/utils/topic/cloneTopic.ts
@@ -20,6 +20,7 @@ export async function cloneTopic(
   const created = await prisma.topic.create({
     data: {
       ...topicInput(topic),
+      shared: false,
       authors: { create: authors },
       resource: resourceConnectOrCreateInput(topic.resource),
       keywords: keywordsConnectOrCreateInput(topic.keywords ?? []),

--- a/server/validators/searchProps.ts
+++ b/server/validators/searchProps.ts
@@ -12,7 +12,7 @@ export const SearchProps = {
     q: { type: "string" },
     filter: {
       type: "string",
-      enum: ["all", "self", "other", "edit", "release", "other-release"],
+      enum: ["all", "self", "other", "edit", "release", "release-shared"],
     },
     sort: {
       type: "string",


### PR DESCRIPTION
以下の変更を行います。

- ブック/トピック一覧の絞り込みで、"共有されたリリース" を "リリース(共有)" に変更
- "リリース(共有)" に自分のブック/トピックも表示する
- ブック編集画面、トピックツリー表示でシェアマークを表示しない
- 一括登録でブック/トピックの shared を false にする
- トピックの再利用、リリース、ブックの複製でブック/トピックを複製するとき shared を false にする
