### PR TITLE
fix: 狭い画面での目次表示時にスクロールを有効化

### DIFF
--- a/components/templates/Book.tsx
+++ b/components/templates/Book.tsx
@@ -93,6 +93,7 @@ const useStyles = makeStyles((theme) => ({
   },
   side: {
     gridArea: "side",
+    overflowY: "auto",
     "&$mobile": {
       marginBottom: theme.spacing(2),
     },


### PR DESCRIPTION
fix #869

モバイルでもサイドパネルにoverflowY: "auto"を追加し，長いトピックタイトルによる画面崩れを防止