### PR TITLE
1099-activities_time_range_logsからのデータ取得のクエリの速度向上

### DIFF
--- a/server/utils/activity/upsertActivity.ts
+++ b/server/utils/activity/upsertActivity.ts
@@ -75,7 +75,6 @@ function findRecentActivityTimeRangeLog(activityId: Activity["id"]) {
         gte: date,
       },
     },
-    orderBy: { updatedAt: "desc" },
   });
 }
 

--- a/server/utils/activity/upsertActivity.ts
+++ b/server/utils/activity/upsertActivity.ts
@@ -25,6 +25,9 @@ const ACTIVITY_COUNT_INTERVAL2 = Number(
 const ACTIVITY_COUNT_INTERVAL_THRESHOLD_MS =
   (ACTIVITY_COUNT_INTERVAL2 * 1000) / 2.0;
 
+const ACTIVITY_COUNT_PREVIOUS_INTERVAL =
+  NEXT_PUBLIC_ACTIVITY_SEND_INTERVAL2 * 1.5 * 1000;
+
 function findActivity({
   learnerId,
   topicId,
@@ -64,9 +67,7 @@ function findTopic(topicId: Topic["id"]) {
 
 function findRecentActivityTimeRangeLog(activityId: Activity["id"]) {
   const now = new Date();
-  const date = new Date(
-    now.getTime() - NEXT_PUBLIC_ACTIVITY_SEND_INTERVAL2 * 1.5 * 1000
-  );
+  const date = new Date(now.getTime() - ACTIVITY_COUNT_PREVIOUS_INTERVAL);
 
   return prisma.activityTimeRangeLog.findMany({
     where: {


### PR DESCRIPTION
#1099

インデックスを貼っていないカラムでのソート処理をなくしました。
（ほか、ほんの一部コードを整理しました）
このソート処理は続く処理に影響しないので無くしても問題ないという判断からです。

これで改善が見られなければ、インデックス等の別の戦略を考えたいと思います。
（インデックスを貼って書き込みが逆に遅くなるといけないので段階的にやっていきたい気持ち）