### PR TITLE
fix: zipファイルのエラーハンドリングでJSONファイルの処理を追加

### DIFF
--- a/server/utils/book/importBooksUtil.ts
+++ b/server/utils/book/importBooksUtil.ts
@@ -512,8 +512,12 @@ class ImportBooksUtil {
       };
       yauzl.open(file, options, (err, zipfile) => {
         if (err) {
-          this.errors.push(`zipファイルのopenでエラーが発生しました。\n${err}`);
-          resolve({});
+          try {
+            resolve(JSON.parse(fs.readFileSync(file).toString()));
+          } catch (e) {
+            this.errors.push(`ファイルがzipではありません。\n${err}`);
+            resolve({});
+          }
           return;
         }
         zipfile.readEntry();


### PR DESCRIPTION
fix #1109 

JSON単体と，元々動作していたZIPでの登録をいくつかの環境で試して，問題なさそうならマージする