### PR TITLE
履歴途中のコンテンツが削除されても履歴が追える

### DIFF
--- a/components/organisms/ReleaseItemList.tsx
+++ b/components/organisms/ReleaseItemList.tsx
@@ -114,13 +114,16 @@ function categorizeReleases(props: Props): CategorizedItems {
   const branch = releases
     .filter((release) => sameId(self?.oid, release.oid) && release.release)
     .sort(compareReleasedAt);
-  let from;
+  let targetVid: string | undefined;
   if (branch.length > 0) {
     const oldest = branch.slice(-1)[0];
-    const oldestPid = oldest.spid ?? oldest.pid;
-    if (oldestPid) {
-      from = releases.filter((release) => sameId(release.vid, oldestPid))[0];
-    }
+    targetVid = oldest.spid ?? oldest.pid;
+  } else {
+    targetVid = self?.spid ?? self?.pid;
+  }
+  let from;
+  if (targetVid) {
+    from = releases.filter((release) => sameId(release.vid, targetVid))[0];
   }
   const to = releases
     .filter((release) => {

--- a/components/organisms/ReleaseItemList.tsx
+++ b/components/organisms/ReleaseItemList.tsx
@@ -116,17 +116,18 @@ function categorizeReleases(props: Props): CategorizedItems {
     .sort(compareReleasedAt);
   let from;
   if (branch.length > 0) {
-    const oldestPid = branch.slice(-1)[0].pid;
+    const oldest = branch.slice(-1)[0];
+    const oldestPid = oldest.spid ?? oldest.pid;
     if (oldestPid) {
       from = releases.filter((release) => sameId(release.vid, oldestPid))[0];
     }
   }
   const to = releases
-    .filter(
-      (release) =>
-        release.oid !== self?.oid &&
-        branch.some((b) => sameId(b.vid, release.pid))
-    )
+    .filter((release) => {
+      if (release.oid === self?.oid) return false;
+      const pid = release.spid ?? release.pid;
+      return branch.some((b) => sameId(b.vid, pid));
+    })
     .sort(compareReleasedAt);
   return { self, editing, branch, from, to };
 }

--- a/openapi/models/InlineResponse20010Releases.ts
+++ b/openapi/models/InlineResponse20010Releases.ts
@@ -92,6 +92,12 @@ export interface InlineResponse20010Releases {
     vid?: string;
     /**
      * 
+     * @type {string}
+     * @memberof InlineResponse20010Releases
+     */
+    spid?: string;
+    /**
+     * 
      * @type {InlineResponse2006Release}
      * @memberof InlineResponse20010Releases
      */
@@ -118,6 +124,7 @@ export function InlineResponse20010ReleasesFromJSONTyped(json: any, ignoreDiscri
         'oid': !exists(json, 'oid') ? undefined : json['oid'],
         'pid': !exists(json, 'pid') ? undefined : json['pid'],
         'vid': !exists(json, 'vid') ? undefined : json['vid'],
+        'spid': !exists(json, 'spid') ? undefined : json['spid'],
         'release': !exists(json, 'release') ? undefined : InlineResponse2006ReleaseFromJSON(json['release']),
     };
 }
@@ -141,6 +148,7 @@ export function InlineResponse20010ReleasesToJSON(value?: InlineResponse20010Rel
         'oid': value.oid,
         'pid': value.pid,
         'vid': value.vid,
+        'spid': value.spid,
         'release': InlineResponse2006ReleaseToJSON(value.release),
     };
 }

--- a/server/models/book.ts
+++ b/server/models/book.ts
@@ -19,7 +19,7 @@ export type BookProps = {
   publicBooks?: PublicBookSchema[];
 };
 
-export type BookSchema = Omit<Book, "poid" | "oid" | "pid" | "vid"> & {
+export type BookSchema = Omit<Book, "poid" | "oid" | "pid" | "vid" | "spid" > & {
   authors: AuthorSchema[];
   sections: SectionSchema[];
   ltiResourceLinks: LtiResourceLinkSchema[];

--- a/server/models/releaseResult.ts
+++ b/server/models/releaseResult.ts
@@ -15,6 +15,7 @@ export const ReleaseItemSchema = {
     oid: { type: "string" },
     pid: { type: "string" },
     vid: { type: "string" },
+    spid: { type: "string" },
     release: {
       ...releaseSchema,
     },

--- a/server/models/topic.ts
+++ b/server/models/topic.ts
@@ -49,7 +49,7 @@ export type TopicProps = Pick<
   keywords?: KeywordPropSchema[];
 };
 
-export type TopicSchema = Omit<Topic, "poid" | "oid" | "pid" | "vid"> & {
+export type TopicSchema = Omit<Topic, "poid" | "oid" | "pid" | "vid" | "spid"> & {
   authors: AuthorSchema[];
   keywords: KeywordSchema[];
   relatedBooks?: RelatedBook[];

--- a/server/prisma/migrations/20250429124949_add_spid/migration.sql
+++ b/server/prisma/migrations/20250429124949_add_spid/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "books" ADD COLUMN     "spid" TEXT NOT NULL DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "topics" ADD COLUMN     "spid" TEXT NOT NULL DEFAULT '';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -121,6 +121,8 @@ model Topic {
   pid      String   @default("")
   // 版番号ID (cuid2, 編集中は "", リリース時に採番)
   vid      String   @default("")
+  // 保存親ID (cuid2, 親削除時に、そのspidを保存する)
+  spid     String   @default("")
 
   @@map("topics")
 }
@@ -262,6 +264,8 @@ model Book {
   pid      String   @default("")
   // 版番号ID (cuid2, 編集中は "", リリース時に採番)
   vid      String   @default("")
+  // 保存親ID (cuid2, 親削除時に、そのspidを保存する)
+  spid     String   @default("")
 
   @@index([zoomMeetingId])
   @@map("books")

--- a/server/utils/book/destroyBook.ts
+++ b/server/utils/book/destroyBook.ts
@@ -1,8 +1,10 @@
 import type { Book } from "@prisma/client";
 import prisma from "$server/utils/prisma";
 import cleanupSections from "./cleanupSections";
+import { updateBookSpid } from "../uniqueId";
 
 async function destroyBook(id: Book["id"]) {
+  await updateBookSpid(id);
   try {
     await prisma.$transaction([
       ...cleanupSections(id),

--- a/server/utils/book/destroyBook.ts
+++ b/server/utils/book/destroyBook.ts
@@ -1,18 +1,23 @@
 import type { Book } from "@prisma/client";
 import prisma from "$server/utils/prisma";
 import cleanupSections from "./cleanupSections";
-import { updateBookSpid } from "../uniqueId";
+import { findBookUniqueIds, updateBookSpid } from "../uniqueId";
 
 async function destroyBook(id: Book["id"]) {
-  await updateBookSpid(id);
   try {
-    await prisma.$transaction([
+    const ops = [
       ...cleanupSections(id),
       prisma.ltiResourceLink.deleteMany({ where: { bookId: id } }),
       prisma.authorship.deleteMany({ where: { bookId: id } }),
       prisma.publicBook.deleteMany({ where: { bookId: id } }),
       prisma.book.deleteMany({ where: { id } }),
-    ]);
+    ];
+    const ids = await findBookUniqueIds(id);
+    // unique id が見つかって、vid があるとき、spid を更新する
+    if (ids && ids.vid) {
+      ops.push(updateBookSpid(ids));
+    }
+    await prisma.$transaction(ops);
   } catch {
     return;
   }

--- a/server/utils/topic/destroyTopic.ts
+++ b/server/utils/topic/destroyTopic.ts
@@ -1,7 +1,9 @@
 import type { Topic } from "@prisma/client";
 import prisma from "$server/utils/prisma";
+import { updateTopicSpid } from "../uniqueId";
 
 async function destroyTopic(id: Topic["id"]) {
+  await updateTopicSpid(id);
   try {
     await prisma.$transaction([
       prisma.topicSection.deleteMany({

--- a/server/utils/uniqueId.ts
+++ b/server/utils/uniqueId.ts
@@ -28,7 +28,7 @@ function releaseUniqueIds(edit: UniqueIds, release: UniqueIds) {
   release.oid = edit.oid;
   release.pid = edit.pid;
   release.vid = createId();
-  release.spid = edit.pid;
+  release.spid = edit.spid;
   edit.pid = release.vid;
   edit.spid = release.vid;
 }
@@ -44,6 +44,9 @@ function cloneUniqueIds(orig: UniqueIds, clone: UniqueIds) {
   clone.spid = orig.vid;
 }
 
+//
+// book
+//
 export async function findBookUniqueIds(
   bookId: Book["id"]
 ): Promise<UniqueIds | undefined> {
@@ -97,6 +100,21 @@ export async function cloneBookUniqueIds(
   return;
 }
 
+export async function updateBookSpid(
+  bookId: Book["id"],
+): Promise<void> {
+  const ids = await findBookUniqueIds(bookId);
+  // unique id が見つからない、vid が空の場合は何もしない
+  if (!ids || !ids.vid) return;
+  const _updated = await prisma.book.updateMany({
+    where: { OR: [{ pid: ids.vid },{ spid: ids.vid }] },
+    data: { spid: ids.spid ?? ids.pid }
+  });
+}
+
+//
+// topic
+//
 export async function findTopicUniqueIds(
   topicId: Topic["id"]
 ): Promise<UniqueIds | undefined> {
@@ -148,4 +166,16 @@ export async function cloneTopicUniqueIds(
   await updateTopicUniqueIds(cloneId, clone);
 
   return;
+}
+
+export async function updateTopicSpid(
+  topicId: Topic["id"],
+): Promise<void> {
+  const ids = await findTopicUniqueIds(topicId);
+  // unique id が見つからない、vid が空の場合は何もしない
+  if (!ids || !ids.vid) return;
+  const _updated = await prisma.topic.updateMany({
+    where: { OR: [{ pid: ids.vid },{ spid: ids.vid }] },
+    data: { spid: ids.spid ?? ids.pid }
+  });
 }

--- a/server/utils/uniqueId.ts
+++ b/server/utils/uniqueId.ts
@@ -2,13 +2,14 @@ import { createId } from '@paralleldrive/cuid2';
 import type { Book, Topic } from '@prisma/client';
 import prisma from './prisma';
 
-export type UniqueIds = Pick<Book, "poid" | "oid" | "pid" | "vid">;
+export type UniqueIds = Pick<Book, "poid" | "oid" | "pid" | "vid" | "spid">;
 
 export const selectUniqueIds = {
   poid: true,
   oid: true,
   pid: true,
   vid: true,
+  spid: true,
 };
 
 function generateUniqueIds(ids: UniqueIds) {
@@ -16,6 +17,7 @@ function generateUniqueIds(ids: UniqueIds) {
   ids.oid = ids.poid;
   ids.pid = "";
   ids.vid = "";
+  ids.spid = "";
 }
 
 function releaseUniqueIds(edit: UniqueIds, release: UniqueIds) {
@@ -26,7 +28,9 @@ function releaseUniqueIds(edit: UniqueIds, release: UniqueIds) {
   release.oid = edit.oid;
   release.pid = edit.pid;
   release.vid = createId();
+  release.spid = edit.pid;
   edit.pid = release.vid;
+  edit.spid = release.vid;
 }
 
 function cloneUniqueIds(orig: UniqueIds, clone: UniqueIds) {
@@ -37,6 +41,7 @@ function cloneUniqueIds(orig: UniqueIds, clone: UniqueIds) {
   clone.oid = createId();
   clone.pid = orig.vid;
   clone.vid = "";
+  clone.spid = orig.vid;
 }
 
 export async function findBookUniqueIds(

--- a/server/utils/uniqueId.ts
+++ b/server/utils/uniqueId.ts
@@ -100,13 +100,10 @@ export async function cloneBookUniqueIds(
   return;
 }
 
-export async function updateBookSpid(
-  bookId: Book["id"],
-): Promise<void> {
-  const ids = await findBookUniqueIds(bookId);
-  // unique id が見つからない、vid が空の場合は何もしない
-  if (!ids || !ids.vid) return;
-  const _updated = await prisma.book.updateMany({
+export function updateBookSpid(
+  ids: UniqueIds,
+) {
+  return prisma.book.updateMany({
     where: { OR: [{ pid: ids.vid },{ spid: ids.vid }] },
     data: { spid: ids.spid ?? ids.pid }
   });
@@ -168,13 +165,10 @@ export async function cloneTopicUniqueIds(
   return;
 }
 
-export async function updateTopicSpid(
-  topicId: Topic["id"],
-): Promise<void> {
-  const ids = await findTopicUniqueIds(topicId);
-  // unique id が見つからない、vid が空の場合は何もしない
-  if (!ids || !ids.vid) return;
-  const _updated = await prisma.topic.updateMany({
+export function updateTopicSpid(
+  ids: UniqueIds,
+) {
+  return prisma.topic.updateMany({
     where: { OR: [{ pid: ids.vid },{ spid: ids.vid }] },
     data: { spid: ids.spid ?? ids.pid }
   });


### PR DESCRIPTION
model Book, Topic に spid を追加し、履歴途中のコンテンツが削除された場合も、履歴を追うことができるようにしました。アルゴリズムの概要は次のとおりです。

- ユニークID spid に直前リリースの vid を覚える
- 新規作成時 pid と同じ内容を設定
- リリースは、リリース前の spid を保持
- 複製には、複製元の vid を設定
- 削除時は、削除対象の vid を pid または spid に持つすべてを更新する
  - 更新対象の spid を、削除対象の spid で書き換える
  - 削除対象の spid が空の場合は pid を使用する

リリース一覧表示も、次のように変更しています。
- 複製元を探すとき spid を使用する
- 複製先を探すとき spid を使用する
- リリースしていない編集中コンテンツの複製元を、リリース一覧に表示する
