### PR TITLE
Fix/download cli errors

### DIFF
--- a/server/utils/activity/bookWithActivity.ts
+++ b/server/utils/activity/bookWithActivity.ts
@@ -89,6 +89,7 @@ export function toSchema({
           const unwatchedActivities = unwatchedLearners.flatMap((learner) => {
             return {
               id: 0,
+              bookId: book.id,
               topicId: topic.id,
               learnerId: learner.id,
               ltiConsumerId: ltiConsumerId,

--- a/server/utils/activity/downloadCli.ts
+++ b/server/utils/activity/downloadCli.ts
@@ -6,7 +6,7 @@ import utcToZoneTime from "date-fns-tz/utcToZonedTime";
 import prisma from "$server/utils/prisma";
 import { nullSession } from "$server/services/session";
 import findAllActivity from "./findAllActivity";
-import getLocaleEntries from "$utils/bookLearningActivity/getLocaleEntries";
+import getLocaleEntries, { label, keyOrder } from "$utils/bookLearningActivity/getLocaleEntries";
 import type { BookActivitySchema } from "$server/models/bookActivity";
 import type { SessionSchema } from "$server/models/session";
 import { getActivityRewatchRate } from "$server/services/activityRewatchRate";
@@ -72,22 +72,29 @@ async function getDecoratedData(consumerId: string, contextId: string) {
 
 const deleteList = ["ユーザ名", "メールアドレス"];
 
-function writeCsv(
+function appendCsv(
   decoratedData: ReturnType<typeof download>,
   filename: string
 ) {
-  if (!decoratedData || decoratedData.length === 0) {
-    throw new Error("No data to write to CSV");
-  }
+  if (!decoratedData || decoratedData.length === 0) return;
+  const fields = keyOrder
+    .map((key) => label[key])
+    .filter((l) => !deleteList.includes(l))
+    .filter((l) => NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD || l !== label["rewatchRate"]);
   const filterd = decoratedData.map((d) => {
     for (const key of deleteList) {
       delete d[key];
     }
     return d;
   });
-  const csv = json2csv.parse(filterd);
-  const bom = "\uFEFF";
-  fs.writeFileSync(filename, bom + csv, "utf-8");
+  const fileExists = fs.existsSync(filename);
+  if (!fileExists) {
+    const csv = json2csv.parse(filterd, { fields });
+    fs.writeFileSync(filename, "\uFEFF" + csv, "utf-8");
+  } else {
+    const csv = json2csv.parse(filterd, { fields, header: false });
+    fs.appendFileSync(filename, "\n" + csv, "utf-8");
+  }
 }
 
 //
@@ -149,15 +156,15 @@ async function do_download(filename: string) {
   }
   try {
     logger("INFO", "begin activity download...");
+    if (fs.existsSync(filename)) fs.unlinkSync(filename);
     const contexts = (await getContexts()).filter(
       ({ consumerId, id }) => consumerId && id
     );
-    const list: ReturnType<typeof download>[] = [];
     for (const { consumerId, id, title } of contexts) {
       logger("INFO", `processing context ${consumerId} ${id} ${title}...`);
-      list.push(consumerId ? await getDecoratedData(consumerId, id) : []);
+      const data = consumerId ? await getDecoratedData(consumerId, id) : [];
+      if (data.length > 0) appendCsv(data, filename);
     }
-    writeCsv(list.flat(), filename);
     exitCode = 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {

--- a/server/utils/activity/downloadCli.ts
+++ b/server/utils/activity/downloadCli.ts
@@ -6,7 +6,10 @@ import utcToZoneTime from "date-fns-tz/utcToZonedTime";
 import prisma from "$server/utils/prisma";
 import { nullSession } from "$server/services/session";
 import findAllActivity from "./findAllActivity";
-import getLocaleEntries, { label, keyOrder } from "$utils/bookLearningActivity/getLocaleEntries";
+import getLocaleEntries, {
+  label,
+  keyOrder,
+} from "$utils/bookLearningActivity/getLocaleEntries";
 import type { BookActivitySchema } from "$server/models/bookActivity";
 import type { SessionSchema } from "$server/models/session";
 import { getActivityRewatchRate } from "$server/services/activityRewatchRate";
@@ -80,7 +83,9 @@ function appendCsv(
   const fields = keyOrder
     .map((key) => label[key])
     .filter((l) => !deleteList.includes(l))
-    .filter((l) => NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD || l !== label["rewatchRate"]);
+    .filter(
+      (l) => NEXT_PUBLIC_ENABLE_TOPIC_VIEW_RECORD || l !== label["rewatchRate"]
+    );
   const filterd = decoratedData.map((d) => {
     for (const key of deleteList) {
       delete d[key];

--- a/server/utils/activity/findAllActivityWithTimeRangeCount.ts
+++ b/server/utils/activity/findAllActivityWithTimeRangeCount.ts
@@ -90,15 +90,22 @@ async function findLtiMembersWithTimeRangeCount(
 
   // Step 2: 絞り込んだ activity_id に対してのみ count を取得（相関クエリ化）
   // activities が空でも Prisma は `in: []` を正しく処理する（0件返却）
+  // activityIds が 32,767 件を超えると PostgreSQL のバインド変数上限を超過するためチャンク分割して処理する
   const activityIds = activities.map((a) => a.id);
-  const countRows = await prisma.activityTimeRangeCount.groupBy({
-    by: ["activityId"],
-    where: {
-      activityId: { in: activityIds },
-      count: { gte: rewatchThreshold },
-    },
-    _count: { activityId: true },
-  });
+  const chunkSize = 10000;
+  const countRows: { activityId: number; _count: { activityId: number } }[] =
+    [];
+  for (let i = 0; i < activityIds.length; i += chunkSize) {
+    const rows = await prisma.activityTimeRangeCount.groupBy({
+      by: ["activityId"],
+      where: {
+        activityId: { in: activityIds.slice(i, i + chunkSize) },
+        count: { gte: rewatchThreshold },
+      },
+      _count: { activityId: true },
+    });
+    countRows.push(...rows);
+  }
   const countMap = new Map(
     countRows.map((r) => [r.activityId, r._count.activityId])
   );


### PR DESCRIPTION
node dist/downloadCli.js -o によるCSV出力で発生していた3つの問題を修正する。


- activityIds が32,767件を超えると発生する too many bind variables エラーをチャンク分割で修正
- unwatchedActivities に bookId が未設定のため未視聴行がCSVに出力されない問題を修正
- 全コース分をメモリに蓄積してから書き出す実装によるOOMをコースごとの逐次追記に変更して修正

関連
Closes [#1131](https://github.com/npocccties/chibichilo/issues/1131)