### PR TITLE
2025年5月8日 打合せの課題への対応

### DIFF
--- a/components/organisms/ReleaseForm.tsx
+++ b/components/organisms/ReleaseForm.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ReleaseForm({ release, onSubmit }: ReleaseFormProps) {
-  const { register, handleSubmit, setValue, formState, reset } =
+  const { register, handleSubmit, formState, reset, getValues } =
     useForm<ReleaseProps>({
       values: release,
     });
@@ -93,12 +93,8 @@ export default function ReleaseForm({ release, onSubmit }: ReleaseFormProps) {
           </Typography>
         </InputLabel>
         <Checkbox
-          id="shared"
-          name="shared"
-          onChange={(_, checked) =>
-            setValue("shared", checked, { shouldDirty: true })
-          }
-          defaultChecked={release.shared}
+          inputProps={update ? register("shared") : {}}
+          checked={getValues("shared")}
           color="primary"
           disabled={!update}
         />

--- a/components/organisms/ReleaseItemList.stories.tsx
+++ b/components/organisms/ReleaseItemList.stories.tsx
@@ -74,5 +74,5 @@ const defaultProps = {
 };
 
 export const Default = () => {
-  return <ReleaseItemList {...defaultProps} />;
+  return <ReleaseItemList {...defaultProps} variant="book" />;
 };

--- a/components/organisms/ReleaseItemList.tsx
+++ b/components/organisms/ReleaseItemList.tsx
@@ -14,6 +14,7 @@ import type { TopicSchema } from "$server/models/topic";
 type Props = {
   id: BookSchema["id"] | TopicSchema["id"];
   releases: Array<ReleaseItemSchema>;
+  variant: "book" | "topic";
   onItemEditClick?(index: number): void;
 };
 
@@ -21,6 +22,7 @@ type ReleaseItemProps = {
   item: ReleaseItemSchema;
   category: string;
   index: number;
+  variant: "book" | "topic";
   onItemEditClick?(index: number): void;
 };
 
@@ -28,6 +30,7 @@ function ReleaseItem({
   item,
   category,
   index,
+  variant,
   onItemEditClick,
 }: ReleaseItemProps) {
   const treeItemClasses = useTreeItemStyle();
@@ -42,7 +45,7 @@ function ReleaseItem({
             {category}
             {item.name}
             <EditButton
-              variant="book"
+              variant={variant}
               onClick={(event) => {
                 event.stopPropagation();
                 onItemEditClick && onItemEditClick(index);
@@ -184,6 +187,7 @@ export default function ReleaseItemList(props: Props) {
             item={item}
             category={categories[index]}
             index={index}
+            variant={props.variant}
             onItemEditClick={handleItemEditClick}
           />
         ))}

--- a/components/templates/BookEdit.tsx
+++ b/components/templates/BookEdit.tsx
@@ -198,6 +198,7 @@ export default function BookEdit({
           <ReleaseItemList
             id={book.id}
             releases={releases}
+            variant="book"
             onItemEditClick={handleItemEditClick}
           />
         </>

--- a/components/templates/BookEditReleased.tsx
+++ b/components/templates/BookEditReleased.tsx
@@ -127,6 +127,7 @@ export default function BookEditReleased({
           <ReleaseItemList
             id={book.id}
             releases={releases}
+            variant="book"
             onItemEditClick={handleItemEditClick}
           />
         </>

--- a/components/templates/TopicEdit.tsx
+++ b/components/templates/TopicEdit.tsx
@@ -149,6 +149,7 @@ export default function TopicEdit(props: Props) {
           <ReleaseItemList
             id={topic.id}
             releases={releases}
+            variant="topic"
             onItemEditClick={handleItemEditClick}
           />
         </>

--- a/pages/book/edit/index.tsx
+++ b/pages/book/edit/index.tsx
@@ -117,7 +117,11 @@ function Edit({ bookId, context }: Query) {
     );
   }
   async function handleItemEditClick(bookId: BookSchema["id"]) {
-    return router.push(pagesPath.book.edit.$url({ query: { bookId } }));
+    return router.push(
+      pagesPath.book.edit.$url({
+        query: { bookId, ...(context && { context }) },
+      })
+    );
   }
   async function handleClone({ id }: Pick<BookSchema, "id">) {
     const created = await cloneBook(id);

--- a/server/utils/book/cloneSections.ts
+++ b/server/utils/book/cloneSections.ts
@@ -5,9 +5,13 @@ import { cloneTopic } from "../topic/cloneTopic";
 import { cloneTopicUniqueIds } from "../uniqueId";
 
 export async function cloneSections(origTopics: number[], sections: SectionProps[], authors: Prisma.AuthorshipUncheckedCreateInput[]) {
+  const used: number[] = [];
   for (const section of sections) {
     for (const topic of section.topics) {
-      if (origTopics && origTopics.includes(topic.id)) continue;
+      if (origTopics && origTopics.includes(topic.id) && !used.includes(topic.id)) {
+        used.push(topic.id);
+        continue;
+      }
       const found = await prisma.topic.findUnique({
         where: { id: topic.id },
         include: { resource: true, keywords: true }


### PR DESCRIPTION
2025年5月8日 打合せの課題について、調査と修正を行いました。すべての課題について、対処できたと考えています。

https://github.com/npocccties/chibichilo-db-refactoring/issues/74#issuecomment-2861999531

- 画面遷移の手順により，リリースの共有で、チェックが表示されないことがある

ブックの編集、トピックの編集を修正しました。

- リリース一覧の，リリースされたブックのえんぴつアイコンをマウスオーバーしたときに，「ブックを編集」と表示される

トピックの編集では、「トピックを編集」と表示するようにしました。

- リリース一覧からえんぴつアイコンをクリックしたときに，戻るボタンが表示され，行き先がブック閲覧画面となる

ブック編集画面のリリース一覧から別のブック編集画面に移動したとき、context を保存するようにしました。戻る先は、books か courses になります。

トピック編集画面の path は 2種類あって、それぞれ戻る先が違います。

```
path                  どこから         戻る先
-----------------------------------------------------
topics/edit           トピック一覧     トピック一覧
book/edit/topic/edit  ブック編集       元のブック編集
```

リリース一覧から別のトピックに移動したとき、path は topics/edit になり、戻る先はトピック一覧です。元のブック編集画面には戻りません。この動作は変更しませんでした。

- ブック編集画面の再利用ボタンの動作

ブックに含まれていたトピックを再利用したとき、同じトピックが複数回ブックに含まれていました。同じトピックを再利用するときは、複製するように変更しました。