### PR TITLE
fix: downloadCli の並列処理をコンテキスト逐次実行に変更

### DIFF
--- a/server/utils/activity/downloadCli.ts
+++ b/server/utils/activity/downloadCli.ts
@@ -152,11 +152,11 @@ async function do_download(filename: string) {
     const contexts = (await getContexts()).filter(
       ({ consumerId, id }) => consumerId && id
     );
-    const list = await Promise.all(
-      contexts.map(async ({ consumerId, id }) =>
-        consumerId ? await getDecoratedData(consumerId, id) : []
-      )
-    );
+    const list: ReturnType<typeof download>[] = [];
+    for (const { consumerId, id, title } of contexts) {
+      logger("INFO", `processing context ${consumerId} ${id} ${title}...`);
+      list.push(consumerId ? await getDecoratedData(consumerId, id) : []);
+    }
     writeCsv(list.flat(), filename);
     exitCode = 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD=true の環境では Promise.all による並列実行が Prisma コネクションプールを使い切りタイムアウトするため、do_sync と同様に for...of による逐次実行へ変更した。 
あわせて各コンテキスト処理の開始時に logger 出力を追加し、長時間実行時の進捗確認を可能にした。