### PR TITLE
fix: 繰返視聴回数についてキャッシュデータの自動再検証を制限

### DIFF
--- a/server/services/activityRewatchRate.ts
+++ b/server/services/activityRewatchRate.ts
@@ -61,7 +61,7 @@ export async function index({
   const activityRewatchRate = activities.map((activity) => {
     return {
       topicId: activity.topic.id,
-      learnerId: activity.learner.id,
+      learnerId: activity.learnerId,
       rewatchRate: round(
         activity._count.timeRangeCounts /
           (activity.topic.timeRequired / ACTIVITY_COUNT_INTERVAL2),

--- a/server/services/activityRewatchRate.ts
+++ b/server/services/activityRewatchRate.ts
@@ -53,19 +53,17 @@ export async function index({
   }
 
   const activities = await findAllActivityWithTimeRangeCount(
+    ACTIVITY_REWATCH_THRESHOLD2,
     session,
     Boolean(query.current_lti_context_only)
   );
 
   const activityRewatchRate = activities.map((activity) => {
-    const rewatchRanges = activity.timeRangeCounts.filter((t) => {
-      return t.count >= ACTIVITY_REWATCH_THRESHOLD2;
-    });
     return {
       topicId: activity.topic.id,
       learnerId: activity.learner.id,
       rewatchRate: round(
-        rewatchRanges.length /
+        activity._count.timeRangeCounts /
           (activity.topic.timeRequired / ACTIVITY_COUNT_INTERVAL2),
         -3
       ),

--- a/server/utils/activity/findAllActivityWithTimeRangeCount.ts
+++ b/server/utils/activity/findAllActivityWithTimeRangeCount.ts
@@ -1,46 +1,103 @@
+import { isInstructor } from "$server/utils/session";
+import type { LtiResourceLinkSchema } from "$server/models/ltiResourceLink";
 import type { SessionSchema } from "$server/models/session";
 import prisma from "$server/utils/prisma";
 
-function findAllActivityWithTimeRangeCount(
+/** 受講者の取得 */
+async function findLtiMembersWithTimeRangeCount(
   rewatchThreshold: number,
   session: SessionSchema,
-  currentLtiContextOnly: boolean
+  {
+    consumerId,
+    contextId,
+  }: Pick<LtiResourceLinkSchema, "consumerId" | "contextId">,
+  currentLtiContextOnly?: boolean
 ) {
-  const activityScope = currentLtiContextOnly
-    ? {
-        ltiConsumerId: session.oauthClient.id,
-        ltiContextId: session.ltiContext.id,
-      }
-    : { ltiConsumerId: "", ltiContextId: "" };
-
-  return prisma.activity.findMany({
-    select: {
-      id: true,
-      totalTimeMs: true,
-      topic: {
-        select: {
-          id: true,
-          timeRequired: true,
-        },
-      },
-      learnerId: true,
-      _count: {
-        select: {
-          timeRangeCounts: {
-            where: {
-              count: {
-                gte: rewatchThreshold,
-              },
+  // NOTE: 表示可能な範囲
+  // 教員・TAの場合…すべて表示
+  // それ以外… 共有されている範囲または著者に含まれる範
+  const displayable = isInstructor(session)
+    ? undefined
+    : [{ shared: true }, { authors: { some: { userId: session.user.id } } }];
+  const topicActivityScope = {
+    topic: {
+      topicSection: {
+        some: {
+          section: {
+            book: {
+              ltiResourceLinks: { some: { consumerId, contextId } },
+              // NOTE: 表示可能な範囲 … 共有されている範囲または著者に含まれる範囲
+              OR: displayable,
             },
           },
         },
       },
     },
-    where: {
-      ...activityScope,
+  };
+
+  const activityScope =
+    currentLtiContextOnly ?? true
+      ? {
+          ltiConsumerId: consumerId,
+          ltiContextId: contextId,
+          ...topicActivityScope,
+        }
+      : { ltiConsumerId: "", ltiContextId: "", ...topicActivityScope };
+
+  const learners = await prisma.user.findMany({
+    select: {
+      activities: {
+        select: {
+          id: true,
+          totalTimeMs: true,
+          topic: {
+            select: {
+              id: true,
+              timeRequired: true,
+            },
+          },
+          learnerId: true,
+          _count: {
+            select: {
+              timeRangeCounts: {
+                where: {
+                  count: {
+                    gte: rewatchThreshold,
+                  },
+                },
+              },
+            },
+          },
+        },
+        where: {
+          ...activityScope,
+        },
+      },
     },
-    orderBy: { id: "asc" },
+    where: {
+      ...{ ltiMembers: { some: { consumerId, contextId } } },
+    },
   });
+
+  return learners;
+}
+
+async function findAllActivityWithTimeRangeCount(
+  rewatchThreshold: number,
+  session: SessionSchema,
+  currentLtiContextOnly: boolean
+) {
+  const consumerId = session.oauthClient.id;
+  const contextId = session.ltiContext.id;
+
+  const ltiMembers = await findLtiMembersWithTimeRangeCount(
+    rewatchThreshold,
+    session,
+    { consumerId, contextId },
+    currentLtiContextOnly
+  );
+
+  return ltiMembers.flatMap(({ activities }) => activities);
 }
 
 export default findAllActivityWithTimeRangeCount;

--- a/server/utils/activity/findAllActivityWithTimeRangeCount.ts
+++ b/server/utils/activity/findAllActivityWithTimeRangeCount.ts
@@ -2,6 +2,7 @@ import type { SessionSchema } from "$server/models/session";
 import prisma from "$server/utils/prisma";
 
 function findAllActivityWithTimeRangeCount(
+  rewatchThreshold: number,
   session: SessionSchema,
   currentLtiContextOnly: boolean
 ) {
@@ -18,7 +19,17 @@ function findAllActivityWithTimeRangeCount(
       totalTimeMs: true,
       topic: true,
       learner: true,
-      timeRangeCounts: true,
+      _count: {
+        select: {
+          timeRangeCounts: {
+            where: {
+              count: {
+                gte: rewatchThreshold,
+              },
+            },
+          },
+        },
+      },
     },
     where: {
       ...activityScope,

--- a/server/utils/activity/findAllActivityWithTimeRangeCount.ts
+++ b/server/utils/activity/findAllActivityWithTimeRangeCount.ts
@@ -17,8 +17,13 @@ function findAllActivityWithTimeRangeCount(
     select: {
       id: true,
       totalTimeMs: true,
-      topic: true,
-      learner: true,
+      topic: {
+        select: {
+          id: true,
+          timeRequired: true,
+        },
+      },
+      learnerId: true,
       _count: {
         select: {
           timeRangeCounts: {

--- a/utils/useRewatchRate.ts
+++ b/utils/useRewatchRate.ts
@@ -12,11 +12,7 @@ function useRewatchRate(currentLtiContextOnly: boolean) {
     NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD
       ? { key, currentLtiContextOnly }
       : null,
-    fetchRewatchRate,
-    {
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-    }
+    fetchRewatchRate
   );
   return { data, error };
 }

--- a/utils/useRewatchRate.ts
+++ b/utils/useRewatchRate.ts
@@ -1,5 +1,6 @@
 import fetchRewatchRate from "$utils/fetchRewatchRate";
 import useSWR from "swr";
+import { NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD } from "$utils/env";
 
 const key = "/api/v2/activityRewatchRate";
 
@@ -8,7 +9,9 @@ const key = "/api/v2/activityRewatchRate";
  */
 function useRewatchRate(currentLtiContextOnly: boolean) {
   const { data, error } = useSWR(
-    { key, currentLtiContextOnly },
+    NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD
+      ? { key, currentLtiContextOnly }
+      : null,
     fetchRewatchRate,
     {
       revalidateIfStale: false,

--- a/utils/useRewatchRate.ts
+++ b/utils/useRewatchRate.ts
@@ -9,7 +9,11 @@ const key = "/api/v2/activityRewatchRate";
 function useRewatchRate(currentLtiContextOnly: boolean) {
   const { data, error } = useSWR(
     { key, currentLtiContextOnly },
-    fetchRewatchRate
+    fetchRewatchRate,
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+    }
   );
   return { data, error };
 }


### PR DESCRIPTION
resolved: #1094 

issue中の画像のように、SWRの挙動としてAPIへの問い合わせを自動で行うので、それを制限してみました。
- すでにキャッシュがあれば更新しない
- ブラウザのタブがフォーカスされる度に更新することはしない